### PR TITLE
fix: Bearer token based authenticators do not feel responsible for the request anymore if no "Bearer" scheme is present in the "Authorization" header.

### DIFF
--- a/internal/pipeline/authenticators/extractors/header_value_extract_strategy_test.go
+++ b/internal/pipeline/authenticators/extractors/header_value_extract_strategy_test.go
@@ -5,83 +5,130 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/heimdall/mocks"
 )
 
-func TestExtractHeaderValueWithoutPrefix(t *testing.T) {
+func TestExtractHeaderValue(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		uc             string
+		strategy       HeaderValueExtractStrategy
+		configureMocks func(t *testing.T, ctx *mocks.MockContext)
+		assert         func(t *testing.T, err error, authData AuthData)
+	}{
+		{
+			uc:       "header is present, schema is irrelevant",
+			strategy: HeaderValueExtractStrategy{Name: "X-Test-Header"},
+			configureMocks: func(t *testing.T, ctx *mocks.MockContext) {
+				t.Helper()
+
+				ctx.On("RequestHeader", "X-Test-Header").Return("TestValue")
+			},
+			assert: func(t *testing.T, err error, authData AuthData) {
+				t.Helper()
+
+				assert.NoError(t, err)
+				assert.Equal(t, "TestValue", authData.Value())
+			},
+		},
+		{
+			uc:       "schema is required, header is present, but without any schema",
+			strategy: HeaderValueExtractStrategy{Name: "X-Test-Header", Prefix: "Foo"},
+			configureMocks: func(t *testing.T, ctx *mocks.MockContext) {
+				t.Helper()
+
+				ctx.On("RequestHeader", "X-Test-Header").Return("TestValue")
+			},
+			assert: func(t *testing.T, err error, authData AuthData) {
+				t.Helper()
+
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, heimdall.ErrArgument)
+				assert.Contains(t, err.Error(), "'Foo' schema")
+			},
+		},
+		{
+			uc:       "schema is required, header is present, but with different schema",
+			strategy: HeaderValueExtractStrategy{Name: "X-Test-Header", Prefix: "Foo"},
+			configureMocks: func(t *testing.T, ctx *mocks.MockContext) {
+				t.Helper()
+
+				ctx.On("RequestHeader", "X-Test-Header").Return("Bar TestValue")
+			},
+			assert: func(t *testing.T, err error, authData AuthData) {
+				t.Helper()
+
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, heimdall.ErrArgument)
+				assert.Contains(t, err.Error(), "'Foo' schema")
+			},
+		},
+		{
+			uc:       "header with required schema is present",
+			strategy: HeaderValueExtractStrategy{Name: "X-Test-Header", Prefix: "Foo"},
+			configureMocks: func(t *testing.T, ctx *mocks.MockContext) {
+				t.Helper()
+
+				ctx.On("RequestHeader", "X-Test-Header").Return("Foo TestValue")
+			},
+			assert: func(t *testing.T, err error, authData AuthData) {
+				t.Helper()
+
+				assert.NoError(t, err)
+				assert.Equal(t, "TestValue", authData.Value())
+			},
+		},
+		{
+			uc:       "header is not present at all",
+			strategy: HeaderValueExtractStrategy{Name: "X-Test-Header", Prefix: "Foo"},
+			configureMocks: func(t *testing.T, ctx *mocks.MockContext) {
+				t.Helper()
+
+				ctx.On("RequestHeader", "X-Test-Header").Return("")
+			},
+			assert: func(t *testing.T, err error, authData AuthData) {
+				t.Helper()
+
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, heimdall.ErrArgument)
+				assert.Contains(t, err.Error(), "no 'X-Test-Header' header")
+			},
+		},
+	} {
+		t.Run("case="+tc.uc, func(t *testing.T) {
+			// GIVEN
+			ctx := &mocks.MockContext{}
+			tc.configureMocks(t, ctx)
+
+			// WHEN
+			authData, err := tc.strategy.GetAuthData(ctx)
+
+			// THEN
+			tc.assert(t, err, authData)
+			ctx.AssertExpectations(t)
+		})
+	}
+}
+
+func TestApplyHeaderAuthDataToRequest(t *testing.T) {
 	t.Parallel()
 
 	// GIVEN
-	headerName := "test_param"
-	headerValue := "foo"
+	headerName := "X-Test-Header"
+	rawHeaderValue := "Foo Bar"
+	headerValueWithoutSchema := "Bar"
 	req, err := http.NewRequest(http.MethodGet, "foobar.local", nil)
 	require.NoError(t, err)
 
-	ctx := &mocks.MockContext{}
-	ctx.On("RequestHeader", headerName).Return(headerValue)
-
-	strategy := HeaderValueExtractStrategy{Name: headerName}
+	authData := &headerAuthData{name: headerName, rawValue: rawHeaderValue, value: headerValueWithoutSchema}
 
 	// WHEN
-	val, err := strategy.GetAuthData(ctx)
+	authData.ApplyTo(req)
 
 	// THEN
-	assert.NoError(t, err)
-	assert.Equal(t, headerValue, val.Value())
-
-	val.ApplyTo(req)
-	assert.Equal(t, headerValue, req.Header.Get(headerName))
-
-	ctx.AssertExpectations(t)
-}
-
-func TestExtractHeaderValueWithPrefix(t *testing.T) {
-	t.Parallel()
-
-	// GIVEN
-	headerName := "test_param"
-	valuePrefix := "bar:"
-	actualValue := "foo"
-	req, err := http.NewRequest(http.MethodGet, "foobar.local", nil)
-	require.NoError(t, err)
-
-	ctx := &mocks.MockContext{}
-	ctx.On("RequestHeader", headerName).Return(valuePrefix + " " + actualValue)
-
-	strategy := HeaderValueExtractStrategy{Name: headerName, Prefix: valuePrefix}
-
-	// WHEN
-	val, err := strategy.GetAuthData(ctx)
-
-	// THEN
-	assert.NoError(t, err)
-	assert.Equal(t, actualValue, val.Value())
-
-	val.ApplyTo(req)
-	assert.Equal(t, actualValue, req.Header.Get(headerName))
-
-	ctx.AssertExpectations(t)
-}
-
-func TestExtractNotExistingHeaderValue(t *testing.T) {
-	t.Parallel()
-
-	// GIVEN
-	ctx := &mocks.MockContext{}
-	ctx.On("RequestHeader", mock.Anything).Return("")
-
-	strategy := HeaderValueExtractStrategy{Name: "Test-Cookie"}
-
-	// WHEN
-	_, err := strategy.GetAuthData(ctx)
-
-	// THEN
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, heimdall.ErrArgument)
-
-	ctx.AssertExpectations(t)
+	assert.Equal(t, rawHeaderValue, req.Header.Get(headerName))
 }


### PR DESCRIPTION
closes #102 