### PR TITLE
feat: If no `kid` is present in the JWT, the `jwt_authenticator` can now iterate over the received JWKS and try to verify the signature until one of the keys matches

### DIFF
--- a/docs/content/docs/configuration/pipeline/authenticators.adoc
+++ b/docs/content/docs/configuration/pipeline/authenticators.adoc
@@ -259,7 +259,7 @@ Enables or disables the verification of the JWK certificate used for JWT signatu
 +
 The path to a PEM file containing the trust anchors, to be used for the JWK certificate validation. Defaults to system trust store.
 
-NOTE: If a JWT does not reference a `kid`, heimdall always fetches a JWKS from the configured endpoint (so no caching is done) and iterates over the received keys until one matches. If none matches, the authenticator fails with an authentication error.
+NOTE: If a JWT does not reference a `kid`, heimdall always fetches a JWKS from the configured endpoint (so no caching is done) and iterates over the received keys until one matches. If none matches, the authenticator fails.
 
 .Minimal possible configuration
 ====

--- a/docs/content/docs/configuration/pipeline/authenticators.adoc
+++ b/docs/content/docs/configuration/pipeline/authenticators.adoc
@@ -49,7 +49,7 @@ type: unauthorized
 
 This authenticator just creates a subject object and sets its id to `anonymous` without doing anything else. You can overwrite the value of subject's id by using the optional `config` property.
 
-To enable the usage of this authenticator, you have to set the `type` property to `anonymous`. 
+To enable the usage of this authenticator, you have to set the `type` property to `anonymous`.
 
 Configuration using the `config` property is optional. Following properties are available:
 
@@ -131,7 +131,7 @@ If set to `true`, allows the pipeline to fall back to the next authenticator in 
 .Configuration of Generic authenticator to work with session cookies
 ====
 
-This example shows how to configure this authenticator to work with an authentication system, which issues a cookie upon successful user authentication to maintain the authentication state. To reduce the communication overhead, it also makes use of `cache_ttl` to cache the response for 5 minutes. 
+This example shows how to configure this authenticator to work with an authentication system, which issues a cookie upon successful user authentication to maintain the authentication state. To reduce the communication overhead, it also makes use of `cache_ttl` to cache the response for 5 minutes.
 
 [source, yaml]
 ----
@@ -221,7 +221,7 @@ config:
 
 === JWT
 
-As the link:{{< relref "#_oauth2_introspection">}}[OAuth2 Introspection] authenticator, this authenticator handles requests that have a Bearer Token in the `Authorization` header, in a different header or a query parameter as well. Unlike the OAuth2 Introspection authenticator it expects the token to be a JSON Web Token (JWT) and verifies it according https://www.rfc-editor.org/rfc/rfc7519#section-7.2[RFC 7519, Section 7.2]. It does however not support encrypted payloads and nested JWTs. In addition to this, validation includes the verification of the time validity. Latter can be adjusted by specifying a leeway. All other validation options can and should be configured.
+As the link:{{< relref "#_oauth2_introspection">}}[OAuth2 Introspection] authenticator, this authenticator handles requests that have a Bearer token in the `Authorization` header, in a different header or a query parameter as well. Unlike the OAuth2 Introspection authenticator it expects the token to be a JSON Web Token (JWT) and verifies it according https://www.rfc-editor.org/rfc/rfc7519#section-7.2[RFC 7519, Section 7.2]. It does however not support encrypted payloads and nested JWTs. In addition to this, validation includes the verification of the time validity. Latter can be adjusted by specifying a leeway. All other validation options can and should be configured.
 
 To enable the usage of this authenticator, you have to set the `type` property to `jwt`.
 
@@ -258,6 +258,8 @@ Enables or disables the verification of the JWK certificate used for JWT signatu
 * *`trust_store`*: _string_ (optional, not overridable)
 +
 The path to a PEM file containing the trust anchors, to be used for the JWK certificate validation. Defaults to system trust store.
+
+NOTE: If a JWT does not reference a `kid`, heimdall always fetches a JWKS from the configured endpoint (so no caching is done) and iterates over the received keys until one matches. If none matches, the authenticator fails with an authentication error.
 
 .Minimal possible configuration
 ====

--- a/docs/content/docs/configuration/pipeline/authenticators.adoc
+++ b/docs/content/docs/configuration/pipeline/authenticators.adoc
@@ -178,7 +178,7 @@ Usually, Bearer tokens are issued by an OAuth2 auth provider and there is a need
 
 === OAuth2 Introspection
 
