### PR TITLE
refactor: error types used in error handler error conditions renamed to enhance comprehensibility

### DIFF
--- a/docs/content/docs/configuration/pipeline/authenticators.md
+++ b/docs/content/docs/configuration/pipeline/authenticators.md
@@ -30,7 +30,7 @@ type: noop
 
 ### Unauthorized
 
-This authenticator rejects all requests as unauthenticated (on HTTP response code level this is then mapped to `Unauthorized`, hence the type name). It basically stops the successful execution of the pipeline resulting in the execution of the error handlers. This authenticator type doesn't have any configuration options.
+This authenticator rejects all requests as unauthenticated (on HTTP response code level this is then mapped to `401 Unauthorized`, hence the type name). It basically stops the successful execution of the pipeline resulting in the execution of the error handlers. This authenticator type doesn't have any configuration options.
 
 To enable the usage of this authenticator, you have to set the `type` property to `unauthorized`.
 

--- a/docs/content/docs/configuration/pipeline/configuration_types.md
+++ b/docs/content/docs/configuration/pipeline/configuration_types.md
@@ -244,9 +244,9 @@ This example shows in principle all possible combinations. The actual values and
 
 ```yaml
 error:
-  - argument_error
+  - precondition_error
   # OR
-  - forbidden
+  - authorization_error
 # AND
 request_cidr:
   - 192.168.0.0/16
@@ -264,7 +264,7 @@ request_headers:
 ```
 
 This condition evaluates to true only if all parts of it (`error`, `request_cidr`, `request_headers`) evaluate to true. With
-* `error` evaluates to true, if the encountered error was either `argument_error` or `forbidden`. 
+* `error` evaluates to true, if the encountered error was either `precondition_error` or `authorization_error`. 
 * `request_cidr` evaluates to true, if the request came from an IP in either `192.168.0.0/16` or `10.0.0.0/8` range. And
 * `request_headers` evaluates to true, if either the HTTP `Accept` header contains one of `text/html`, or `*/*`, or the HTTP `Contet-Type` header contains `application/json`. 
 
@@ -274,21 +274,21 @@ This example is a very simple one, showing just the usage of the `error` attribu
 
 ```yaml
 error:
-  - unauthorized
+  - authentication_error
 ```
 
-This condition evaluate to true, if the encountered error was `unauthorized`. 
+This condition evaluate to true, if the encountered error was `authentication_error`. 
 
 ## Error Type
 
-Heimdall defines a couple of error types, which it uses to signal errors and which you can use while configuring your [Error Condition]({{< ref "#error-condition" >}})s.
+Heimdall defines a couple of error types, which it uses to signal errors. Some of them are available for configuring your [Error Condition]({{< ref "#error-condition" >}})s.
 
 Following types are available:
 
-* `unauthorized` - used if an authenticator failed to verify authentication data available in the request. E.g. an authenticator was configured to verify a JWT and the signature of it was invalid. 
-* `forbidden` - used if an authorizer failed to authorize the subject. E.g. an authorizer is configured to use a script to execute on the given subject and request context, but this script returned with an error.
-* `internal_server_error` - used if Heimdall run into an internal error condition while processing the request. E.g. something went wrong while unmarshalling a JSON object, or if there was a configuration error, which couldn't be raised while loading a rule, etc. 
-* `bad_argument` - used if the request does not contain required/expected data. E.g. if an authenticator could not find a cookie configured.
+* `authentication_error` - used if an authenticator failed to verify authentication data available in the request. E.g. an authenticator was configured to verify a JWT and the signature of it was invalid. 
+* `authorization_error` - used if an authorizer failed to authorize the subject. E.g. an authorizer is configured to use a script to execute on the given subject and request context, but this script returned with an error.
+* `internal_error` - used if Heimdall run into an internal error condition while processing the request. E.g. something went wrong while unmarshalling a JSON object, or if there was a configuration error, which couldn't be raised while loading a rule, etc. 
+* `precondition_error` - used if the request does not contain required/expected data. E.g. if an authenticator could not find a cookie configured.
 
 ## Retry
 

--- a/docs/content/docs/configuration/pipeline/error_handlers.md
+++ b/docs/content/docs/configuration/pipeline/error_handlers.md
@@ -47,8 +47,8 @@ Configuration using the `config` property is mandatory. Following properties are
 **Example**
 
 The redirect error handler below is configured to kick in if either 
