### PR TITLE
refactor!: `session` property used by some authenticators renamed (incl. its properties) to `subject` to better reflect its meaning

### DIFF
--- a/docs/content/docs/configuration/pipeline/authenticators.adoc
+++ b/docs/content/docs/configuration/pipeline/authenticators.adoc
@@ -116,7 +116,7 @@ The endpoint to communicate to for the actual subject authentication status veri
 +
 Where to extract the authentication data from the request. This authenticator will use the matched authentication data source as is while sending it to the `identity_info_endpoint`.
 
-* *`session`*: _link:{{< relref "configuration_types.adoc#_session" >}}[Session]_ (mandatory, not overridable)
+* *`subject`*: _link:{{< relref "configuration_types.adoc#_subject" >}}[Subject]_ (mandatory, not overridable)
 +
 Where to extract the subject id from the identity info endpoint response, as well as which attributes to use.
 
@@ -142,7 +142,7 @@ config:
     url: http://my-auth.system/sessions/whoami
   authentication_data_source:
     - cookie: my_session
-  session:
+  subject:
     id_from: "identity.id"
   cache_ttl: 5m
 ----
@@ -169,7 +169,7 @@ config:
   authentication_data_source:
     - header: X-Custom-Bearer-Token
       schema: Bearer
-  session:
+  subject:
     id_from: "sub"
   cache_ttl: 5m
 ----
@@ -197,7 +197,7 @@ Where to get the access token from. Defaults to retrieve it from the `Authorizat
 +
 Configures the required claim assertions. Overriding on rule level is possible even partially. Those parts of the assertion, which have not been overridden are taken from the prototype configuration.
 
-* *`session`*: _link:{{< relref "configuration_types.adoc#_session" >}}[Session]_ (optional, not overridable)
+* *`subject`*: _link:{{< relref "configuration_types.adoc#_subject" >}}[Subject]_ (optional, not overridable)
 +
 Where to extract the subject id from the introspection endpoint response, as well as which attributes to use. If not configured `sub` is used to extract the subject id and all attributes from the introspection endpoint response are made available as attributes of the subject.
 
@@ -244,7 +244,7 @@ Where to get the access token from. Defaults to retrieve it from the `Authorizat
 +
 Configures the required claim assertions. Overriding on rule level is possible even partially. Those parts of the assertion, which have not been overridden are taken from the prototype configuration.
 
-* *`session`*: _link:{{< relref "configuration_types.adoc#_session" >}}[Session]_ (optional, not overridable)
+* *`subject`*: _link:{{< relref "configuration_types.adoc#_subject" >}}[Subject]_ (optional, not overridable)
 +
 Where to extract the subject id from the JWT, as well as which attributes to use. If not configured `sub` is used to extract the subject id and all attributes from the JWT payload are made available as attributes of the subject.
 

--- a/docs/content/docs/configuration/pipeline/authenticators.adoc
+++ b/docs/content/docs/configuration/pipeline/authenticators.adoc
@@ -143,7 +143,7 @@ config:
   authentication_data_source:
     - cookie: my_session
   subject:
-    id_from: "identity.id"
+    id: "identity.id"
   cache_ttl: 5m
 ----
 ====
@@ -170,7 +170,7 @@ config:
     - header: X-Custom-Bearer-Token
       schema: Bearer
   subject:
-    id_from: "sub"
+    id: "sub"
   cache_ttl: 5m
 ----
 

--- a/docs/content/docs/configuration/pipeline/authenticators.adoc
+++ b/docs/content/docs/configuration/pipeline/authenticators.adoc
@@ -143,7 +143,7 @@ config:
   authentication_data_source:
     - cookie: my_session
   session:
-    subject_id_from: "identity.id"
+    id_from: "identity.id"
   cache_ttl: 5m
 ----
 ====
@@ -170,7 +170,7 @@ config:
     - header: X-Custom-Bearer-Token
       schema: Bearer
   session:
-    subject_id_from: "sub"
+    id_from: "sub"
   cache_ttl: 5m
 ----
 