-This authenticator handles requests that have Bearer token in e.g. the HTTP Authorization header (`Authorization: Bearer <token>`), in a different header or a query parameter. It then uses https://datatracker.ietf.org/doc/html/rfc7662[OAuth 2.0 Token Introspection] endpoint to check if the token is valid. The validation includes at least the verification of the status and the time validity. That is if the token is still active and whether it has been issued in an acceptable time frame. Latter can be adjusted by specifying a leeway. All other validation options can and should be configured.
+This authenticator handles requests that have Bearer token in the HTTP Authorization header (`Authorization: Bearer <token>`), in the `access_token` query parameter or the `access_token` body parameter (latter, if the body is of `application/x-www-form-urlencoded` MIME type). It then uses https://datatracker.ietf.org/doc/html/rfc7662[OAuth 2.0 Token Introspection] endpoint to check if the token is valid. The validation includes at least the verification of the status and the time validity. That is if the token is still active and whether it has been issued in an acceptable time frame. Latter can be adjusted by specifying a leeway. All other validation options can and should be configured.
 
 To enable the usage of this authenticator, you have to set the `type` property to `oauth2_introspection`.
 
@@ -221,7 +221,7 @@ config:
 
 === JWT
 
-As the link:{{< relref "#_oauth2_introspection">}}[OAuth2 Introspection] authenticator, this authenticator handles requests that have a Bearer token in the `Authorization` header, in a different header or a query parameter as well. Unlike the OAuth2 Introspection authenticator it expects the token to be a JSON Web Token (JWT) and verifies it according https://www.rfc-editor.org/rfc/rfc7519#section-7.2[RFC 7519, Section 7.2]. It does however not support encrypted payloads and nested JWTs. In addition to this, validation includes the verification of the time validity. Latter can be adjusted by specifying a leeway. All other validation options can and should be configured.
+As the link:{{< relref "#_oauth2_introspection">}}[OAuth2 Introspection] authenticator, this authenticator handles requests that have a Bearer token in the `Authorization` header, in a different header, a query parameter or a body parameter as well. Unlike the OAuth2 Introspection authenticator it expects the token to be a JSON Web Token (JWT) and verifies it according https://www.rfc-editor.org/rfc/rfc7519#section-7.2[RFC 7519, Section 7.2]. It does however not support encrypted payloads and nested JWTs. In addition to this, validation includes the verification of the time validity. Latter can be adjusted by specifying a leeway. All other validation options can and should be configured.
 
 To enable the usage of this authenticator, you have to set the `type` property to `jwt`.
 
@@ -233,7 +233,7 @@ The JWKS endpoint, this authenticator retrieves the key material in a format spe
 
 * *`jwt_from`*: _link:{{< relref "configuration_types.adoc#_authentication_data_source" >}}[Authentication Data Source]_ (optional, not overridable)
 +
-Where to get the access token from. If not set, this authenticator tries to retrieve it from the `Authorization` header and the `access_token` query paramter.
+Where to get the access token from. Defaults to retrieve it from the `Authorization` header, the `access_token` query parameter or the `access_token` body parameter (latter, if the body is of `application/x-www-form-urlencoded` MIME type).
 
 * *`assertions`*: _link:{{< relref "configuration_types.adoc#_assertions" >}}[Assertions]_ (mandatory, overridable)
 +

--- a/internal/pipeline/authenticators/jwt_authenticator_test.go
+++ b/internal/pipeline/authenticators/jwt_authenticator_test.go
@@ -1797,9 +1797,11 @@ func createJWT(t *testing.T, keyEntry *keystore.Entry, subject, issuer, audience
 
 	signerOpts := &jose.SignerOptions{}
 	signerOpts = signerOpts.WithType("JWT")
+
 	if setKid {
 		signerOpts = signerOpts.WithHeader("kid", keyEntry.KeyID)
 	}
+
 	signer, err := jose.NewSigner(
 		jose.SigningKey{
 			Algorithm: keyEntry.JOSEAlgorithm(),

--- a/internal/testsupport/pem_builder.go
+++ b/internal/testsupport/pem_builder.go
@@ -3,6 +3,7 @@ package testsupport
 import (
 	"bytes"
 	"crypto/ecdsa"
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 )
@@ -55,6 +56,19 @@ func WithECDSAPrivateKey(key *ecdsa.PrivateKey, opts ...PEMBlockOption) PEMEntry
 
 		block.Type = "EC PRIVATE KEY"
 		block.Bytes = raw
+
+		for _, opt := range opts {
+			opt(block)
+		}
+
+		return nil
+	}
+}
+
+func WithRSAPrivateKey(key *rsa.PrivateKey, opts ...PEMBlockOption) PEMEntryOption {
+	return func(block *pem.Block) error {
+		block.Type = "RSA PRIVATE KEY"
+		block.Bytes = x509.MarshalPKCS1PrivateKey(key)
 
 		for _, opt := range opts {
 			opt(block)


### PR DESCRIPTION
closes: #99 