-* a first error condition evaluates to true. This condition is for web requests (HTTP `Accept` header contains `text/html`) if an `unauthorized` error occurred (an error raised by authenticators). In this case, it will redirect the client (for web requests, usually a browser) to `http://127.0.0.1:4433/self-service/login/browser` and also add the `return_to` query parameter with the current url to the redirect url.
-* Or if a second condition evaluates to true. The only difference to the previous one is the error type, which is `forbidden` in this case.
+* a first error condition evaluates to true. This condition is for web requests (HTTP `Accept` header contains `text/html`) if an `authentication_error` error occurred (an error raised by authenticators). In this case, it will redirect the client (for web requests, usually a browser) to `http://127.0.0.1:4433/self-service/login/browser` and also add the `return_to` query parameter with the current url to the redirect url.
+* Or if a second condition evaluates to true. The only difference to the previous one is the error type, which is `authorization_error` in this case.
 
 So, e.g. if Heimdall was handling the request for `http://my-service.local/foo` and run into an error like described above, the value of the HTTP `Location` header will be set to `http://127.0.0.1:4433/self-service/login/browser?return_to=http%3A%2F%2Fmy-service.local%2Ffoo`
 
@@ -60,12 +60,12 @@ config:
   return_to_query_parameter: return_to
   when:
     - error:
-        - unauthorized
+        - authentication_error
       request_headers:
         Accept:
           - text/html
     - error:
-        - forbidden
+        - authorization_error
       request_headers:
         Accept:
           - text/html
@@ -81,8 +81,8 @@ config:
   return_to_query_parameter: return_to
   when:
     - error:
-        - unauthorized
-        - forbidden
+        - authentication_error
+        - authorization_error
       request_headers:
         Accept:
           - text/html
@@ -104,7 +104,7 @@ Configuration using the `config` property is mandatory. Following properties are
 
 **Example**
 
-The www authenticate error handler below is configured to kick in for web requests (HTTP `Accept` header contains `text/html`) if an `unauthorized` error occurred (an error raised by authenticators). In this case, it will respond with HTTP `401 Unauthorized` and a `WWW-Authenticate` header set to `Basic realm="My fancy app"`.
+The www authenticate error handler below is configured to kick in for web requests (HTTP `Accept` header contains `text/html`) if an `authentication_error` error occurred (an error raised by authenticators). In this case, it will respond with HTTP `401 Unauthorized` and a `WWW-Authenticate` header set to `Basic realm="My fancy app"`.
 
 ```yaml
 id: basic_authenticate
@@ -113,7 +113,7 @@ config:
   realm: "My fancy app"
   when:
     - error:
-        - unauthorized
+        - authentication_error
       request_headers:
         Accept:
           - text/html

--- a/internal/pipeline/errorhandlers/matcher/mapstructure_decoder.go
+++ b/internal/pipeline/errorhandlers/matcher/mapstructure_decoder.go
@@ -50,14 +50,14 @@ func DecodeErrorTypeMatcherHookFunc() mapstructure.DecodeHookFunc {
 		// nolint: forcetypeassert
 		for _, val := range data.([]any) {
 			switch val {
-			case "unauthorized":
+			case "authentication_error":
 				matcher = append(matcher, heimdall.ErrAuthentication)
-			case "forbidden":
+			case "authorization_error":
 				matcher = append(matcher, heimdall.ErrAuthorization)
-			case "internal_server_error":
+			case "internal_error":
 				matcher = append(matcher, heimdall.ErrInternal)
 				matcher = append(matcher, heimdall.ErrConfiguration)
-			case "bad_argument":
+			case "precondition_error":
 				matcher = append(matcher, heimdall.ErrArgument)
 			default:
 				return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,

--- a/internal/pipeline/errorhandlers/matcher/mapstructure_decoder_test.go
+++ b/internal/pipeline/errorhandlers/matcher/mapstructure_decoder_test.go
@@ -55,10 +55,10 @@ func TestDecodeErrorTypeMatcherHookFunc(t *testing.T) {
 
 	rawConfig := []byte(`
 error:
