### PR TITLE
docs: retain page path while switching between documentation versions

### DIFF
--- a/docs/redirect/index.html
+++ b/docs/redirect/index.html
@@ -1,0 +1,1 @@
+<head><meta http-equiv="Refresh" content="0; url='x-released-version'" /></head>

--- a/docs/themes/mytheme/layouts/partials/header.html
+++ b/docs/themes/mytheme/layouts/partials/header.html
@@ -46,7 +46,10 @@
         </ul>
         <hr class="text-white-50 d-md-none">
         <ul class="navbar-nav flex-column ms-auto">
-          <doc-version-select class="nav-item dropdown" version-info="/heimdall/data.json" current-version="{{ .Site.Params.version }}">
+          <doc-version-select class="nav-item dropdown"
+                              version-file="/{{ .Site.Params.github.project }}/data.json"
+                              current-version="{{ .Site.Params.version }}"
+                              current-page="{{ .RelPermalink }}" >
             <button class="btn btn-dark dropdown-toggle me-4" data-bs-toggle="dropdown" aria-expanded="false">
               {{ .Site.Params.version }}
             </button>

--- a/docs/themes/mytheme/static/js/doc-version-select.js
+++ b/docs/themes/mytheme/static/js/doc-version-select.js
@@ -1,92 +1,78 @@
 function splitVersionString(version) {
-  const [corepre, build] = version.split('+')
-  const [core, pre] = corepre.split('-').map(x => String(x).split('.').map(y => isNaN(y) ? y : parseInt(y, 10)))
-  return {core, pre, build}
+    const [corepre, build] = version.split('+')
+    const [core, pre] = corepre.split('-').map(x => String(x).split('.').map(y => isNaN(y) ? y : parseInt(y, 10)))
+    return {core, pre, build}
 }
 
 function compareCore(a, b) {
-  for (let i = 0; i < 3; i++) {
-    if (a[i] < b[i]) {
-      return -1
+    for (let i = 0; i < 3; i++) {
+        if (a[i] < b[i]) {
+            return -1
+        } else if (a[i] > b[i]) {
+            return 1
+        }
     }
 
-    if (a[i] > b[i]) {
-      return 1
-    }
-  }
+    return 0
 }
 
 function comparePre(a, b) {
-  if (a && !b) {
-    return -1
-  }
-
-  if (!a && b) {
-    return 1
-  }
-
-  if (a && b) {
-    const len = a.length > b.length ? a.length : b.length
-    for (let i = 0; i < len; i++) {
-      if (typeof a[i] === 'undefined' && typeof b[i] !== 'undefined') {
+    if (a && !b) {
         return -1
-      }
-
-      if (typeof a[i] !== 'undefined' && typeof b[i] === 'undefined') {
+    } else if (!a && b) {
         return 1
-      }
-
-      if (typeof a[i] === 'number' && typeof b[i] === 'string') {
-        return -1
-      }
-
-      if (typeof a[i] === 'string' && typeof b[i] === 'number') {
-        return 1
-      }
-
-      if (a[i] < b[i]) {
-        return -1
-      }
-
-      if (a[i] > b[i]) {
-        return 1
-      }
+    } else {
+        const len = a.length > b.length ? a.length : b.length
+        for (let i = 0; i < len; i++) {
+            if (typeof a[i] === 'undefined' && typeof b[i] !== 'undefined') {
+                return -1
+            } else if (typeof a[i] !== 'undefined' && typeof b[i] === 'undefined') {
+                return 1
+            } else if (typeof a[i] === 'number' && typeof b[i] === 'string') {
+                return -1
+            } else if (typeof a[i] === 'string' && typeof b[i] === 'number') {
+                return 1
+            } else if (a[i] < b[i]) {
+                return -1
+            } else if (a[i] > b[i]) {
+                return 1
+            }
+        }
     }
-  }
 }
 
 const semanticCompare = (a, b) => {
-  const va = splitVersionString(a)
-  const vb = splitVersionString(b)
+    const va = splitVersionString(a)
+    const vb = splitVersionString(b)
 
-  const core = compareCore(va.core, vb.core)
+    const core = compareCore(va.core, vb.core)
 
-  if (core) {
-    return core
-  }
+    if (core) {
+        return core
+    }
 
-  const pre = comparePre(va.pre, vb.pre)
+    const pre = comparePre(va.pre, vb.pre)
 
-  if (pre) {
-    return pre
-  }
+    if (pre) {
+        return pre
+    }
 
-  return 0
+    return 0
 }
 
 const html = htmlSnippet => {
-  const parser = new DOMParser()
-  const doc = parser.parseFromString(htmlSnippet, 'text/html')
-  return doc.body.firstChild
+    const parser = new DOMParser()
+    const doc = parser.parseFromString(htmlSnippet, 'text/html')
+    return doc.body.firstChild
 }
 
-const linkListItem = currentVersion => element => `
-<li><a class="dropdown-item ${currentVersion === element.version ? 'current' : ''}" href="${element.path}">${element.version}</a></li>`
+const linkListItem = (currentVersion, currentPath) => element => `
+<li><a class="dropdown-item ${currentVersion === element.version ? 'current' : ''}" href="${element.path}${currentPath}">${element.version}</a></li>`
 
-const linkList = (elements = [], currentVersion) => {
-  const linkItem = linkListItem(currentVersion)
+const linkList = (elements = [], currentVersion, currentPath) => {
+    const linkItem = linkListItem(currentVersion, currentPath)
 
-  return html(`
+    return html(`
     <ul class="dropdown-menu">
       ${linkItem(elements[0])}
       <li><hr class="dropdown-divider"></li>
@@ -96,42 +82,48 @@ const linkList = (elements = [], currentVersion) => {
 }
 
 const load = async dataFile => {
-  const result = await fetch(dataFile, {
-    headers: { Accept: 'application/json' },
-    credentials: 'same-origin',
-    method: 'GET',
-    mode: 'same-origin',
-    redirect: 'follow'
-  })
+    const result = await fetch(dataFile, {
+        headers: {Accept: 'application/json'},
+        credentials: 'same-origin',
+        method: 'GET',
+        mode: 'same-origin',
+        redirect: 'follow'
+    })
 
-  if (!result.ok) {
-    throw new Error(`Data could not be loaded: ${result.status}`)
-  }
+    if (!result.ok) {
+        throw new Error(`Data could not be loaded: ${result.status}`)
+    }
 
-  return result.json()
+    return result.json()
 }
 
 class DocVersionSelect extends HTMLElement {
-  async connectedCallback () {
-    const versions = await load(this.versionInfoFile)
+    async connectedCallback() {
+        const versions = await load(this.versionsFile)
 
-    this.appendChild(linkList(versions, this.currentVersion))
-  }
-
-  get versionInfoFile () {
-    const versionInfoFile = this.hasAttribute('version-info') ? this.getAttribute('version-info') : null
-
-    if (!versionInfoFile) {
-      throw new Error('No version info data provided! Please add the attribute "version-info"!')
+        this.appendChild(linkList(versions, this.currentVersion, this.currentPage))
     }
 
-    return versionInfoFile
-  }
+    get currentPage() {
+        const page = this.hasAttribute('current-page') ? this.getAttribute('current-page') : null
 
-  get currentVersion () {
-    const currentVersion = this.hasAttribute('current-version') ? this.getAttribute('current-version') : null
-    return currentVersion || 'unknown'
-  }
+        return page || '/'
+    }
+
+    get versionsFile() {
+        const versionsFile = this.hasAttribute('version-file') ? this.getAttribute('version-file') : null
+
+        if (!versionsFile) {
+            throw new Error('No version info data provided! Please add the attribute "version-file"!')
+        }
+
+        return versionsFile
+    }
+
+    get currentVersion() {
+        const currentVersion = this.hasAttribute('current-version') ? this.getAttribute('current-version') : null
+        return currentVersion || 'unknown'
+    }
 }
 
 customElements.define('doc-version-select', DocVersionSelect)


### PR DESCRIPTION
closes #177 

If the required path does not exist in the linked version, a redirect to the main page of the latest released version happens.