### PR TITLE
refactor!: `strip_prefix` in header authentication data strategy renamed to `schema` to reflect the actual mening and behavior

### DIFF
--- a/docs/content/docs/configuration/pipeline/authenticators.adoc
+++ b/docs/content/docs/configuration/pipeline/authenticators.adoc
@@ -110,7 +110,7 @@ The endpoint to communicate to for the actual subject authentication status veri
 
 * *`authentication_data_source`*: _link:{{< relref "configuration_types.adoc#_authentication_data_source" >}}[Authentication Data Source]_ (mandatory, not overridable)
 +
-Where to extract the authentication data from the request. This authenticator will use the matched authentication data source as is while sending it to the `identity_info_endpoint`. If you configure to strip a prefix (if header is defined, this will most probably not work).
+Where to extract the authentication data from the request. This authenticator will use the matched authentication data source as is while sending it to the `identity_info_endpoint`.
 
 * *`session`*: _link:{{< relref "configuration_types.adoc#_session" >}}[Session]_ (mandatory, not overridable)
 +

--- a/docs/content/docs/configuration/pipeline/configuration_types.adoc
+++ b/docs/content/docs/configuration/pipeline/configuration_types.adoc
@@ -63,7 +63,7 @@ This fallback mechanism can become handy, if different clients of your applicati
 [source, yaml]
 ----
 - header: Authorization
-  strip_prefix: Bearer
+  schema: Bearer
 - query_parameter: access_token
 - body_parameter: access_token
 ----
@@ -97,9 +97,9 @@ This strategy can retrieve authentication data from a specific HTTP header. Foll
 +
 The name of the header to use.
 
-* *`strip_prefix`*: _string_ (optional)
+* *`schema`*: _string_ (optional)
 +
-Prefix, which should be stripped from the header value. Stripping the prefix doesn't always make sense. Consider the scopes in which this strategy is applied.
+Schema, which should be present in the header value. If specified, but not present, the authentication data cannot be retrieved, effectively making the affected authenticator feel not responsible for the request.
 
 .Header Strategy usage
 ====
@@ -109,7 +109,7 @@ Imagine you want Heimdall to verify an access token used to protect your upstrea
 [source, yaml]
 ----
 - header: Authorization
-  strip_prefix: Bearer
+  schema: Bearer
 ----
 ====
 

--- a/docs/content/docs/configuration/reference/configuration.adoc
+++ b/docs/content/docs/configuration/reference/configuration.adoc
@@ -157,7 +157,7 @@ pipeline:
           method: GET
         jwt_from:
           - header: Authorization
-            strip_prefix: Bearer
+            schema: Bearer
         assertions:
           audience:
             - bla

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -142,7 +142,7 @@ pipeline:
           method: GET
         jwt_from:
           - header: Authorization
-            strip_prefix: Bearer
+            schema: Bearer
         assertions:
           audience:
             - bla

--- a/internal/pipeline/authenticators/basic_auth_authenticator_test.go
+++ b/internal/pipeline/authenticators/basic_auth_authenticator_test.go
@@ -254,7 +254,7 @@ password: bar`))
 		assert           func(t *testing.T, err error, sub *subject.Subject)
 	}{
 		{
-			uc: "no authorization header",
+			uc: "no no required header present",
 			configureContext: func(t *testing.T, ctx *mocks.MockContext) {
 				t.Helper()
 
@@ -266,43 +266,7 @@ password: bar`))
 				assert.Error(t, err)
 				assert.ErrorIs(t, err, heimdall.ErrAuthentication)
 				assert.ErrorIs(t, err, heimdall.ErrArgument)