-  - unauthorized
-  - forbidden
-  - internal_server_error
-  - bad_argument
+  - authentication_error
+  - authorization_error
+  - internal_error
+  - precondition_error
 `)
 
 	var typ Type

--- a/internal/pipeline/errorhandlers/redirect_error_handler_test.go
+++ b/internal/pipeline/errorhandlers/redirect_error_handler_test.go
@@ -89,7 +89,7 @@ to: http://foo.bar
 bar: foo
 when:
   - error:
-    - unauthorized
+    - authentication_error
 `),
 			assert: func(t *testing.T, err error, redEH *redirectErrorHandler) {
 				t.Helper()
@@ -105,7 +105,7 @@ when:
 to: http://foo.bar
 when:
   - error:
-    - unauthorized
+    - authentication_error
 `),
 			assert: func(t *testing.T, err error, redEH *redirectErrorHandler) {
 				t.Helper()
@@ -136,15 +136,15 @@ code: 301
 return_to_query_parameter: foobar
 when:
   - error:
-      - unauthorized
-      - forbidden
+      - authentication_error
+      - authorization_error
     request_headers:
       Accept:
         - text/html
     request_cidr:
       - 192.168.10.0/24
   - error:
-      - internal_server_error
+      - internal_error
     request_headers:
       Accept:
         - '*/*'
@@ -224,7 +224,7 @@ func TestCreateRedirectErrorHandlerFromPrototype(t *testing.T) {
 to: http://foo.bar
 when:
   - error:
-      - unauthorized
+      - authentication_error
 `),
 			assert: func(t *testing.T, err error, prototype *redirectErrorHandler, configured *redirectErrorHandler) {
 				t.Helper()
@@ -239,7 +239,7 @@ when:
 to: http://foo.bar
 when:
   - error:
-      - unauthorized
+      - authentication_error
 `),
 			config: []byte(``),
 			assert: func(t *testing.T, err error, prototype *redirectErrorHandler, configured *redirectErrorHandler) {
@@ -255,7 +255,7 @@ when:
 to: http://foo.bar
 when:
   - error:
-      - unauthorized
+      - authentication_error
 `),
 			config: []byte(`to: http://foo.bar`),
 			assert: func(t *testing.T, err error, prototype *redirectErrorHandler, configured *redirectErrorHandler) {
@@ -274,13 +274,13 @@ code: 301
 return_to_query_parameter: foobar
 when:
   - error:
-      - unauthorized
-      - forbidden
+      - authentication_error
+      - authorization_error
 `),
 			config: []byte(`
 when:
   - error:
-      - bad_argument
+      - precondition_error
 `),
 			assert: func(t *testing.T, err error, prototype *redirectErrorHandler, configured *redirectErrorHandler) {
 				t.Helper()
@@ -348,7 +348,7 @@ func TestRedirectErrorHandlerExecute(t *testing.T) {
 to: http://foo.bar
 when:
   - error:
-      - unauthorized
+      - authentication_error
 `),
 			error: heimdall.ErrInternal,
 			assert: func(t *testing.T, wasResponsible bool, err error) {
@@ -364,7 +364,7 @@ when:
 to: http://foo.bar
 when:
   - error:
-      - unauthorized
+      - authentication_error
 `),
 			error: heimdall.ErrAuthentication,
 			configureContext: func(t *testing.T, ctx *mocks.MockContext) {
@@ -398,7 +398,7 @@ code: 300
 return_to_query_parameter: foobar
 when:
   - error:
-      - unauthorized
+      - authentication_error
 `),
 			error: heimdall.ErrAuthentication,
 			configureContext: func(t *testing.T, ctx *mocks.MockContext) {

--- a/internal/pipeline/errorhandlers/www_authenticate_error_handler_test.go
+++ b/internal/pipeline/errorhandlers/www_authenticate_error_handler_test.go
@@ -61,7 +61,7 @@ func TestCreateWWWAuthenticateErrorHandler(t *testing.T) {
 realm: FooBar
 when:
   - error:
-      - unauthorized
+      - authentication_error
 foo: bar
 `),
 			assert: func(t *testing.T, err error, errorHandler *wwwAuthenticateErrorHandler) {
@@ -77,7 +77,7 @@ foo: bar
 			config: []byte(`
 when:
   - error:
-      - unauthorized
+      - authentication_error
 `),
 			assert: func(t *testing.T, err error, errorHandler *wwwAuthenticateErrorHandler) {
 				t.Helper()
@@ -100,7 +100,7 @@ when:
 realm: "What is your password"
 when:
   - error:
-      - bad_argument
+      - precondition_error
 `),
 			assert: func(t *testing.T, err error, errorHandler *wwwAuthenticateErrorHandler) {
 				t.Helper()
@@ -146,7 +146,7 @@ func TestCreateWWWAuthenticateErrorHandlerFromPrototype(t *testing.T) {
 			prototypeConfig: []byte(`
 when:
   - error:
-      - unauthorized
+      - authentication_error
 `),
 			assert: func(t *testing.T, err error, prototype *wwwAuthenticateErrorHandler,
 				configured *wwwAuthenticateErrorHandler,
@@ -162,7 +162,7 @@ when:
 			prototypeConfig: []byte(`
 when:
   - error:
-      - unauthorized
+      - authentication_error
 `),
 			config: []byte(``),
 			assert: func(t *testing.T, err error, prototype *wwwAuthenticateErrorHandler,
@@ -179,7 +179,7 @@ when:
 			prototypeConfig: []byte(`
 when:
   - error:
-      - unauthorized
+      - authentication_error
 `),
 			config: []byte(`to: http://foo.bar`),
 			assert: func(t *testing.T, err error, prototype *wwwAuthenticateErrorHandler,
@@ -197,13 +197,13 @@ when:
 			prototypeConfig: []byte(`
 when:
   - error:
-      - unauthorized
-      - forbidden
+      - authentication_error
+      - authorization_error
 `),
 			config: []byte(`
 when:
   - error:
-      - bad_argument
+      - precondition_error
 `),
 			assert: func(t *testing.T, err error, prototype *wwwAuthenticateErrorHandler,
 				configured *wwwAuthenticateErrorHandler,
@@ -231,7 +231,7 @@ when:
 			prototypeConfig: []byte(`
 when:
   - error:
-      - unauthorized
+      - authentication_error
 `),
 			config: []byte(`realm: "You password please"`),
 			assert: func(t *testing.T, err error, prototype *wwwAuthenticateErrorHandler,
@@ -292,7 +292,7 @@ func TestWWWAuthenticateErrorHandlerExecute(t *testing.T) {
 			config: []byte(`
 when:
   - error:
-      - unauthorized
+      - authentication_error
 `),
 			error: heimdall.ErrInternal,
 			assert: func(t *testing.T, wasResponsible bool, err error) {
@@ -307,7 +307,7 @@ when:
 			config: []byte(`
 when:
   - error:
-      - unauthorized
+      - authentication_error
 `),
 			error: heimdall.ErrAuthentication,
 			configureContext: func(t *testing.T, ctx *mocks.MockContext) {
@@ -336,7 +336,7 @@ when:
 realm: "Your password please"
 when:
   - error:
-      - unauthorized
+      - authentication_error
 `),
 			error: heimdall.ErrAuthentication,
 			configureContext: func(t *testing.T, ctx *mocks.MockContext) {

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -1065,10 +1065,10 @@
             "items": {
               "type": "string",
               "enum": [
-                "unauthorized",
-                "forbidden",
-                "internal_server_error",
-                "bad_argument"
+                "authentication_error",
+                "authorization_error",
+                "internal_error",
+                "precondition_error"
               ]
             }
           },

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -132,15 +132,15 @@ pipeline:
   error_handlers:
     - id: default
       type: default
-    - id: authenticate_on_unauthorized_or_forbidden
+    - id: authenticate_with_kratos
       type: redirect
       config:
         to: http://127.0.0.1:4433/self-service/login/browser
         return_to_query_parameter: return_to
         when:
           - error:
-            - unauthorized
-            - forbidden
+            - authentication_error
+            - authorization_error
             request_headers:
               Accept:
               - '*/*'
@@ -154,7 +154,7 @@ rules:
       - authenticator: anonymous_authenticator
       - mutator: jwt
     on_error:
-      - error_handler: authenticate_on_unauthorized_or_forbidden
+      - error_handler: authenticate_with_kratos
 
   providers:
     file:


### PR DESCRIPTION
This is a breaking change

closes #52 
closes #53