### PR TITLE
feat: Health endpoint

### DIFF
--- a/internal/fiber/middleware/tracing/options.go
+++ b/internal/fiber/middleware/tracing/options.go
@@ -45,7 +45,7 @@ func WithOperationNameProvider(provider OperationNameProvider) Option {
 	}
 }
 
-func WithOperationFiler(filter OperationFilter) Option {
+func WithOperationFilter(filter OperationFilter) Option {
 	return func(o *opts) {
 		if filter != nil {
 			o.filterOperation = filter

--- a/internal/fiber/middleware/tracing/options_test.go
+++ b/internal/fiber/middleware/tracing/options_test.go
@@ -186,7 +186,7 @@ func TestOptionsWithOperationFilter(t *testing.T) {
 	} {
 		t.Run("case="+tc.uc, func(t *testing.T) {
 			// GIVEN
-			apply := WithOperationFiler(tc.filter)
+			apply := WithOperationFilter(tc.filter)
 
 			// WHEN
 			apply(&tc.opt)

--- a/internal/fiber/middleware/tracing/tracer_test.go
+++ b/internal/fiber/middleware/tracing/tracer_test.go
@@ -27,7 +27,7 @@ func TestTracerSpanManagementWithoutSkippingOnMissingParentSpan(t *testing.T) {
 	app := fiber.New()
 	app.Use(New(
 		WithTracer(mtracer),
-		WithOperationFiler(func(ctx *fiber.Ctx) bool { return ctx.Path() == "/filtered" }),
+		WithOperationFilter(func(ctx *fiber.Ctx) bool { return ctx.Path() == "/filtered" }),
 		WithSpanObserver(func(span opentracing.Span, ctx *fiber.Ctx) {
 			if ctx.Method() == fiber.MethodGet {
 				span.SetTag("foo", "bar")

--- a/internal/handler/decision/handler.go
+++ b/internal/handler/decision/handler.go
@@ -7,6 +7,7 @@ import (
 
 	fiberauditor "github.com/dadrus/heimdall/internal/fiber/middleware/auditor"
 	fiberxforwarded "github.com/dadrus/heimdall/internal/fiber/middleware/xforwarded"
+	"github.com/dadrus/heimdall/internal/handler/health"
 	"github.com/dadrus/heimdall/internal/handler/requestcontext"
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/rules"
@@ -33,7 +34,10 @@ func newHandler(params handlerParams) (*Handler, error) {
 		s: params.Signer,
 	}
 
-	handler.registerRoutes(params.App.Group(""), params.Logger)
+	router := params.App.Group("/")
+
+	handler.registerRoutes(router, params.Logger)
+	health.RegisterRoutes(router, params.Logger)
 
 	return handler, nil
 }

--- a/internal/handler/decision/module.go
+++ b/internal/handler/decision/module.go
@@ -52,6 +52,7 @@ func newFiberApp(conf config.Configuration, cache cache.Cache, logger zerolog.Lo
 	app.Use(recover.New(recover.Config{EnableStackTrace: true}))
 	app.Use(fibertracing.New(
 		fibertracing.WithTracer(opentracing.GlobalTracer()),
+		fibertracing.WithOperationFilter(func(ctx *fiber.Ctx) bool { return ctx.Path() == "/.well-known/health" }),
 		fibertracing.WithSpanObserver(func(span opentracing.Span, ctx *fiber.Ctx) {
 			ext.Component.Set(span, "heimdall")
 		})))

--- a/internal/handler/health/handler.go
+++ b/internal/handler/health/handler.go
@@ -1,0 +1,20 @@
+package health
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+)
+
+func RegisterRoutes(router fiber.Router, logger zerolog.Logger) {
+	logger.Debug().Msg("Registering health route")
+
+	router.Get("/.well-known/health", health)
+}
+
+func health(c *fiber.Ctx) error {
+	type status struct {
+		Status string `json:"status"`
+	}
+
+	return c.JSON(status{Status: "ok"})
+}


### PR DESCRIPTION
closes #2 

Actually, it doesn't make sense (at least for now) to have separate readyness and lifeness endpoints, as there are no databases and also no conditions, on which heimdall could not be used. For that reason, a simple health endpoint, available under `/.well-known/health` has been implemented.