### PR TITLE
feat!: Make decision endpoint being available directly on the root (`/`) path of the decision service

### DIFF
--- a/DockerHub-README.md
+++ b/DockerHub-README.md
@@ -50,7 +50,7 @@ docker run -t -p 4456:4456 -v $PWD:/heimdall/conf \
 Call the decision api endpoint to emulate behavior of an API-Gateway:
 
 ```bash
-curl -v 127.0.0.1:4456/decisions/foobar
+curl -v 127.0.0.1:4456/foobar
 ```
 
 You should now see similar output to the following snippet:
@@ -58,7 +58,7 @@ You should now see similar output to the following snippet:
 ```bash
 *   Trying 127.0.0.1:4456...
 * Connected to 127.0.0.1 (127.0.0.1) port 4456 (#0)
-> GET /decisions/foobar HTTP/1.1
+> GET /foobar HTTP/1.1
 > Host: 127.0.0.1:4456
 > User-Agent: curl/7.74.0
 > Accept: */*

--- a/docs/content/docs/api/_index.adoc
+++ b/docs/content/docs/api/_index.adoc
@@ -12,7 +12,7 @@ This section lists available endpoints implemented by heimdall:
 
 == Decision API
 
-This endpoint is available under `<decision service>/decisions/` path when Heimdall is operated in the Decision API mode. It accepts any subpaths, headers, cookies, etc. Also, all methods can be used as well.
+This endpoint is available under `<decision service>/` path when Heimdall is operated in the Decision API mode. It accepts any subpaths, headers, cookies, etc. Also, all methods can be used as well.
 
 == Proxy
 

--- a/docs/content/docs/configuration/services/decision_api.adoc
+++ b/docs/content/docs/configuration/services/decision_api.adoc
@@ -9,7 +9,7 @@ menu:
     parent: "Services"
 ---
 
-Decision API is one of the operating modes supported by Heimdall, used if you start Heimdall with `heimdall serve api`. By default, Heimdall listens on `0.0.0.0:4456/decisions` endpoint for incoming requests in this mode of operation and also configures useful default timeouts. No other options are configured. You can, and should however adjust the configuration for your needs.
+Decision API is one of the operating modes supported by Heimdall, used if you start Heimdall with `heimdall serve api`. By default, Heimdall listens on `0.0.0.0:4456/` endpoint for incoming requests in this mode of operation and also configures useful default timeouts. No other options are configured. You can, and should however adjust the configuration for your needs.
 
 This service exposes only the Decision API endpoint.
 

--- a/docs/content/docs/getting_started/concepts.adoc
+++ b/docs/content/docs/getting_started/concepts.adoc
@@ -209,7 +209,7 @@ Imagine following request hits Heimdall (sent to it by an API gateway)
 
 [source, bash]
 ----
-GET decisions/my-service/api HTTP/1.1
+GET /my-service/api HTTP/1.1
 Host: heimdall:4455
 
 Some payload

--- a/docs/content/docs/getting_started/decision_api_quickstart.adoc
+++ b/docs/content/docs/getting_started/decision_api_quickstart.adoc
@@ -95,7 +95,7 @@ Sent some request to heimdall's decision endpoint:
 
 [source, bash]
 ----
-$ curl -v 127.0.0.1:4456/decisions/foobar
+$ curl -v 127.0.0.1:4456/foobar
 ----
 
 Here, we're asking to apply the default rule for the `foobar` path using the `GET` HTTP verb.
@@ -106,7 +106,7 @@ On completion, you should see the `Authorization` header in the response, like i
 ----
 *   Trying 127.0.0.1:4456...
 * Connected to 127.0.0.1 (127.0.0.1) port 4456 (#0)
-> GET /decisions/foobar HTTP/1.1
+> GET /foobar HTTP/1.1
 > Host: 127.0.0.1:4456
 > User-Agent: curl/7.74.0
 > Accept: */*

--- a/docs/content/docs/guides/traefik.adoc
+++ b/docs/content/docs/guides/traefik.adoc
@@ -31,7 +31,7 @@ edge-router:
   image: traefik
   # further configuration
   labels:
-    - traefik.http.middlewares.heimdall.forwardauth.address=http://heimdall:4456/decisions
+    - traefik.http.middlewares.heimdall.forwardauth.address=http://heimdall:4456
     - traefik.http.middlewares.heimdall.forwardauth.authResponseHeaders=X-Id-Token,Authorization
     # further labels
 

--- a/internal/handler/decision/handler.go
+++ b/internal/handler/decision/handler.go
@@ -52,7 +52,7 @@ func newHandler(params handlerParams) (*Handler, error) {
 func (h *Handler) registerRoutes(router fiber.Router, logger zerolog.Logger) {
 	logger.Debug().Msg("Registering decision api routes")
 
-	router.All("/decisions/*", fiberxforwarded.New(), fiberauditor.New(), h.decisions)
+	router.All("/*", fiberxforwarded.New(), fiberauditor.New(), h.decisions)
 }
 
 func (h *Handler) decisions(c *fiber.Ctx) error {

--- a/internal/handler/decision/handler_test.go
+++ b/internal/handler/decision/handler_test.go
@@ -47,7 +47,7 @@ func TestHandleDecisionEndpointRequest(t *testing.T) {
 			createRequest: func(t *testing.T) *http.Request {
 				t.Helper()
 
-				return httptest.NewRequest("GET", "/decisions", nil)
+				return httptest.NewRequest("GET", "/", nil)
 			},
 			configureMocks: func(t *testing.T, repository *mocks2.MockRepository, rule *mocks4.MockRule) {
 				t.Helper()
@@ -70,7 +70,7 @@ func TestHandleDecisionEndpointRequest(t *testing.T) {
 			createRequest: func(t *testing.T) *http.Request {
 				t.Helper()
 
-				return httptest.NewRequest("POST", "/decisions", nil)
+				return httptest.NewRequest("POST", "/", nil)
 			},
 			configureMocks: func(t *testing.T, repository *mocks2.MockRepository, rule *mocks4.MockRule) {
 				t.Helper()
@@ -95,7 +95,7 @@ func TestHandleDecisionEndpointRequest(t *testing.T) {
 			createRequest: func(t *testing.T) *http.Request {
 				t.Helper()
 
-				return httptest.NewRequest("POST", "/decisions", nil)
+				return httptest.NewRequest("POST", "/", nil)
 			},
 			configureMocks: func(t *testing.T, repository *mocks2.MockRepository, rule *mocks4.MockRule) {
 				t.Helper()
@@ -121,7 +121,7 @@ func TestHandleDecisionEndpointRequest(t *testing.T) {
 			createRequest: func(t *testing.T) *http.Request {
 				t.Helper()
 
-				return httptest.NewRequest("POST", "/decisions", nil)
+				return httptest.NewRequest("POST", "/", nil)
 			},
 			configureMocks: func(t *testing.T, repository *mocks2.MockRepository, rule *mocks4.MockRule) {
 				t.Helper()
@@ -154,7 +154,7 @@ func TestHandleDecisionEndpointRequest(t *testing.T) {
 
 				return httptest.NewRequest(
 					"POST",
-					"http://heimdall.test.local/decisions/foobar",
+					"http://heimdall.test.local/foobar",
 					nil)
 			},
 			configureMocks: func(t *testing.T, repository *mocks2.MockRepository, rule *mocks4.MockRule) {
@@ -199,7 +199,7 @@ func TestHandleDecisionEndpointRequest(t *testing.T) {
 
 				req := httptest.NewRequest(
 					"POST",
-					"http://heimdall.test.local/decisions/foobar",
+					"http://heimdall.test.local/foobar",
 					nil)
 
 				req.Header.Set("X-Forwarded-Proto", "https")
@@ -252,7 +252,7 @@ func TestHandleDecisionEndpointRequest(t *testing.T) {
 
 				req := httptest.NewRequest(
 					"POST",
-					"http://heimdall.test.local/decisions/foobar",
+					"http://heimdall.test.local/foobar",
 					nil)
 
 				req.Header.Set("X-Forwarded-Proto", "https")
@@ -305,7 +305,7 @@ func TestHandleDecisionEndpointRequest(t *testing.T) {
 
 				req := httptest.NewRequest(
 					"POST",
-					"http://heimdall.test.local/decisions/foobar",
+					"http://heimdall.test.local/foobar",
 					nil)
 
 				req.Header.Set("X-Forwarded-Method", "GET")
@@ -338,7 +338,7 @@ func TestHandleDecisionEndpointRequest(t *testing.T) {
 
 				req := httptest.NewRequest(
 					"POST",
-					"http://heimdall.test.local/decisions/foobar",
+					"http://heimdall.test.local/foobar",
 					nil)
 
 				req.Header.Set("X-Forwarded-Host", "test.com")
@@ -371,7 +371,7 @@ func TestHandleDecisionEndpointRequest(t *testing.T) {
 
 				req := httptest.NewRequest(
 					"POST",
-					"http://heimdall.test.local/decisions/foobar",
+					"http://heimdall.test.local/foobar",
 					nil)
 
 				req.Header.Set("X-Forwarded-Path", "bar")
@@ -404,7 +404,7 @@ func TestHandleDecisionEndpointRequest(t *testing.T) {
 
 				req := httptest.NewRequest(
 					"POST",
-					"http://heimdall.test.local/decisions/foobar",
+					"http://heimdall.test.local/foobar",
 					nil)
 
 				req.Header.Set("X-Forwarded-Proto", "https")
@@ -437,7 +437,7 @@ func TestHandleDecisionEndpointRequest(t *testing.T) {
 
 				req := httptest.NewRequest(
 					"POST",
-					"http://heimdall.test.local/decisions/foobar",
+					"http://heimdall.test.local/foobar",
 					nil)
 
 				req.Header.Set("X-Forwarded-Proto", "https")


### PR DESCRIPTION
closes #110 