--- a/docs/content/docs/configuration/pipeline/configuration_types.adoc
+++ b/docs/content/docs/configuration/pipeline/configuration_types.adoc
@@ -505,7 +505,7 @@ This matcher enables matching scopes using wildcards. It goes beyond the link:{{
 
 This matcher can only be used by explicitly setting the `matching_strategy` to `wildcard` and defining the required patterns in the `values` property.
 
-== Session
+== Subject
 
 This configuration type enables extraction of subject information from responses received by Heimdall from authentication services. Following properties are available.
 

--- a/docs/content/docs/configuration/pipeline/configuration_types.adoc
+++ b/docs/content/docs/configuration/pipeline/configuration_types.adoc
@@ -509,11 +509,11 @@ This matcher can only be used by explicitly setting the `matching_strategy` to `
 
 This configuration type enables extraction of subject information from responses received by Heimdall from authentication services. Following properties are available.
 
-* *`subject_id_from`*: _string_ (mandatory)
+* *`id_from`*: _string_ (mandatory)
 +
 A https://github.com/tidwall/gjson/blob/master/SYNTAX.md[GJSON Path] pointing to the id of the subject in the JSON object.
 
-* *`subject_attributes_from`*: _string_ (optional)
+* *`attributes_from`*: _string_ (optional)
 +
 A https://github.com/tidwall/gjson/blob/master/SYNTAX.md[GJSON Path] pointing to the attributes of the subject in the JSON object. Defaults to `@this`.
 
@@ -524,20 +524,20 @@ This example shows how to extract the subject id from an https://tools.ietf.org/
 
 [source, yaml]
 ----
-subject_id_from: sub
-subject_attributes_from: @this
+id_from: sub
+attributes_from: @this
 ----
 
-Setting `subject_attributes_from` was actually not required, as `@this` would be set by default anyway.
+Setting `attributes_from` was actually not required, as `@this` would be set by default anyway.
 ====
 
 .Extracting subject id from an https://www.ory.sh/docs/kratos/[Ory Kratos] "whoami" endpoint response
 ====
 
-This example shows how to extract the subject id from an https://www.ory.sh/docs/kratos/[Ory Kratos] "whoami" endpoint response and set the subject attributes to the entire response. `subject_attributes_from` is not configured, so default is used.
+This example shows how to extract the subject id from an https://www.ory.sh/docs/kratos/[Ory Kratos] "whoami" endpoint response and set the subject attributes to the entire response. `attributes_from` is not configured, so default is used.
 
 [source, yaml]
 ----
-subject_id_from: identity.id
+id_from: identity.id
 ----
 ====

--- a/docs/content/docs/configuration/pipeline/configuration_types.adoc
+++ b/docs/content/docs/configuration/pipeline/configuration_types.adoc
@@ -509,11 +509,11 @@ This matcher can only be used by explicitly setting the `matching_strategy` to `
 
 This configuration type enables extraction of subject information from responses received by Heimdall from authentication services. Following properties are available.
 
-* *`id_from`*: _string_ (mandatory)
+* *`id`*: _string_ (mandatory)
 +
 A https://github.com/tidwall/gjson/blob/master/SYNTAX.md[GJSON Path] pointing to the id of the subject in the JSON object.
 
-* *`attributes_from`*: _string_ (optional)
+* *`attributes`*: _string_ (optional)
 +
 A https://github.com/tidwall/gjson/blob/master/SYNTAX.md[GJSON Path] pointing to the attributes of the subject in the JSON object. Defaults to `@this`.
 
@@ -524,20 +524,20 @@ This example shows how to extract the subject id from an https://tools.ietf.org/
 
 [source, yaml]
 ----
-id_from: sub
-attributes_from: @this
+id: sub
+attributes: @this
 ----
 
-Setting `attributes_from` was actually not required, as `@this` would be set by default anyway.
+Setting `attributes` was actually not required, as `@this` would be set by default anyway.
 ====
 
 .Extracting subject id from an https://www.ory.sh/docs/kratos/[Ory Kratos] "whoami" endpoint response
 ====
 
-This example shows how to extract the subject id from an https://www.ory.sh/docs/kratos/[Ory Kratos] "whoami" endpoint response and set the subject attributes to the entire response. `attributes_from` is not configured, so default is used.
+This example shows how to extract the subject id from an https://www.ory.sh/docs/kratos/[Ory Kratos] "whoami" endpoint response and set the subject attributes to the entire response. `attributes` is not configured, so default is used.
 
 [source, yaml]
 ----
-id_from: identity.id
+id: identity.id
 ----
 ====

--- a/docs/content/docs/configuration/reference/configuration.adoc
+++ b/docs/content/docs/configuration/reference/configuration.adoc
@@ -134,7 +134,7 @@ pipeline:
             give_up_after: 2s
         authentication_data_source:
           - cookie: ory_kratos_session
-        session:
+        subject:
           attributes_from: "@this"
           id_from: "identity.id"
         allow_fallback_on_error: true
@@ -164,7 +164,7 @@ pipeline:
             - bar
           audience:
             - bla
-        session:
+        subject:
           attributes_from: "@this"
           id_from: "sub"
         allow_fallback_on_error: true
@@ -188,7 +188,7 @@ pipeline:
             - RSA
           issuers:
             - bla
-        session:
+        subject:
           attributes_from: "@this"
           id_from: "identity.id"
         cache_ttl: 5m

--- a/docs/content/docs/configuration/reference/configuration.adoc
+++ b/docs/content/docs/configuration/reference/configuration.adoc
@@ -135,8 +135,8 @@ pipeline:
         authentication_data_source:
           - cookie: ory_kratos_session
         subject:
-          attributes_from: "@this"
-          id_from: "identity.id"
+          attributes: "@this"
+          id: "identity.id"
         allow_fallback_on_error: true
     - id: hydra_authenticator
       type: oauth2_introspection
@@ -165,8 +165,8 @@ pipeline:
           audience:
             - bla
         subject:
-          attributes_from: "@this"
-          id_from: "sub"
+          attributes: "@this"
+          id: "sub"
         allow_fallback_on_error: true
     - id: jwt_authenticator
       type: jwt
@@ -189,8 +189,8 @@ pipeline:
           issuers:
             - bla
         subject:
-          attributes_from: "@this"
-          id_from: "identity.id"
+          attributes: "@this"
+          id: "identity.id"
         cache_ttl: 5m
         allow_fallback_on_error: true
 

--- a/docs/content/docs/configuration/reference/configuration.adoc
+++ b/docs/content/docs/configuration/reference/configuration.adoc
@@ -135,8 +135,8 @@ pipeline:
         authentication_data_source:
           - cookie: ory_kratos_session
         session:
-          subject_attributes_from: "@this"
-          subject_id_from: "identity.id"
+          attributes_from: "@this"
+          id_from: "identity.id"
         allow_fallback_on_error: true
     - id: hydra_authenticator
       type: oauth2_introspection
@@ -165,8 +165,8 @@ pipeline:
           audience:
             - bla
         session:
-          subject_attributes_from: "@this"
-          subject_id_from: "sub"
+          attributes_from: "@this"
+          id_from: "sub"
         allow_fallback_on_error: true
     - id: jwt_authenticator
       type: jwt
@@ -189,8 +189,8 @@ pipeline:
           issuers:
             - bla
         session:
-          subject_attributes_from: "@this"
-          subject_id_from: "identity.id"
+          attributes_from: "@this"
+          id_from: "identity.id"
         cache_ttl: 5m
         allow_fallback_on_error: true
 

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -114,8 +114,8 @@ pipeline:
         authentication_data_source:
           - cookie: ory_kratos_session
         subject:
-          attributes_from: "@this"
-          id_from: "identity.id"
+          attributes: "@this"
+          id: "identity.id"
         allow_fallback_on_error: true
     - id: hydra_authenticator
       type: oauth2_introspection
@@ -142,8 +142,8 @@ pipeline:
           audience:
             - bla
         subject:
-          attributes_from: "@this"
-          id_from: sub
+          attributes: "@this"
+          id: sub
         allow_fallback_on_error: true
     - id: jwt_authenticator
       type: jwt
@@ -164,8 +164,8 @@ pipeline:
           issuers:
             - bla
         subject:
-          attributes_from: "@this"
-          id_from: "identity.id"
+          attributes: "@this"
+          id: "identity.id"
         cache_ttl: 5m
         allow_fallback_on_error: true
         validate_jwk: true

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -113,7 +113,7 @@ pipeline:
             give_up_after: 2s
         authentication_data_source:
           - cookie: ory_kratos_session
-        session:
+        subject:
           attributes_from: "@this"
           id_from: "identity.id"
         allow_fallback_on_error: true
@@ -141,7 +141,7 @@ pipeline:
             - bar
           audience:
             - bla
-        session:
+        subject:
           attributes_from: "@this"
           id_from: sub
         allow_fallback_on_error: true
@@ -163,7 +163,7 @@ pipeline:
             - RSA
           issuers:
             - bla
-        session:
+        subject:
           attributes_from: "@this"
           id_from: "identity.id"
         cache_ttl: 5m

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -114,8 +114,8 @@ pipeline:
         authentication_data_source:
           - cookie: ory_kratos_session
         session:
-          subject_attributes_from: "@this"
-          subject_id_from: "identity.id"
+          attributes_from: "@this"
+          id_from: "identity.id"
         allow_fallback_on_error: true
     - id: hydra_authenticator
       type: oauth2_introspection
@@ -142,8 +142,8 @@ pipeline:
           audience:
             - bla
         session:
-          subject_attributes_from: "@this"
-          subject_id_from: sub
+          attributes_from: "@this"
+          id_from: sub
         allow_fallback_on_error: true
     - id: jwt_authenticator
       type: jwt
@@ -164,8 +164,8 @@ pipeline:
           issuers:
             - bla
         session:
-          subject_attributes_from: "@this"
-          subject_id_from: "identity.id"
+          attributes_from: "@this"
+          id_from: "identity.id"
         cache_ttl: 5m
         allow_fallback_on_error: true
         validate_jwk: true

--- a/internal/pipeline/authenticators/generic_authenticator.go
+++ b/internal/pipeline/authenticators/generic_authenticator.go
@@ -48,7 +48,7 @@ func newGenericAuthenticator(rawConfig map[string]any) (*genericAuthenticator, e
 	type Config struct {
 		Endpoint             endpoint.Endpoint                   `mapstructure:"identity_info_endpoint"`
 		AuthDataSource       extractors.CompositeExtractStrategy `mapstructure:"authentication_data_source"`
-		Session              Session                             `mapstructure:"session"`
+		Session              SubjectInfo                         `mapstructure:"session"`
 		CacheTTL             *time.Duration                      `mapstructure:"cache_ttl"`
 		AllowFallbackOnError bool                                `mapstructure:"allow_fallback_on_error"`
 	}

--- a/internal/pipeline/authenticators/generic_authenticator.go
+++ b/internal/pipeline/authenticators/generic_authenticator.go
@@ -48,7 +48,7 @@ func newGenericAuthenticator(rawConfig map[string]any) (*genericAuthenticator, e
 	type Config struct {
 		Endpoint             endpoint.Endpoint                   `mapstructure:"identity_info_endpoint"`
 		AuthDataSource       extractors.CompositeExtractStrategy `mapstructure:"authentication_data_source"`
-		Session              SubjectInfo                         `mapstructure:"session"`
+		SubjectInfo          SubjectInfo                         `mapstructure:"subject"`
 		CacheTTL             *time.Duration                      `mapstructure:"cache_ttl"`
 		AllowFallbackOnError bool                                `mapstructure:"allow_fallback_on_error"`
 	}
@@ -67,9 +67,9 @@ func newGenericAuthenticator(rawConfig map[string]any) (*genericAuthenticator, e
 			CausedBy(err)
 	}
 
-	if err := conf.Session.Validate(); err != nil {
+	if err := conf.SubjectInfo.Validate(); err != nil {
 		return nil, errorchain.
-			NewWithMessage(heimdall.ErrConfiguration, "failed to validate session configuration").
+			NewWithMessage(heimdall.ErrConfiguration, "failed to validate subject configuration").
 			CausedBy(err)
 	}
 
@@ -81,7 +81,7 @@ func newGenericAuthenticator(rawConfig map[string]any) (*genericAuthenticator, e
 	return &genericAuthenticator{
 		e:   conf.Endpoint,
 		ads: conf.AuthDataSource,
-		sf:  &conf.Session,
+		sf:  &conf.SubjectInfo,
 		ttl: x.IfThenElseExec(conf.CacheTTL != nil,
 			func() time.Duration { return *conf.CacheTTL },
 			func() time.Duration { return 0 }),

--- a/internal/pipeline/authenticators/generic_authenticator_test.go
+++ b/internal/pipeline/authenticators/generic_authenticator_test.go
@@ -36,7 +36,7 @@ func TestCreateGenericAuthenticator(t *testing.T) {
 foo: bar
 identity_info_endpoint:
   url: http://test.com
-session:
+subject:
   id_from: some_template`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
@@ -51,7 +51,7 @@ session:
 			config: []byte(`
 authentication_data_source:
   - header: foo-header
-session:
+subject:
   id_from: some_template`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
@@ -62,7 +62,7 @@ session:
 			},
 		},
 		{
-			uc: "missing session config",
+			uc: "missing subject config",
 			config: []byte(`
 identity_info_endpoint:
   url: http://test.com
@@ -73,7 +73,7 @@ authentication_data_source:
 
 				require.Error(t, err)
 				assert.ErrorIs(t, err, heimdall.ErrConfiguration)
-				assert.Contains(t, err.Error(), "session configuration")
+				assert.Contains(t, err.Error(), "subject configuration")
 			},
 		},
 		{
@@ -81,7 +81,7 @@ authentication_data_source:
 			config: []byte(`
 identity_info_endpoint:
   url: http://test.com
-session:
+subject:
   id_from: some_template`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
@@ -99,7 +99,7 @@ identity_info_endpoint:
   method: GET
 authentication_data_source:
   - header: foo-header
-session:
+subject:
   id_from: some_template`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
@@ -126,7 +126,7 @@ identity_info_endpoint:
   method: POST
 authentication_data_source:
   - cookie: foo-cookie
-session:
+subject:
   id_from: some_template
 cache_ttl: 5s`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
@@ -154,7 +154,7 @@ identity_info_endpoint:
   method: POST
 authentication_data_source:
   - cookie: foo-cookie
-session:
+subject:
   id_from: some_template
 allow_fallback_on_error: true`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
@@ -206,7 +206,7 @@ identity_info_endpoint:
   method: POST
 authentication_data_source:
   - header: foo-header
-session:
+subject:
   id_from: some_template
 allow_fallback_on_error: true`),
 			assert: func(t *testing.T, err error, prototype *genericAuthenticator,
@@ -227,7 +227,7 @@ identity_info_endpoint:
   method: POST
 authentication_data_source:
   - header: foo-header
-session:
+subject:
   id_from: some_template`),
 			config: []byte(`foo: bar`),
 			assert: func(t *testing.T, err error, prototype *genericAuthenticator,
@@ -248,7 +248,7 @@ identity_info_endpoint:
   method: POST
 authentication_data_source:
   - header: foo-header
-session:
+subject:
   id_from: some_template`),
 			config: []byte(`cache_ttl: 5s`),
 			assert: func(t *testing.T, err error, prototype *genericAuthenticator,
@@ -275,7 +275,7 @@ identity_info_endpoint:
   method: POST
 authentication_data_source:
   - header: foo-header
-session:
+subject:
   id_from: some_template`),
 			config: []byte(`allow_fallback_on_error: true`),
 			assert: func(t *testing.T, err error, prototype *genericAuthenticator,
@@ -301,7 +301,7 @@ identity_info_endpoint:
   method: POST
 authentication_data_source:
   - header: foo-header
-session:
+subject:
   id_from: some_template
 cache_ttl: 5s`),
 			config: []byte(`

--- a/internal/pipeline/authenticators/generic_authenticator_test.go
+++ b/internal/pipeline/authenticators/generic_authenticator_test.go
@@ -113,7 +113,7 @@ session:
 				assert.True(t, ok)
 				assert.Len(t, ces, 1)
 				assert.Contains(t, ces, &extractors.HeaderValueExtractStrategy{Name: "foo-header"})
-				assert.Equal(t, &Session{SubjectIDFrom: "some_template"}, auth.sf)
+				assert.Equal(t, &SubjectInfo{IDFrom: "some_template"}, auth.sf)
 				assert.Equal(t, time.Duration(0), auth.ttl)
 				assert.False(t, auth.IsFallbackOnErrorAllowed())
 			},
@@ -141,7 +141,7 @@ cache_ttl: 5s`),
 				assert.True(t, ok)
 				assert.Len(t, ces, 1)
 				assert.Contains(t, ces, &extractors.CookieValueExtractStrategy{Name: "foo-cookie"})
-				assert.Equal(t, &Session{SubjectIDFrom: "some_template"}, auth.sf)
+				assert.Equal(t, &SubjectInfo{IDFrom: "some_template"}, auth.sf)
 				assert.Equal(t, 5*time.Second, auth.ttl)
 				assert.False(t, auth.IsFallbackOnErrorAllowed())
 			},
@@ -169,7 +169,7 @@ allow_fallback_on_error: true`),
 				assert.True(t, ok)
 				assert.Len(t, ces, 1)
 				assert.Contains(t, ces, &extractors.CookieValueExtractStrategy{Name: "foo-cookie"})
-				assert.Equal(t, &Session{SubjectIDFrom: "some_template"}, auth.sf)
+				assert.Equal(t, &SubjectInfo{IDFrom: "some_template"}, auth.sf)
 				assert.Equal(t, time.Duration(0), auth.ttl)
 				assert.True(t, auth.IsFallbackOnErrorAllowed())
 			},
@@ -485,7 +485,7 @@ func TestGenericAuthenticatorExecute(t *testing.T) {
 						"Accept": "application/json",
 					},
 				},
-				sf: &Session{SubjectIDFrom: "barfoo"},
+				sf: &SubjectInfo{IDFrom: "barfoo"},
 			},
 			configureMocks: func(t *testing.T,
 				ctx *heimdallmocks.MockContext,
@@ -532,7 +532,7 @@ func TestGenericAuthenticatorExecute(t *testing.T) {
 						"Accept": "application/json",
 					},
 				},
-				sf: &Session{SubjectIDFrom: "user_id"},
+				sf: &SubjectInfo{IDFrom: "user_id"},
 			},
 			configureMocks: func(t *testing.T,
 				ctx *heimdallmocks.MockContext,
@@ -581,7 +581,7 @@ func TestGenericAuthenticatorExecute(t *testing.T) {
 						"Accept": "application/json",
 					},
 				},
-				sf:  &Session{SubjectIDFrom: "user_id"},
+				sf:  &SubjectInfo{IDFrom: "user_id"},
 				ttl: 5 * time.Second,
 			},
 			configureMocks: func(t *testing.T,
@@ -636,7 +636,7 @@ func TestGenericAuthenticatorExecute(t *testing.T) {
 						"Accept": "application/json",
 					},
 				},
-				sf:  &Session{SubjectIDFrom: "user_id"},
+				sf:  &SubjectInfo{IDFrom: "user_id"},
 				ttl: 5 * time.Second,
 			},
 			configureMocks: func(t *testing.T,
@@ -674,7 +674,7 @@ func TestGenericAuthenticatorExecute(t *testing.T) {
 						"Accept": "application/json",
 					},
 				},
-				sf:  &Session{SubjectIDFrom: "user_id"},
+				sf:  &SubjectInfo{IDFrom: "user_id"},
 				ttl: 5 * time.Second,
 			},
 			configureMocks: func(t *testing.T,

--- a/internal/pipeline/authenticators/generic_authenticator_test.go
+++ b/internal/pipeline/authenticators/generic_authenticator_test.go
@@ -37,7 +37,7 @@ foo: bar
 identity_info_endpoint:
   url: http://test.com
 session:
-  subject_id_from: some_template`),
+  id_from: some_template`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
 
@@ -52,7 +52,7 @@ session:
 authentication_data_source:
   - header: foo-header
 session:
-  subject_id_from: some_template`),
+  id_from: some_template`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
 
@@ -82,7 +82,7 @@ authentication_data_source:
 identity_info_endpoint:
   url: http://test.com
 session:
-  subject_id_from: some_template`),
+  id_from: some_template`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
 
@@ -100,7 +100,7 @@ identity_info_endpoint:
 authentication_data_source:
   - header: foo-header
 session:
-  subject_id_from: some_template`),
+  id_from: some_template`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
 
@@ -127,7 +127,7 @@ identity_info_endpoint:
 authentication_data_source:
   - cookie: foo-cookie
 session:
-  subject_id_from: some_template
+  id_from: some_template
 cache_ttl: 5s`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
@@ -155,7 +155,7 @@ identity_info_endpoint:
 authentication_data_source:
   - cookie: foo-cookie
 session:
-  subject_id_from: some_template
+  id_from: some_template
 allow_fallback_on_error: true`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
@@ -207,7 +207,7 @@ identity_info_endpoint:
 authentication_data_source:
   - header: foo-header
 session:
-  subject_id_from: some_template
+  id_from: some_template
 allow_fallback_on_error: true`),
 			assert: func(t *testing.T, err error, prototype *genericAuthenticator,
 				configured *genericAuthenticator,
@@ -228,7 +228,7 @@ identity_info_endpoint:
 authentication_data_source:
   - header: foo-header
 session:
-  subject_id_from: some_template`),
+  id_from: some_template`),
 			config: []byte(`foo: bar`),
 			assert: func(t *testing.T, err error, prototype *genericAuthenticator,
 				configured *genericAuthenticator,
@@ -249,7 +249,7 @@ identity_info_endpoint:
 authentication_data_source:
   - header: foo-header
 session:
-  subject_id_from: some_template`),
+  id_from: some_template`),
 			config: []byte(`cache_ttl: 5s`),
 			assert: func(t *testing.T, err error, prototype *genericAuthenticator,
 				configured *genericAuthenticator,
@@ -276,7 +276,7 @@ identity_info_endpoint:
 authentication_data_source:
   - header: foo-header
 session:
-  subject_id_from: some_template`),
+  id_from: some_template`),
 			config: []byte(`allow_fallback_on_error: true`),
 			assert: func(t *testing.T, err error, prototype *genericAuthenticator,
 				configured *genericAuthenticator,
@@ -302,7 +302,7 @@ identity_info_endpoint:
 authentication_data_source:
   - header: foo-header
 session:
-  subject_id_from: some_template
+  id_from: some_template
 cache_ttl: 5s`),
 			config: []byte(`
 cache_ttl: 15s`),

--- a/internal/pipeline/authenticators/generic_authenticator_test.go
+++ b/internal/pipeline/authenticators/generic_authenticator_test.go
@@ -37,7 +37,7 @@ foo: bar
 identity_info_endpoint:
   url: http://test.com
 subject:
-  id_from: some_template`),
+  id: some_template`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
 
@@ -52,7 +52,7 @@ subject:
 authentication_data_source:
   - header: foo-header
 subject:
-  id_from: some_template`),
+  id: some_template`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
 
@@ -82,7 +82,7 @@ authentication_data_source:
 identity_info_endpoint:
   url: http://test.com
 subject:
-  id_from: some_template`),
+  id: some_template`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
 
@@ -100,7 +100,7 @@ identity_info_endpoint:
 authentication_data_source:
   - header: foo-header
 subject:
-  id_from: some_template`),
+  id: some_template`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
 
@@ -127,7 +127,7 @@ identity_info_endpoint:
 authentication_data_source:
   - cookie: foo-cookie
 subject:
-  id_from: some_template
+  id: some_template
 cache_ttl: 5s`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