-				assert.Contains(t, err.Error(), "no Authorization header")
-
-				assert.Nil(t, sub)
-			},
-		},
-		{
-			uc: "malformed scheme",
-			configureContext: func(t *testing.T, ctx *mocks.MockContext) {
-				t.Helper()
-
-				ctx.On("RequestHeader", "Authorization").Return("foo bar baz")
-			},
-			assert: func(t *testing.T, err error, sub *subject.Subject) {
-				t.Helper()
-
-				assert.Error(t, err)
-				assert.ErrorIs(t, err, heimdall.ErrAuthentication)
-				assert.ErrorIs(t, err, heimdall.ErrArgument)
-				assert.Contains(t, err.Error(), "unexpected value")
-
-				assert.Nil(t, sub)
-			},
-		},
-		{
-			uc: "unexpected authentication scheme",
-			configureContext: func(t *testing.T, ctx *mocks.MockContext) {
-				t.Helper()
-
-				ctx.On("RequestHeader", "Authorization").Return("foo bar")
-			},
-			assert: func(t *testing.T, err error, sub *subject.Subject) {
-				t.Helper()
-
-				assert.Error(t, err)
-				assert.ErrorIs(t, err, heimdall.ErrAuthentication)
-				assert.ErrorIs(t, err, heimdall.ErrArgument)
-				assert.Contains(t, err.Error(), "unexpected authentication scheme")
+				assert.Contains(t, err.Error(), "expected header not present")
 
 				assert.Nil(t, sub)
 			},

--- a/internal/pipeline/authenticators/extractors/composite_extract_strategy_test.go
+++ b/internal/pipeline/authenticators/extractors/composite_extract_strategy_test.go
@@ -40,16 +40,16 @@ func TestCompositeExtractHeaderValueWithPrefix(t *testing.T) {
 	// GIVEN
 	headerName := "Test-Header"
 	queryParamName := "test_param"
-	valuePrefix := "bar:"
+	headerSchema := "bar:"
 	actualValue := "foo"
 
 	ctx := &mocks.MockContext{}
-	ctx.On("RequestHeader", headerName).Return(valuePrefix + " " + actualValue)
+	ctx.On("RequestHeader", headerName).Return(headerSchema + " " + actualValue)
 	ctx.On("RequestQueryParameter", queryParamName).Return("")
 
 	strategy := CompositeExtractStrategy{
 		QueryParameterExtractStrategy{Name: queryParamName},
-		HeaderValueExtractStrategy{Name: headerName, Prefix: valuePrefix},
+		HeaderValueExtractStrategy{Name: headerName, Schema: headerSchema},
 	}
 
 	// WHEN
@@ -67,14 +67,14 @@ func TestCompositeExtractStrategyOrder(t *testing.T) {
 	// GIVEN
 	headerName := "Test-Header"
 	queryParamName := "test_param"
-	valuePrefix := "bar:"
+	headerSchema := "bar:"
 	actualValue := "foo"
 
 	ctx := &mocks.MockContext{}
-	ctx.On("RequestHeader", headerName).Return(valuePrefix + " " + actualValue)
+	ctx.On("RequestHeader", headerName).Return(headerSchema + " " + actualValue)
 
 	strategy := CompositeExtractStrategy{
-		HeaderValueExtractStrategy{Name: headerName, Prefix: valuePrefix},
+		HeaderValueExtractStrategy{Name: headerName, Schema: headerSchema},
 		QueryParameterExtractStrategy{Name: queryParamName},
 	}
 

--- a/internal/pipeline/authenticators/extractors/composite_extract_strategy_test.go
+++ b/internal/pipeline/authenticators/extractors/composite_extract_strategy_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/dadrus/heimdall/internal/heimdall/mocks"
 )
 
-func TestCompositeExtractCookieValueWithoutPrefix(t *testing.T) {
+func TestCompositeExtractCookieValueWithoutSchema(t *testing.T) {
 	t.Parallel()
 
 	// GIVEN
@@ -34,7 +34,7 @@ func TestCompositeExtractCookieValueWithoutPrefix(t *testing.T) {
 	ctx.AssertExpectations(t)
 }
 
-func TestCompositeExtractHeaderValueWithPrefix(t *testing.T) {
+func TestCompositeExtractHeaderValueWithSchema(t *testing.T) {
 	t.Parallel()
 
 	// GIVEN

--- a/internal/pipeline/authenticators/extractors/header_value_extract_strategy.go
+++ b/internal/pipeline/authenticators/extractors/header_value_extract_strategy.go
@@ -11,20 +11,20 @@ import (
 
 type HeaderValueExtractStrategy struct {
 	Name   string
-	Prefix string
+	Schema string
 }
 
 func (es HeaderValueExtractStrategy) GetAuthData(s heimdall.Context) (AuthData, error) {
 	if val := s.RequestHeader(es.Name); len(val) != 0 {
-		if len(es.Prefix) != 0 && !strings.HasPrefix(val, fmt.Sprintf("%s ", es.Prefix)) {
+		if len(es.Schema) != 0 && !strings.HasPrefix(val, fmt.Sprintf("%s ", es.Schema)) {
 			return nil, errorchain.NewWithMessagef(heimdall.ErrArgument,
-				"'%s' header present, but without required '%s' schema", es.Name, es.Prefix)
+				"'%s' header present, but without required '%s' schema", es.Name, es.Schema)
 		}
 
 		return &headerAuthData{
 			name:     es.Name,
 			rawValue: val,
-			value:    strings.TrimSpace(strings.TrimPrefix(val, es.Prefix)),
+			value:    strings.TrimSpace(strings.TrimPrefix(val, es.Schema)),
 		}, nil
 	}
 

--- a/internal/pipeline/authenticators/extractors/header_value_extract_strategy_test.go
+++ b/internal/pipeline/authenticators/extractors/header_value_extract_strategy_test.go
@@ -37,7 +37,7 @@ func TestExtractHeaderValue(t *testing.T) {
 		},
 		{
 			uc:       "schema is required, header is present, but without any schema",
-			strategy: HeaderValueExtractStrategy{Name: "X-Test-Header", Prefix: "Foo"},
+			strategy: HeaderValueExtractStrategy{Name: "X-Test-Header", Schema: "Foo"},
 			configureMocks: func(t *testing.T, ctx *mocks.MockContext) {
 				t.Helper()
 
@@ -53,7 +53,7 @@ func TestExtractHeaderValue(t *testing.T) {
 		},
 		{
 			uc:       "schema is required, header is present, but with different schema",
-			strategy: HeaderValueExtractStrategy{Name: "X-Test-Header", Prefix: "Foo"},
+			strategy: HeaderValueExtractStrategy{Name: "X-Test-Header", Schema: "Foo"},
 			configureMocks: func(t *testing.T, ctx *mocks.MockContext) {
 				t.Helper()
 
@@ -69,7 +69,7 @@ func TestExtractHeaderValue(t *testing.T) {
 		},
 		{
 			uc:       "header with required schema is present",
-			strategy: HeaderValueExtractStrategy{Name: "X-Test-Header", Prefix: "Foo"},
+			strategy: HeaderValueExtractStrategy{Name: "X-Test-Header", Schema: "Foo"},
 			configureMocks: func(t *testing.T, ctx *mocks.MockContext) {
 				t.Helper()
 
@@ -84,7 +84,7 @@ func TestExtractHeaderValue(t *testing.T) {
 		},
 		{
 			uc:       "header is not present at all",
-			strategy: HeaderValueExtractStrategy{Name: "X-Test-Header", Prefix: "Foo"},
+			strategy: HeaderValueExtractStrategy{Name: "X-Test-Header", Schema: "Foo"},
 			configureMocks: func(t *testing.T, ctx *mocks.MockContext) {
 				t.Helper()
 

--- a/internal/pipeline/authenticators/extractors/mapstructure_decoder.go
+++ b/internal/pipeline/authenticators/extractors/mapstructure_decoder.go
@@ -62,12 +62,12 @@ func DecodeCompositeExtractStrategyHookFunc() mapstructure.DecodeHookFunc {
 
 func createStrategy(data map[string]string) (AuthDataExtractStrategy, error) {
 	if value, ok := data["header"]; ok { // nolint: nestif
-		var prefix string
-		if p, ok := data["strip_prefix"]; ok {
-			prefix = p
+		var schema string
+		if p, ok := data["schema"]; ok {
+			schema = p
 		}
 
-		return &HeaderValueExtractStrategy{Name: value, Prefix: prefix}, nil
+		return &HeaderValueExtractStrategy{Name: value, Schema: schema}, nil
 	} else if value, ok := data["cookie"]; ok {
 		return &CookieValueExtractStrategy{Name: value}, nil
 	} else if value, ok := data["query_parameter"]; ok {

--- a/internal/pipeline/authenticators/extractors/mapstructure_decoder_test.go
+++ b/internal/pipeline/authenticators/extractors/mapstructure_decoder_test.go
@@ -23,7 +23,7 @@ func TestUnmarshalAuthenticationDataSourceFromValidYaml(t *testing.T) {
 authentication_data_source:
   - cookie: foo_cookie
   - header: foo_header
-    strip_prefix: hfoo
+    schema: hfoo
   - query_parameter: foo_qparam
   - body_parameter: foo_bparam
 `)
@@ -54,7 +54,7 @@ authentication_data_source:
 	he, ok := ces[1].(*HeaderValueExtractStrategy)
 	require.True(t, ok)
 	assert.Equal(t, "foo_header", he.Name)
-	assert.Equal(t, "hfoo", he.Prefix)
+	assert.Equal(t, "hfoo", he.Schema)
 
 	qe, ok := ces[2].(*QueryParameterExtractStrategy)
 	require.True(t, ok)

--- a/internal/pipeline/authenticators/jwt_authenticator.go
+++ b/internal/pipeline/authenticators/jwt_authenticator.go
@@ -101,7 +101,7 @@ func newJwtAuthenticator(rawConfig map[string]any) (*jwtAuthenticator, error) {
 	var adg extractors.AuthDataExtractStrategy
 	if conf.AuthDataSource == nil {
 		adg = extractors.CompositeExtractStrategy{
-			extractors.HeaderValueExtractStrategy{Name: "Authorization", Prefix: "Bearer"},
+			extractors.HeaderValueExtractStrategy{Name: "Authorization", Schema: "Bearer"},
 			extractors.QueryParameterExtractStrategy{Name: "access_token"},
 			extractors.BodyParameterExtractStrategy{Name: "access_token"},
 		}

--- a/internal/pipeline/authenticators/jwt_authenticator_test.go
+++ b/internal/pipeline/authenticators/jwt_authenticator_test.go
@@ -110,7 +110,7 @@ assertions:
 				// token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
 				assert.Len(t, auth.ads, 3)
-				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Prefix: "Bearer"})
+				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Schema: "Bearer"})
 				assert.Contains(t, auth.ads, extractors.QueryParameterExtractStrategy{Name: "access_token"})
 				assert.Contains(t, auth.ads, extractors.BodyParameterExtractStrategy{Name: "access_token"})
 
@@ -161,7 +161,7 @@ cache_ttl: 5s`),
 				// token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
 				assert.Len(t, auth.ads, 3)
-				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Prefix: "Bearer"})
+				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Schema: "Bearer"})
 				assert.Contains(t, auth.ads, extractors.QueryParameterExtractStrategy{Name: "access_token"})
 				assert.Contains(t, auth.ads, extractors.BodyParameterExtractStrategy{Name: "access_token"})
 
@@ -199,7 +199,7 @@ jwks_endpoint:
     Accept-Type: application/foobar
 jwt_from:
   - header: foo-header
-    strip_prefix: foo
+    schema: foo
   - query_parameter: foo_query_param
   - body_parameter: foo_body_param
 assertions:
@@ -229,7 +229,7 @@ session:
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
 				assert.Len(t, auth.ads, 3)
 				assert.Contains(t, auth.ads, &extractors.HeaderValueExtractStrategy{
-					Name: "foo-header", Prefix: "foo",
+					Name: "foo-header", Schema: "foo",
 				})
 				assert.Contains(t, auth.ads, &extractors.QueryParameterExtractStrategy{Name: "foo_query_param"})
 				assert.Contains(t, auth.ads, &extractors.BodyParameterExtractStrategy{Name: "foo_body_param"})

--- a/internal/pipeline/authenticators/oauth2_introspection_authenticator.go
+++ b/internal/pipeline/authenticators/oauth2_introspection_authenticator.go
@@ -99,7 +99,7 @@ func newOAuth2IntrospectionAuthenticator(rawConfig map[string]any) (*oauth2Intro
 	}
 
 	extractor := extractors.CompositeExtractStrategy{
-		extractors.HeaderValueExtractStrategy{Name: "Authorization", Prefix: "Bearer"},
+		extractors.HeaderValueExtractStrategy{Name: "Authorization", Schema: "Bearer"},
 		extractors.QueryParameterExtractStrategy{Name: "access_token"},
 		extractors.BodyParameterExtractStrategy{Name: "access_token"},
 	}

--- a/internal/pipeline/authenticators/oauth2_introspection_authenticator_test.go
+++ b/internal/pipeline/authenticators/oauth2_introspection_authenticator_test.go
@@ -147,7 +147,7 @@ session:
 				// assert token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
 				assert.Len(t, auth.ads, 3)
-				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Prefix: "Bearer"})
+				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Schema: "Bearer"})
 				assert.Contains(t, auth.ads, extractors.QueryParameterExtractStrategy{Name: "access_token"})
 				assert.Contains(t, auth.ads, extractors.BodyParameterExtractStrategy{Name: "access_token"})
 

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -448,7 +448,7 @@
               "header": {
                 "type": "string"
               },
-              "strip_prefix": {
+              "schema": {
                 "type": "string"
               }
             }

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -73,7 +73,7 @@ pipeline:
           method: GET
         jwt_from:
           - header: Authorization
-            strip_prefix: Bearer
+            schema: Bearer
         assertions:
           audience:
             - bla


### PR DESCRIPTION
relates to #102 and #128