### PR TITLE
docs: caution to the description of endpoint configuration added related to the headers, which can be configured

### DIFF
--- a/docs/content/docs/configuration/pipeline/configuration_types.adoc
+++ b/docs/content/docs/configuration/pipeline/configuration_types.adoc
@@ -288,6 +288,8 @@ Authentication strategy to apply, if the endpoint requires authentication.
 * *`headers`* _map of strings_ (optional)
 +
 HTTP headers to be sent to the endpoint.
++
+CAUTION: These headers are not analyzed by heimdall and are just forwarded to the endpoint. E.g. if you configure the `Content-Encoding` to something like `gzip`, the service behind the used endpoint might fail to answer, as it would expect the body to be compressed.
 
 .Endpoint configuration
 ====


### PR DESCRIPTION
closes #184 