@@ -155,7 +155,7 @@ identity_info_endpoint:
 authentication_data_source:
   - cookie: foo-cookie
 subject:
-  id_from: some_template
+  id: some_template
 allow_fallback_on_error: true`),
 			assertError: func(t *testing.T, err error, auth *genericAuthenticator) {
 				t.Helper()
@@ -207,7 +207,7 @@ identity_info_endpoint:
 authentication_data_source:
   - header: foo-header
 subject:
-  id_from: some_template
+  id: some_template
 allow_fallback_on_error: true`),
 			assert: func(t *testing.T, err error, prototype *genericAuthenticator,
 				configured *genericAuthenticator,
@@ -228,7 +228,7 @@ identity_info_endpoint:
 authentication_data_source:
   - header: foo-header
 subject:
-  id_from: some_template`),
+  id: some_template`),
 			config: []byte(`foo: bar`),
 			assert: func(t *testing.T, err error, prototype *genericAuthenticator,
 				configured *genericAuthenticator,
@@ -249,7 +249,7 @@ identity_info_endpoint:
 authentication_data_source:
   - header: foo-header
 subject:
-  id_from: some_template`),
+  id: some_template`),
 			config: []byte(`cache_ttl: 5s`),
 			assert: func(t *testing.T, err error, prototype *genericAuthenticator,
 				configured *genericAuthenticator,
@@ -276,7 +276,7 @@ identity_info_endpoint:
 authentication_data_source:
   - header: foo-header
 subject:
-  id_from: some_template`),
+  id: some_template`),
 			config: []byte(`allow_fallback_on_error: true`),
 			assert: func(t *testing.T, err error, prototype *genericAuthenticator,
 				configured *genericAuthenticator,
@@ -302,7 +302,7 @@ identity_info_endpoint:
 authentication_data_source:
   - header: foo-header
 subject:
-  id_from: some_template
+  id: some_template
 cache_ttl: 5s`),
 			config: []byte(`
 cache_ttl: 15s`),

--- a/internal/pipeline/authenticators/jwt_authenticator.go
+++ b/internal/pipeline/authenticators/jwt_authenticator.go
@@ -61,7 +61,7 @@ func newJwtAuthenticator(rawConfig map[string]any) (*jwtAuthenticator, error) {
 		Endpoint             endpoint.Endpoint                   `mapstructure:"jwks_endpoint"`
 		AuthDataSource       extractors.CompositeExtractStrategy `mapstructure:"jwt_source"`
 		Assertions           oauth2.Expectation                  `mapstructure:"assertions"`
-		Session              SubjectInfo                         `mapstructure:"session"`
+		SubjectInfo          SubjectInfo                         `mapstructure:"subject"`
 		CacheTTL             *time.Duration                      `mapstructure:"cache_ttl"`
 		AllowFallbackOnError bool                                `mapstructure:"allow_fallback_on_error"`
 		ValidateJWK          *bool                               `mapstructure:"validate_jwk"`
@@ -107,8 +107,8 @@ func newJwtAuthenticator(rawConfig map[string]any) (*jwtAuthenticator, error) {
 		conf.Assertions.ScopesMatcher = oauth2.NoopMatcher{}
 	}
 
-	if len(conf.Session.IDFrom) == 0 {
-		conf.Session.IDFrom = "sub"
+	if len(conf.SubjectInfo.IDFrom) == 0 {
+		conf.SubjectInfo.IDFrom = "sub"
 	}
 
 	validateJWKCert := x.IfThenElseExec(conf.ValidateJWK != nil,
@@ -130,7 +130,7 @@ func newJwtAuthenticator(rawConfig map[string]any) (*jwtAuthenticator, error) {
 		e:                    conf.Endpoint,
 		a:                    conf.Assertions,
 		ttl:                  conf.CacheTTL,
-		sf:                   &conf.Session,
+		sf:                   &conf.SubjectInfo,
 		ads:                  ads,
 		allowFallbackOnError: conf.AllowFallbackOnError,
 		validateJWKCert:      validateJWKCert,

--- a/internal/pipeline/authenticators/jwt_authenticator.go
+++ b/internal/pipeline/authenticators/jwt_authenticator.go
@@ -61,7 +61,7 @@ func newJwtAuthenticator(rawConfig map[string]any) (*jwtAuthenticator, error) {
 		Endpoint             endpoint.Endpoint                   `mapstructure:"jwks_endpoint"`
 		AuthDataSource       extractors.CompositeExtractStrategy `mapstructure:"jwt_source"`
 		Assertions           oauth2.Expectation                  `mapstructure:"assertions"`
-		Session              Session                             `mapstructure:"session"`
+		Session              SubjectInfo                         `mapstructure:"session"`
 		CacheTTL             *time.Duration                      `mapstructure:"cache_ttl"`
 		AllowFallbackOnError bool                                `mapstructure:"allow_fallback_on_error"`
 		ValidateJWK          *bool                               `mapstructure:"validate_jwk"`
@@ -107,8 +107,8 @@ func newJwtAuthenticator(rawConfig map[string]any) (*jwtAuthenticator, error) {
 		conf.Assertions.ScopesMatcher = oauth2.NoopMatcher{}
 	}
 
-	if len(conf.Session.SubjectIDFrom) == 0 {
-		conf.Session.SubjectIDFrom = "sub"
+	if len(conf.Session.IDFrom) == 0 {
+		conf.Session.IDFrom = "sub"
 	}
 
 	validateJWKCert := x.IfThenElseExec(conf.ValidateJWK != nil,

--- a/internal/pipeline/authenticators/jwt_authenticator_test.go
+++ b/internal/pipeline/authenticators/jwt_authenticator_test.go
@@ -90,7 +90,7 @@ jwt_source:
 assertions:
   issuers:
     - foobar
-session:
+subject:
   id_from: some_template`),
 			assert: func(t *testing.T, err error, a *jwtAuthenticator) {
 				t.Helper()
@@ -108,7 +108,7 @@ jwks_endpoint:
 assertions:
   audience:
     - foobar
-session:
+subject:
   id_from: some_template`),
 			assert: func(t *testing.T, err error, a *jwtAuthenticator) {
 				t.Helper()
@@ -158,7 +158,7 @@ assertions:
 				})
 				assert.Equal(t, time.Duration(0), auth.a.ValidityLeeway)
 
-				// session settings
+				// subject settings
 				sess, ok := auth.sf.(*SubjectInfo)
 				require.True(t, ok)
 				assert.Equal(t, "sub", sess.IDFrom)
@@ -216,7 +216,7 @@ cache_ttl: 5s`),
 				})
 				assert.Equal(t, time.Duration(0), auth.a.ValidityLeeway)
 
