### PR TITLE
fix: making overwriting of JWT specific claims, set by the JWT signer not possible

### DIFF
--- a/internal/signer/jwt_signer.go
+++ b/internal/signer/jwt_signer.go
@@ -128,6 +128,7 @@ func (s *jwtSigner) Sign(sub string, ttl time.Duration, custClaims map[string]an
 	}
 
 	claims := make(map[string]any)
+	maps.Merge(custClaims, claims)
 
 	now := time.Now().UTC()
 	exp := now.Add(ttl)
@@ -137,8 +138,6 @@ func (s *jwtSigner) Sign(sub string, ttl time.Duration, custClaims map[string]an
 	claims["iss"] = s.iss
 	claims["nbf"] = now.Unix()
 	claims["sub"] = sub
-
-	maps.Merge(custClaims, claims)
 
 	builder := jwt.Signed(signer).Claims(claims)
 

--- a/internal/signer/jwt_signer_test.go
+++ b/internal/signer/jwt_signer_test.go
@@ -359,6 +359,18 @@ func TestJWTSignerSign(t *testing.T) {
 			},
 		},
 		{
+			uc:     "sign claims, which contain JWT specific claims",
+			signer: &jwtSigner{iss: "foo", key: ecdsaPrivKey1, kid: "bar", alg: jose.ES256},
+			claims: map[string]any{"iss": "bar"},
+			assert: func(t *testing.T, err error, rawJWT string, signer *jwtSigner, claims map[string]any) {
+				t.Helper()
+
+				require.NoError(t, err)
+				claims["iss"] = signer.iss
+				validateTestJWT(t, rawJWT, signer, subjectID, ttl, claims)
+			},
+		},
+		{
 			uc:     "sign with unsupported algorithm",
 			signer: &jwtSigner{iss: "foo", key: rsaPrivKey1, kid: "bar", alg: jose.SignatureAlgorithm("foobar")},
 			claims: map[string]any{"baz": "zab", "bla": "foo"},


### PR DESCRIPTION
closes #47 