### PR TITLE
fix: authenticator fallback happens now only if the authentication data expected by a failed authenticator is not present.

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+enabled: true
+titleOnly: true

--- a/internal/pipeline/authenticators/basic_auth_authenticator.go
+++ b/internal/pipeline/authenticators/basic_auth_authenticator.go
@@ -85,8 +85,8 @@ func (a *basicAuthAuthenticator) Execute(ctx heimdall.Context) (*subject.Subject
 
 	headerValue := ctx.RequestHeader("Authorization")
 	if len(headerValue) == 0 {
-		return nil, errorchain.
-			NewWithMessage(heimdall.ErrAuthentication, "no Authorization header received")
+		return nil, errorchain.NewWithMessage(heimdall.ErrAuthentication, "no Authorization header received").
+			CausedBy(heimdall.ErrArgument)
 	}
 
 	schemeAndValue := strings.Split(headerValue, " ")

--- a/internal/pipeline/authenticators/basic_auth_authenticator_test.go
+++ b/internal/pipeline/authenticators/basic_auth_authenticator_test.go
@@ -265,6 +265,7 @@ password: bar`))
 
 				assert.Error(t, err)
 				assert.ErrorIs(t, err, heimdall.ErrAuthentication)
+				assert.ErrorIs(t, err, heimdall.ErrArgument)
 				assert.Contains(t, err.Error(), "no Authorization header")
 
 				assert.Nil(t, sub)


### PR DESCRIPTION
fixes #29 