-				// session settings
+				// subject settings
 				sess, ok := auth.sf.(*SubjectInfo)
 				require.True(t, ok)
 				assert.Equal(t, "sub", sess.IDFrom)
@@ -256,7 +256,7 @@ assertions:
     - foobar
   allowed_algorithms:
     - ES256
-session:
+subject:
   id_from: some_claim
 allow_fallback_on_error: true
 validate_jwk: false
@@ -293,7 +293,7 @@ trust_store: ` + trustStorePath),
 				assert.ElementsMatch(t, auth.a.AllowedAlgorithms, []string{string(jose.ES256)})
 				assert.Equal(t, time.Duration(0), auth.a.ValidityLeeway)
 
-				// session settings
+				// subject settings
 				sess, ok := auth.sf.(*SubjectInfo)
 				require.True(t, ok)
 				assert.Equal(t, "some_claim", sess.IDFrom)

--- a/internal/pipeline/authenticators/jwt_authenticator_test.go
+++ b/internal/pipeline/authenticators/jwt_authenticator_test.go
@@ -159,10 +159,10 @@ assertions:
 				assert.Equal(t, time.Duration(0), auth.a.ValidityLeeway)
 
 				// session settings
-				sess, ok := auth.sf.(*Session)
+				sess, ok := auth.sf.(*SubjectInfo)
 				require.True(t, ok)
-				assert.Equal(t, "sub", sess.SubjectIDFrom)
-				assert.Empty(t, sess.SubjectAttributesFrom)
+				assert.Equal(t, "sub", sess.IDFrom)
+				assert.Empty(t, sess.AttributesFrom)
 
 				// cache settings
 				assert.Nil(t, auth.ttl)
@@ -217,10 +217,10 @@ cache_ttl: 5s`),
 				assert.Equal(t, time.Duration(0), auth.a.ValidityLeeway)
 
 				// session settings
-				sess, ok := auth.sf.(*Session)
+				sess, ok := auth.sf.(*SubjectInfo)
 				require.True(t, ok)
-				assert.Equal(t, "sub", sess.SubjectIDFrom)
-				assert.Empty(t, sess.SubjectAttributesFrom)
+				assert.Equal(t, "sub", sess.IDFrom)
+				assert.Empty(t, sess.AttributesFrom)
 
 				// cache settings
 				assert.NotNil(t, auth.ttl)
@@ -294,10 +294,10 @@ trust_store: ` + trustStorePath),
 				assert.Equal(t, time.Duration(0), auth.a.ValidityLeeway)
 
 				// session settings
-				sess, ok := auth.sf.(*Session)
+				sess, ok := auth.sf.(*SubjectInfo)
 				require.True(t, ok)
-				assert.Equal(t, "some_claim", sess.SubjectIDFrom)
-				assert.Empty(t, sess.SubjectAttributesFrom)
+				assert.Equal(t, "some_claim", sess.IDFrom)
+				assert.Empty(t, sess.AttributesFrom)
 
 				// cache settings
 				assert.Nil(t, auth.ttl)
@@ -1091,7 +1091,7 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					TrustedIssuers:    []string{issuer},
 					ScopesMatcher:     oauth2.ExactScopeStrategyMatcher{},
 				},
-				sf:  &Session{SubjectIDFrom: "foobar"},
+				sf:  &SubjectInfo{IDFrom: "foobar"},
 				ttl: &tenSecondsTTL,
 			},
 			configureMocks: func(t *testing.T,
@@ -1136,7 +1136,7 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					TrustedIssuers:    []string{issuer},
 					ScopesMatcher:     oauth2.ExactScopeStrategyMatcher{},
 				},
-				sf:  &Session{SubjectIDFrom: "sub"},
+				sf:  &SubjectInfo{IDFrom: "sub"},
 				ttl: &tenSecondsTTL,
 			},
 			configureMocks: func(t *testing.T,
@@ -1191,7 +1191,7 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					TrustedIssuers:    []string{issuer},
 					ScopesMatcher:     oauth2.ExactScopeStrategyMatcher{},
 				},
-				sf:  &Session{SubjectIDFrom: "sub"},
+				sf:  &SubjectInfo{IDFrom: "sub"},
 				ttl: &tenSecondsTTL,
 			},
 			configureMocks: func(t *testing.T,
@@ -1258,7 +1258,7 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					TrustedIssuers:    []string{issuer},
 					ScopesMatcher:     oauth2.ExactScopeStrategyMatcher{},
 				},
-				sf:  &Session{SubjectIDFrom: "sub"},
+				sf:  &SubjectInfo{IDFrom: "sub"},
 				ttl: &tenSecondsTTL,
 			},
 			configureMocks: func(t *testing.T,
@@ -1325,7 +1325,7 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					TrustedIssuers:    []string{issuer},
 					ScopesMatcher:     oauth2.ExactScopeStrategyMatcher{},
 				},
-				sf:              &Session{SubjectIDFrom: "sub"},
+				sf:              &SubjectInfo{IDFrom: "sub"},
 				ttl:             &tenSecondsTTL,
 				validateJWKCert: true,
 			},
@@ -1380,7 +1380,7 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					TrustedIssuers:    []string{issuer},
 					ScopesMatcher:     oauth2.ExactScopeStrategyMatcher{},
 				},
-				sf:              &Session{SubjectIDFrom: "sub"},
+				sf:              &SubjectInfo{IDFrom: "sub"},
 				ttl:             &tenSecondsTTL,
 				validateJWKCert: true,
 				trustStore:      truststore.TrustStore{keyAndCertEntry.CertChain[2]},
@@ -1449,7 +1449,7 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					TrustedIssuers:    []string{issuer},
 					ScopesMatcher:     oauth2.ExactScopeStrategyMatcher{},
 				},
-				sf:  &Session{SubjectIDFrom: "sub"},
+				sf:  &SubjectInfo{IDFrom: "sub"},
 				ttl: &tenSecondsTTL,
 			},
 			configureMocks: func(t *testing.T,
@@ -1517,7 +1517,7 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					TrustedIssuers:    []string{issuer},
 					ScopesMatcher:     oauth2.ExactScopeStrategyMatcher{},
 				},
-				sf:              &Session{SubjectIDFrom: "sub"},
+				sf:              &SubjectInfo{IDFrom: "sub"},
 				validateJWKCert: true,
 				trustStore:      truststore.TrustStore{keyAndCertEntry.CertChain[2]},
 			},

--- a/internal/pipeline/authenticators/jwt_authenticator_test.go
+++ b/internal/pipeline/authenticators/jwt_authenticator_test.go
@@ -91,7 +91,7 @@ assertions:
   issuers:
     - foobar
 subject:
-  id_from: some_template`),
+  id: some_template`),
 			assert: func(t *testing.T, err error, a *jwtAuthenticator) {
 				t.Helper()
 
@@ -109,7 +109,7 @@ assertions:
   audience:
     - foobar
 subject:
-  id_from: some_template`),
+  id: some_template`),
 			assert: func(t *testing.T, err error, a *jwtAuthenticator) {
 				t.Helper()
 
@@ -257,7 +257,7 @@ assertions:
   allowed_algorithms:
     - ES256
 subject:
-  id_from: some_claim
+  id: some_claim
 allow_fallback_on_error: true
 validate_jwk: false
 trust_store: ` + trustStorePath),

--- a/internal/pipeline/authenticators/jwt_authenticator_test.go
+++ b/internal/pipeline/authenticators/jwt_authenticator_test.go
@@ -91,7 +91,7 @@ assertions:
   issuers:
     - foobar
 session:
-  subject_id_from: some_template`),
+  id_from: some_template`),
 			assert: func(t *testing.T, err error, a *jwtAuthenticator) {
 				t.Helper()
 
@@ -109,7 +109,7 @@ assertions:
   audience:
     - foobar
 session:
-  subject_id_from: some_template`),
+  id_from: some_template`),
 			assert: func(t *testing.T, err error, a *jwtAuthenticator) {
 				t.Helper()
 
@@ -257,7 +257,7 @@ assertions:
   allowed_algorithms:
     - ES256
 session:
-  subject_id_from: some_claim
+  id_from: some_claim
 allow_fallback_on_error: true
 validate_jwk: false
 trust_store: ` + trustStorePath),

--- a/internal/pipeline/authenticators/oauth2_introspection_authenticator.go
+++ b/internal/pipeline/authenticators/oauth2_introspection_authenticator.go
@@ -53,7 +53,7 @@ func newOAuth2IntrospectionAuthenticator(rawConfig map[string]any) (*oauth2Intro
 		Endpoint             endpoint.Endpoint                   `mapstructure:"introspection_endpoint"`
 		AuthDataSource       extractors.CompositeExtractStrategy `mapstructure:"token_source"`
 		Assertions           oauth2.Expectation                  `mapstructure:"assertions"`
-		Session              Session                             `mapstructure:"session"`
+		Session              SubjectInfo                         `mapstructure:"session"`
 		CacheTTL             *time.Duration                      `mapstructure:"cache_ttl"`
 		AllowFallbackOnError bool                                `mapstructure:"allow_fallback_on_error"`
 	}
@@ -73,8 +73,8 @@ func newOAuth2IntrospectionAuthenticator(rawConfig map[string]any) (*oauth2Intro
 		return nil, errorchain.NewWithMessage(heimdall.ErrConfiguration, "no trusted issuers configured")
 	}
 
-	if len(conf.Session.SubjectIDFrom) == 0 {
-		conf.Session.SubjectIDFrom = "sub"
+	if len(conf.Session.IDFrom) == 0 {
+		conf.Session.IDFrom = "sub"
 	}
 
 	if conf.Endpoint.Headers == nil {

--- a/internal/pipeline/authenticators/oauth2_introspection_authenticator.go
+++ b/internal/pipeline/authenticators/oauth2_introspection_authenticator.go
@@ -53,7 +53,7 @@ func newOAuth2IntrospectionAuthenticator(rawConfig map[string]any) (*oauth2Intro
 		Endpoint             endpoint.Endpoint                   `mapstructure:"introspection_endpoint"`
 		AuthDataSource       extractors.CompositeExtractStrategy `mapstructure:"token_source"`
 		Assertions           oauth2.Expectation                  `mapstructure:"assertions"`
-		Session              SubjectInfo                         `mapstructure:"session"`
+		SubjectInfo          SubjectInfo                         `mapstructure:"subject"`
 		CacheTTL             *time.Duration                      `mapstructure:"cache_ttl"`
 		AllowFallbackOnError bool                                `mapstructure:"allow_fallback_on_error"`
 	}
@@ -73,8 +73,8 @@ func newOAuth2IntrospectionAuthenticator(rawConfig map[string]any) (*oauth2Intro
 		return nil, errorchain.NewWithMessage(heimdall.ErrConfiguration, "no trusted issuers configured")
 	}
 
-	if len(conf.Session.IDFrom) == 0 {
-		conf.Session.IDFrom = "sub"
+	if len(conf.SubjectInfo.IDFrom) == 0 {
+		conf.SubjectInfo.IDFrom = "sub"
 	}
 
 	if conf.Endpoint.Headers == nil {
@@ -116,7 +116,7 @@ func newOAuth2IntrospectionAuthenticator(rawConfig map[string]any) (*oauth2Intro
 		ads:                  ads,
 		e:                    conf.Endpoint,
 		a:                    conf.Assertions,
-		sf:                   &conf.Session,
+		sf:                   &conf.SubjectInfo,
 		ttl:                  conf.CacheTTL,
 		allowFallbackOnError: conf.AllowFallbackOnError,
 	}, nil

--- a/internal/pipeline/authenticators/oauth2_introspection_authenticator_test.go
+++ b/internal/pipeline/authenticators/oauth2_introspection_authenticator_test.go
@@ -41,7 +41,7 @@ assertions:
   issuers:
     - foobar
 session:
-  subject_id_from: some_template
+  id_from: some_template
 foo: bar
 `),
 			assert: func(t *testing.T, err error, _ *oauth2IntrospectionAuthenticator) {
@@ -59,7 +59,7 @@ assertions:
   issuers:
     - foobar
 session:
-  subject_id_from: some_template
+  id_from: some_template
 `),
 			assert: func(t *testing.T, err error, _ *oauth2IntrospectionAuthenticator) {
 				t.Helper()
@@ -75,7 +75,7 @@ session:
 introspection_endpoint:
   url: foobar.local
 session:
-  subject_id_from: some_template
+  id_from: some_template
 `),
 			assert: func(t *testing.T, err error, _ *oauth2IntrospectionAuthenticator) {
 				t.Helper()
@@ -114,7 +114,7 @@ assertions:
   issuers:
     - foobar
 session:
-  subject_id_from: some_template
+  id_from: some_template
 `),
 			assert: func(t *testing.T, err error, auth *oauth2IntrospectionAuthenticator) {
 				t.Helper()
@@ -180,7 +180,7 @@ assertions:
   allowed_algorithms:
     - ES256
 session:
-  subject_id_from: some_claim
+  id_from: some_claim
 cache_ttl: 5s
 allow_fallback_on_error: true
 `),
@@ -261,7 +261,7 @@ assertions:
   issuers:
     - foobar
 session:
-  subject_id_from: some_template`),
+  id_from: some_template`),
 			assert: func(t *testing.T, err error, prototype *oauth2IntrospectionAuthenticator,
 				configured *oauth2IntrospectionAuthenticator,
 			) {
@@ -281,7 +281,7 @@ assertions:
   issuers:
     - foobar
 session:
-  subject_id_from: some_template`),
+  id_from: some_template`),
 			config: []byte(`foo: bar`),
 			assert: func(t *testing.T, err error, _ *oauth2IntrospectionAuthenticator,
 				_ *oauth2IntrospectionAuthenticator,
@@ -304,7 +304,7 @@ assertions:
   audience:
     - baz
 session:
-  subject_id_from: some_template`),
+  id_from: some_template`),
 			config: []byte(`
 assertions:
   issuers:
@@ -343,7 +343,7 @@ assertions:
   issuers:
     - foobar
 session:
-  subject_id_from: some_template`),
+  id_from: some_template`),
 			config: []byte(`cache_ttl: 5s`),
 			assert: func(t *testing.T, err error, prototype *oauth2IntrospectionAuthenticator,
 				configured *oauth2IntrospectionAuthenticator,
@@ -371,7 +371,7 @@ assertions:
   issuers:
     - foobar
 session:
-  subject_id_from: some_template
+  id_from: some_template
 cache_ttl: 5s`),
 			config: []byte(`
 assertions:
@@ -406,7 +406,7 @@ assertions:
   issuers:
     - foobar
 session:
-  subject_id_from: some_template`),
+  id_from: some_template`),
 			config: []byte(`allow_fallback_on_error: true`),
 			assert: func(t *testing.T, err error, prototype *oauth2IntrospectionAuthenticator,
 				configured *oauth2IntrospectionAuthenticator,

--- a/internal/pipeline/authenticators/oauth2_introspection_authenticator_test.go
+++ b/internal/pipeline/authenticators/oauth2_introspection_authenticator_test.go
@@ -99,10 +99,10 @@ assertions:
 
 				require.NoError(t, err)
 
-				assert.IsType(t, &Session{}, auth.sf)
-				sess, ok := auth.sf.(*Session)
+				assert.IsType(t, &SubjectInfo{}, auth.sf)
+				sess, ok := auth.sf.(*SubjectInfo)
 				assert.True(t, ok)
-				assert.Equal(t, "sub", sess.SubjectIDFrom)
+				assert.Equal(t, "sub", sess.IDFrom)
 			},
 		},
 		{
@@ -775,7 +775,7 @@ func TestOauth2IntrospectionAuthenticatorExecute(t *testing.T) {
 					TrustedIssuers: []string{"foobar"},
 					ScopesMatcher:  oauth2.ExactScopeStrategyMatcher{},
 				},
-				sf:  &Session{SubjectIDFrom: "sub"},
+				sf:  &SubjectInfo{IDFrom: "sub"},
 				ttl: &zeroTTL,
 			},
 			configureMocks: func(t *testing.T,
@@ -858,7 +858,7 @@ func TestOauth2IntrospectionAuthenticatorExecute(t *testing.T) {
 					TrustedIssuers: []string{"foobar"},
 					ScopesMatcher:  oauth2.ExactScopeStrategyMatcher{},
 				},
-				sf: &Session{SubjectIDFrom: "sub"},
+				sf: &SubjectInfo{IDFrom: "sub"},
 			},
 			configureMocks: func(t *testing.T,
 				ctx *heimdallmocks.MockContext,
@@ -942,7 +942,7 @@ func TestOauth2IntrospectionAuthenticatorExecute(t *testing.T) {
 					TrustedIssuers: []string{"foobar"},
 					ScopesMatcher:  oauth2.ExactScopeStrategyMatcher{},
 				},
-				sf: &Session{SubjectIDFrom: "sub"},
+				sf: &SubjectInfo{IDFrom: "sub"},
 			},
 			configureMocks: func(t *testing.T,
 				ctx *heimdallmocks.MockContext,
@@ -1027,7 +1027,7 @@ func TestOauth2IntrospectionAuthenticatorExecute(t *testing.T) {
 					TrustedIssuers: []string{"foobar"},
 					ScopesMatcher:  oauth2.ExactScopeStrategyMatcher{},
 				},
-				sf: &Session{SubjectIDFrom: "sub"},
+				sf: &SubjectInfo{IDFrom: "sub"},
 			},
 			configureMocks: func(t *testing.T,
 				ctx *heimdallmocks.MockContext,

--- a/internal/pipeline/authenticators/oauth2_introspection_authenticator_test.go
+++ b/internal/pipeline/authenticators/oauth2_introspection_authenticator_test.go
@@ -41,7 +41,7 @@ assertions:
   issuers:
     - foobar
 subject:
-  id_from: some_template
+  id: some_template
 foo: bar
 `),
 			assert: func(t *testing.T, err error, _ *oauth2IntrospectionAuthenticator) {
@@ -59,7 +59,7 @@ assertions:
   issuers:
     - foobar
 subject:
-  id_from: some_template
+  id: some_template
 `),
 			assert: func(t *testing.T, err error, _ *oauth2IntrospectionAuthenticator) {
 				t.Helper()
@@ -75,7 +75,7 @@ subject:
 introspection_endpoint:
   url: foobar.local
 subject:
-  id_from: some_template
+  id: some_template
 `),
 			assert: func(t *testing.T, err error, _ *oauth2IntrospectionAuthenticator) {
 				t.Helper()
@@ -114,7 +114,7 @@ assertions:
   issuers:
     - foobar
 subject:
-  id_from: some_template
+  id: some_template
 `),
 			assert: func(t *testing.T, err error, auth *oauth2IntrospectionAuthenticator) {
 				t.Helper()
@@ -180,7 +180,7 @@ assertions:
   allowed_algorithms:
     - ES256
 subject:
-  id_from: some_claim
+  id: some_claim
 cache_ttl: 5s
 allow_fallback_on_error: true
 `),
@@ -261,7 +261,7 @@ assertions:
   issuers:
     - foobar
 subject:
-  id_from: some_template`),
+  id: some_template`),
 			assert: func(t *testing.T, err error, prototype *oauth2IntrospectionAuthenticator,
 				configured *oauth2IntrospectionAuthenticator,
 			) {
@@ -281,7 +281,7 @@ assertions:
   issuers:
     - foobar
 subject:
-  id_from: some_template`),
+  id: some_template`),
 			config: []byte(`foo: bar`),
 			assert: func(t *testing.T, err error, _ *oauth2IntrospectionAuthenticator,
 				_ *oauth2IntrospectionAuthenticator,
@@ -304,7 +304,7 @@ assertions:
   audience:
     - baz
 subject:
-  id_from: some_template`),
+  id: some_template`),
 			config: []byte(`
 assertions:
   issuers:
@@ -343,7 +343,7 @@ assertions:
   issuers:
     - foobar
 subject:
-  id_from: some_template`),
+  id: some_template`),
 			config: []byte(`cache_ttl: 5s`),
 			assert: func(t *testing.T, err error, prototype *oauth2IntrospectionAuthenticator,
 				configured *oauth2IntrospectionAuthenticator,
@@ -371,7 +371,7 @@ assertions:
   issuers:
     - foobar
 subject:
-  id_from: some_template
+  id: some_template
 cache_ttl: 5s`),
 			config: []byte(`
 assertions:
@@ -406,7 +406,7 @@ assertions:
   issuers:
     - foobar
 subject:
-  id_from: some_template`),
+  id: some_template`),
 			config: []byte(`allow_fallback_on_error: true`),
 			assert: func(t *testing.T, err error, prototype *oauth2IntrospectionAuthenticator,
 				configured *oauth2IntrospectionAuthenticator,

--- a/internal/pipeline/authenticators/oauth2_introspection_authenticator_test.go
+++ b/internal/pipeline/authenticators/oauth2_introspection_authenticator_test.go
@@ -40,7 +40,7 @@ func TestCreateOAuth2IntrospectionAuthenticator(t *testing.T) {
 assertions:
   issuers:
     - foobar
-session:
+subject:
   id_from: some_template
 foo: bar
 `),
@@ -58,7 +58,7 @@ foo: bar
 assertions:
   issuers:
     - foobar
-session:
+subject:
   id_from: some_template
 `),
 			assert: func(t *testing.T, err error, _ *oauth2IntrospectionAuthenticator) {
@@ -74,7 +74,7 @@ session:
 			config: []byte(`
 introspection_endpoint:
   url: foobar.local
-session:
+subject:
   id_from: some_template
 `),
 			assert: func(t *testing.T, err error, _ *oauth2IntrospectionAuthenticator) {
@@ -86,7 +86,7 @@ session:
 			},
 		},
 		{
-			uc: "with missing session config",
+			uc: "with missing subject config",
 			config: []byte(`
 introspection_endpoint:
   url: foobar.local
@@ -113,7 +113,7 @@ introspection_endpoint:
 assertions:
   issuers:
     - foobar
-session:
+subject:
   id_from: some_template
 `),
 			assert: func(t *testing.T, err error, auth *oauth2IntrospectionAuthenticator) {
@@ -179,7 +179,7 @@ assertions:
     - foobar
   allowed_algorithms:
     - ES256
-session:
+subject:
   id_from: some_claim
 cache_ttl: 5s
 allow_fallback_on_error: true
@@ -260,7 +260,7 @@ introspection_endpoint:
 assertions:
   issuers:
     - foobar
-session:
+subject:
   id_from: some_template`),
 			assert: func(t *testing.T, err error, prototype *oauth2IntrospectionAuthenticator,
 				configured *oauth2IntrospectionAuthenticator,
@@ -280,7 +280,7 @@ introspection_endpoint:
 assertions:
   issuers:
     - foobar
-session:
+subject:
   id_from: some_template`),
 			config: []byte(`foo: bar`),
 			assert: func(t *testing.T, err error, _ *oauth2IntrospectionAuthenticator,
@@ -303,7 +303,7 @@ assertions:
     - foobar
   audience:
     - baz
-session:
+subject:
   id_from: some_template`),
 			config: []byte(`
 assertions:
@@ -342,7 +342,7 @@ introspection_endpoint:
 assertions:
   issuers:
     - foobar
-session:
+subject:
   id_from: some_template`),
 			config: []byte(`cache_ttl: 5s`),
 			assert: func(t *testing.T, err error, prototype *oauth2IntrospectionAuthenticator,
@@ -370,7 +370,7 @@ introspection_endpoint:
 assertions:
   issuers:
     - foobar
-session:
+subject:
   id_from: some_template
 cache_ttl: 5s`),
 			config: []byte(`
@@ -405,7 +405,7 @@ introspection_endpoint:
 assertions:
   issuers:
     - foobar
-session:
+subject:
   id_from: some_template`),
 			config: []byte(`allow_fallback_on_error: true`),
 			assert: func(t *testing.T, err error, prototype *oauth2IntrospectionAuthenticator,

--- a/internal/pipeline/authenticators/subject_info.go
+++ b/internal/pipeline/authenticators/subject_info.go
@@ -9,13 +9,13 @@ import (
 )
 
 type SubjectInfo struct {
-	IDFrom         string `mapstructure:"id_from"`
-	AttributesFrom string `mapstructure:"attributes_from"`
+	IDFrom         string `mapstructure:"id"`
+	AttributesFrom string `mapstructure:"attributes"`
 }
 
 func (s *SubjectInfo) Validate() error {
 	if len(s.IDFrom) == 0 {
-		return errorchain.NewWithMessage(heimdall.ErrConfiguration, "no subject_from set")
+		return errorchain.NewWithMessage(heimdall.ErrConfiguration, "no subject.id set")
 	}
 
 	return nil

--- a/internal/pipeline/authenticators/subject_info.go
+++ b/internal/pipeline/authenticators/subject_info.go
@@ -8,29 +8,29 @@ import (
 	"github.com/dadrus/heimdall/internal/x/errorchain"
 )
 
-type Session struct {
-	SubjectIDFrom         string `mapstructure:"subject_id_from"`
-	SubjectAttributesFrom string `mapstructure:"subject_attributes_from"`
+type SubjectInfo struct {
+	IDFrom         string `mapstructure:"subject_id_from"`
+	AttributesFrom string `mapstructure:"subject_attributes_from"`
 }
 
-func (s *Session) Validate() error {
-	if len(s.SubjectIDFrom) == 0 {
+func (s *SubjectInfo) Validate() error {
+	if len(s.IDFrom) == 0 {
 		return errorchain.NewWithMessage(heimdall.ErrConfiguration, "no subject_from set")
 	}
 
 	return nil
 }
 
-func (s *Session) CreateSubject(rawData []byte) (*subject.Subject, error) {
+func (s *SubjectInfo) CreateSubject(rawData []byte) (*subject.Subject, error) {
 	attributesFrom := "@this"
-	if len(s.SubjectAttributesFrom) != 0 {
-		attributesFrom = s.SubjectAttributesFrom
+	if len(s.AttributesFrom) != 0 {
+		attributesFrom = s.AttributesFrom
 	}
 
-	subjectID := gjson.GetBytes(rawData, s.SubjectIDFrom).String()
+	subjectID := gjson.GetBytes(rawData, s.IDFrom).String()
 	if len(subjectID) == 0 {
 		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
-			"could not extract subject identifier using '%s' template", s.SubjectIDFrom)
+			"could not extract subject identifier using '%s' template", s.IDFrom)
 	}
 
 	attributes := gjson.GetBytes(rawData, attributesFrom).Value()

--- a/internal/pipeline/authenticators/subject_info.go
+++ b/internal/pipeline/authenticators/subject_info.go
@@ -9,8 +9,8 @@ import (
 )
 
 type SubjectInfo struct {
-	IDFrom         string `mapstructure:"subject_id_from"`
-	AttributesFrom string `mapstructure:"subject_attributes_from"`
+	IDFrom         string `mapstructure:"id_from"`
+	AttributesFrom string `mapstructure:"attributes_from"`
 }
 
 func (s *SubjectInfo) Validate() error {

--- a/internal/pipeline/authenticators/subject_info_test.go
+++ b/internal/pipeline/authenticators/subject_info_test.go
@@ -17,7 +17,7 @@ func TestSubjectInfoValidate(t *testing.T) {
 		assert    func(t *testing.T, err error)
 	}{
 		{
-			uc: "subject_from is set",
+			uc: "subject.id is set",
 			configure: func(t *testing.T, s *SubjectInfo) {
 				t.Helper()
 
@@ -29,7 +29,7 @@ func TestSubjectInfoValidate(t *testing.T) {
 			},
 		},
 		{
-			uc:        "subject_from is not set",
+			uc:        "subject.id is not set",
 			configure: func(t *testing.T, s *SubjectInfo) { t.Helper() },
 			assert: func(t *testing.T, err error) {
 				t.Helper()

--- a/internal/pipeline/authenticators/subject_info_test.go
+++ b/internal/pipeline/authenticators/subject_info_test.go
@@ -13,15 +13,15 @@ import (
 func TestSessionValidation(t *testing.T) {
 	for _, tc := range []struct {
 		uc        string
-		configure func(t *testing.T, s *Session)
+		configure func(t *testing.T, s *SubjectInfo)
 		assert    func(t *testing.T, err error)
 	}{
 		{
 			uc: "subject_from is set",
-			configure: func(t *testing.T, s *Session) {
+			configure: func(t *testing.T, s *SubjectInfo) {
 				t.Helper()
 
-				s.SubjectIDFrom = "foobar"
+				s.IDFrom = "foobar"
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -30,7 +30,7 @@ func TestSessionValidation(t *testing.T) {
 		},
 		{
 			uc:        "subject_from is not set",
-			configure: func(t *testing.T, s *Session) { t.Helper() },
+			configure: func(t *testing.T, s *SubjectInfo) { t.Helper() },
 			assert: func(t *testing.T, err error) {
 				t.Helper()
 				assert.Error(t, err)
@@ -39,7 +39,7 @@ func TestSessionValidation(t *testing.T) {
 	} {
 		t.Run("case="+tc.uc, func(t *testing.T) {
 			// GIVEN
-			s := Session{}
+			s := SubjectInfo{}
 			tc.configure(t, &s)
 
 			// WHEN
@@ -85,15 +85,15 @@ func TestGetSubjectFromSession(t *testing.T) {
 
 	for _, tc := range []struct {
 		uc        string
-		configure func(t *testing.T, s *Session)
+		configure func(t *testing.T, s *SubjectInfo)
 		assert    func(t *testing.T, err error, sub *subject.Subject)
 	}{
 		{
 			uc: "subject is extracted and attributes are the whole object",
-			configure: func(t *testing.T, s *Session) {
+			configure: func(t *testing.T, s *SubjectInfo) {
 				t.Helper()
 
-				s.SubjectIDFrom = "subject"
+				s.IDFrom = "subject"
 			},
 			assert: func(t *testing.T, err error, sub *subject.Subject) {
 				t.Helper()
@@ -108,11 +108,11 @@ func TestGetSubjectFromSession(t *testing.T) {
 		},
 		{
 			uc: "subject is extracted and attributes are the nested object",
-			configure: func(t *testing.T, s *Session) {
+			configure: func(t *testing.T, s *SubjectInfo) {
 				t.Helper()
 
-				s.SubjectIDFrom = "string_slice.1"
-				s.SubjectAttributesFrom = "complex.nested"
+				s.IDFrom = "string_slice.1"
+				s.AttributesFrom = "complex.nested"
 			},
 			assert: func(t *testing.T, err error, sub *subject.Subject) {
 				t.Helper()
@@ -130,11 +130,11 @@ func TestGetSubjectFromSession(t *testing.T) {
 		},
 		{
 			uc: "attributes could no be extracted",
-			configure: func(t *testing.T, s *Session) {
+			configure: func(t *testing.T, s *SubjectInfo) {
 				t.Helper()
 
-				s.SubjectIDFrom = "subject"
-				s.SubjectAttributesFrom = "foobar"
+				s.IDFrom = "subject"
+				s.AttributesFrom = "foobar"
 			},
 			assert: func(t *testing.T, err error, _ *subject.Subject) {
 				t.Helper()
@@ -144,10 +144,10 @@ func TestGetSubjectFromSession(t *testing.T) {
 		},
 		{
 			uc: "subject could not be extracted",
-			configure: func(t *testing.T, s *Session) {
+			configure: func(t *testing.T, s *SubjectInfo) {
 				t.Helper()
 
-				s.SubjectIDFrom = "foo"
+				s.IDFrom = "foo"
 			},
 			assert: func(t *testing.T, err error, sub *subject.Subject) {
 				t.Helper()
@@ -158,7 +158,7 @@ func TestGetSubjectFromSession(t *testing.T) {
 	} {
 		t.Run("case="+tc.uc, func(t *testing.T) {
 			// GIVEN
-			s := Session{}
+			s := SubjectInfo{}
 			tc.configure(t, &s)
 
 			// WHEN

--- a/internal/pipeline/authenticators/subject_info_test.go
+++ b/internal/pipeline/authenticators/subject_info_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/dadrus/heimdall/internal/pipeline/subject"
 )
 
-func TestSessionValidation(t *testing.T) {
+func TestSubjectInfoValidate(t *testing.T) {
 	for _, tc := range []struct {
 		uc        string
 		configure func(t *testing.T, s *SubjectInfo)
@@ -51,7 +51,7 @@ func TestSessionValidation(t *testing.T) {
 	}
 }
 
-func TestGetSubjectFromSession(t *testing.T) {
+func TestSubjectInfoCreateSubject(t *testing.T) {
 	type Nested struct {
 		Val bool `json:"val"`
 	}

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -229,18 +229,18 @@
         }
       }
     },
-    "sessionConfiguration": {
-      "description": "Session information about the subject to maintain",
+    "subjectConfiguration": {
+      "description": "Configuration of where to get subject information/attributes from",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "attributes_from": {
-          "description": "The `attributes` field in the Heimdall authentication session is set using this JSON Path. Defaults to `@this` (for the root element), `foo.bar` (for key foo.bar), or any other valid GJSON path. See [GSJON Syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) for reference.",
+          "description": "The `attributes` field in the Heimdall's subject object is set using this JSON Path. Defaults to `@this` (for the root element), `foo.bar` (for key foo.bar), or any other valid GJSON path. See [GSJON Syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) for reference.",
           "type": "string",
           "default": "@this"
         },
         "id_from": {
-          "description": "The `id` field in the Heimdall authentication session is set using this JSON Path. See [GSJON Syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) for reference.",
+          "description": "The `id` field in the Heimdall's subject object is set using this JSON Path. See [GSJON Syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) for reference.",
           "type": "string"
         }
       }
@@ -645,8 +645,8 @@
             "authentication_data_source": {
               "$ref": "#/definitions/authenticationDataSource"
             },
-            "session": {
-              "$ref": "#/definitions/sessionConfiguration"
+            "subject": {
+              "$ref": "#/definitions/subjectConfiguration"
             },
             "cache_ttl": {
               "type": "string",
@@ -697,8 +697,8 @@
             "assertions": {
               "$ref": "#/definitions/assertionRequirements"
             },
-            "session": {
-              "$ref": "#/definitions/sessionConfiguration"
+            "subject": {
+              "$ref": "#/definitions/subjectConfiguration"
             },
             "cache_ttl": {
               "type": "string",
@@ -749,8 +749,8 @@
             "assertions": {
               "$ref": "#/definitions/assertionRequirements"
             },
-            "session": {
-              "$ref": "#/definitions/sessionConfiguration"
+            "subject": {
+              "$ref": "#/definitions/subjectConfiguration"
             },
             "cache_ttl": {
               "type": "string",
@@ -994,7 +994,7 @@
       }
     },
     "mutatorJwt": {
-      "description": "Creates a JWT Token from the given session information",
+      "description": "Creates a JWT Token from the given subject information",
       "type": "object",
       "additionalProperties": false,
       "required": [

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -234,12 +234,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "subject_attributes_from": {
+        "attributes_from": {
           "description": "The `attributes` field in the Heimdall authentication session is set using this JSON Path. Defaults to `@this` (for the root element), `foo.bar` (for key foo.bar), or any other valid GJSON path. See [GSJON Syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) for reference.",
           "type": "string",
           "default": "@this"
         },
-        "subject_id_from": {
+        "id_from": {
           "description": "The `id` field in the Heimdall authentication session is set using this JSON Path. See [GSJON Syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) for reference.",
           "type": "string"
         }

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -234,12 +234,12 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "attributes_from": {
+        "attributes": {
           "description": "The `attributes` field in the Heimdall's subject object is set using this JSON Path. Defaults to `@this` (for the root element), `foo.bar` (for key foo.bar), or any other valid GJSON path. See [GSJON Syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) for reference.",
           "type": "string",
           "default": "@this"
         },
-        "id_from": {
+        "id": {
           "description": "The `id` field in the Heimdall's subject object is set using this JSON Path. See [GSJON Syntax](https://github.com/tidwall/gjson/blob/master/SYNTAX.md) for reference.",
           "type": "string"
         }

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -38,7 +38,7 @@ pipeline:
             give_up_after: 2s
         authentication_data_source:
           - cookie: ory_kratos_session
-        session:
+        subject:
           attributes_from: "@this"
           id_from: "identity.id"
     - id: hydra_authenticator
@@ -62,7 +62,7 @@ pipeline:
             - bar
           audience:
             - bla
-        session:
+        subject:
           attributes_from: "@this"
           id_from: sub
     - id: jwt_authenticator
@@ -83,7 +83,7 @@ pipeline:
             - RSA
           issuers:
             - bla
-        session:
+        subject:
           attributes_from: "@this"
           id_from: "identity.id"
         cache_ttl: 5m

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -39,8 +39,8 @@ pipeline:
         authentication_data_source:
           - cookie: ory_kratos_session
         session:
-          subject_attributes_from: "@this"
-          subject_id_from: "identity.id"
+          attributes_from: "@this"
+          id_from: "identity.id"
     - id: hydra_authenticator
       type: oauth2_introspection
       config:
@@ -63,8 +63,8 @@ pipeline:
           audience:
             - bla
         session:
-          subject_attributes_from: "@this"
-          subject_id_from: sub
+          attributes_from: "@this"
+          id_from: sub
     - id: jwt_authenticator
       type: jwt
       config:
@@ -84,8 +84,8 @@ pipeline:
           issuers:
             - bla
         session:
-          subject_attributes_from: "@this"
-          subject_id_from: "identity.id"
+          attributes_from: "@this"
+          id_from: "identity.id"
         cache_ttl: 5m
   authorizers:
     - id: allow_all_authorizer

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -39,8 +39,8 @@ pipeline:
         authentication_data_source:
           - cookie: ory_kratos_session
         subject:
-          attributes_from: "@this"
-          id_from: "identity.id"
+          attributes: "@this"
+          id: "identity.id"
     - id: hydra_authenticator
       type: oauth2_introspection
       config:
@@ -63,8 +63,8 @@ pipeline:
           audience:
             - bla
         subject:
-          attributes_from: "@this"
-          id_from: sub
+          attributes: "@this"
+          id: sub
     - id: jwt_authenticator
       type: jwt
       config:
@@ -84,8 +84,8 @@ pipeline:
           issuers:
             - bla
         subject:
-          attributes_from: "@this"
-          id_from: "identity.id"
+          attributes: "@this"
+          id: "identity.id"
         cache_ttl: 5m
   authorizers:
     - id: allow_all_authorizer


### PR DESCRIPTION
Affected authenticators are `generic`, `oauth2` and `jwt` authenticator.

Renamed and refactored property is `session` which had the following structure:

```yaml
session:
  subject_id_from: <some template>
  subject_attributes_from: <some template>
```

This PR changes it to

```yaml
subject:
  id: <some template>
  attributes: <some template>
```