### PR TITLE
fix!:Prefix for considered environment variables renamed from `HEIMDALL_` to `HEIMDALLCFG_` and made this prefix configurable via a `--env-config-prefix` flag

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -17,9 +17,10 @@ func init() {
 	RootCmd.AddCommand(serveCmd)
 
 	serveCmd.PersistentFlags().StringP("config", "c", "",
-		"Path to heimdall's configuration file")
+		"Path to heimdall's configuration file.\n"+
+			"If not provided, the lookup sequence is:\n  1. $PWD\n  2. $HOME/.config\n  3. /etc/heimdall/")
 	serveCmd.PersistentFlags().String("env-config-prefix", "HEIMDALLCFG_",
-		"Prefix for the environment variables to consider for loading configuration from")
+		"Prefix for the environment variables to consider for\nloading configuration from")
 	serveCmd.AddCommand(serve.NewProxyCommand())
 	serveCmd.AddCommand(serve.NewDecisionCommand())
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -16,7 +16,10 @@ var serveCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(serveCmd)
 
-	serveCmd.PersistentFlags().StringP("config", "c", "", "Config file")
+	serveCmd.PersistentFlags().StringP("config", "c", "",
+		"Path to heimdall's configuration file")
+	serveCmd.PersistentFlags().String("env-config-prefix", "HEIMDALLCFG_",
+		"Prefix for the environment variables to consider for loading configuration from")
 	serveCmd.AddCommand(serve.NewProxyCommand())
 	serveCmd.AddCommand(serve.NewDecisionCommand())
 }

--- a/cmd/serve/decision.go
+++ b/cmd/serve/decision.go
@@ -1,11 +1,11 @@
 package serve
 
 import (
-	"github.com/dadrus/heimdall/internal/config"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
 	"github.com/dadrus/heimdall/internal"
+	"github.com/dadrus/heimdall/internal/config"
 	"github.com/dadrus/heimdall/internal/handler/decision"
 )
 
@@ -22,8 +22,8 @@ func NewDecisionCommand() *cobra.Command {
 			app := fx.New(
 				fx.NopLogger,
 				fx.Supply(
-					config.ConfigPath(configPath),
-					config.EnvPrefix(envPrefix)),
+					config.ConfigurationPath(configPath),
+					config.EnvVarPrefix(envPrefix)),
 				internal.Module,
 				decision.Module,
 			)

--- a/cmd/serve/decision.go
+++ b/cmd/serve/decision.go
@@ -1,6 +1,7 @@
 package serve
 
 import (
+	"github.com/dadrus/heimdall/internal/config"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
@@ -16,10 +17,13 @@ func NewDecisionCommand() *cobra.Command {
 		Example: "heimdall serve decision",
 		Run: func(cmd *cobra.Command, args []string) {
 			configPath, _ := cmd.Flags().GetString("config")
+			envPrefix, _ := cmd.Flags().GetString("env-config-prefix")
 
 			app := fx.New(
 				fx.NopLogger,
-				fx.Supply(configPath),
+				fx.Supply(
+					config.ConfigPath(configPath),
+					config.EnvPrefix(envPrefix)),
 				internal.Module,
 				decision.Module,
 			)

--- a/cmd/serve/proxy.go
+++ b/cmd/serve/proxy.go
@@ -1,6 +1,7 @@
 package serve
 
 import (
+	"github.com/dadrus/heimdall/internal/config"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
@@ -16,10 +17,13 @@ func NewProxyCommand() *cobra.Command {
 		Example: "heimdall serve proxy",
 		Run: func(cmd *cobra.Command, args []string) {
 			configPath, _ := cmd.Flags().GetString("config")
+			envPrefix, _ := cmd.Flags().GetString("env-config-prefix")
 
 			app := fx.New(
 				fx.NopLogger,
-				fx.Supply(configPath),
+				fx.Supply(
+					config.ConfigPath(configPath),
+					config.EnvPrefix(envPrefix)),
 				internal.Module,
 				proxy.Module,
 			)

--- a/cmd/serve/proxy.go
+++ b/cmd/serve/proxy.go
@@ -1,11 +1,11 @@
 package serve
 
 import (
-	"github.com/dadrus/heimdall/internal/config"
 	"github.com/spf13/cobra"
 	"go.uber.org/fx"
 
 	"github.com/dadrus/heimdall/internal"
+	"github.com/dadrus/heimdall/internal/config"
 	"github.com/dadrus/heimdall/internal/handler/proxy"
 )
 
@@ -22,8 +22,8 @@ func NewProxyCommand() *cobra.Command {
 			app := fx.New(
 				fx.NopLogger,
 				fx.Supply(
-					config.ConfigPath(configPath),
-					config.EnvPrefix(envPrefix)),
+					config.ConfigurationPath(configPath),
+					config.EnvVarPrefix(envPrefix)),
 				internal.Module,
 				proxy.Module,
 			)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -19,6 +19,7 @@ var validateCmd = &cobra.Command{
 func init() {
 	RootCmd.AddCommand(validateCmd)
 
-	validateCmd.PersistentFlags().StringP("config", "c", "", "Config file")
+	validateCmd.PersistentFlags().StringP("config", "c", "",
+		"Path to heimdall's configuration file")
 	validateCmd.AddCommand(validate.NewValidateConfigCommand())
 }

--- a/docs/content/docs/getting_started/configuration_introduction.adoc
+++ b/docs/content/docs/getting_started/configuration_introduction.adoc
@@ -78,7 +78,9 @@ rules:
 
 Every configuration property, which can be defined in a link:{{< relref "#_configuration_file" >}}[configuration file] can also be defined as environment variable. Following rules apply:
 
-* All variables start with `HEIMDALL_` prefix.
+* If not specified while starting heimdall, all variables start with `HEIMDALLCFG_` prefix.
++
+NOTE: If for whatever reason, your environment configuration contains variables starting with `HEIMDALLCFG_`, which do not define heimdall specific configuration, heimdall will refuse starting if such configuration variable clashes (has an unexpected type) with heimdall's configuration properties (even for environment variables, the configuration is type safe). You can overcome such situation, by ether renaming such variables, or, if this is not possible, make use of the `--env-config-prefix` flag with heimdall's `serve` command.
 
 * Properties in a hierarchy are separated by `_`
 +
@@ -94,7 +96,7 @@ and using an environment variable with
 +
 [source, bash]
 ----
-HEIMDALL_LOG_LEVEL=info
+HEIMDALLCFG_LOG_LEVEL=info
 ----
 
 
@@ -115,8 +117,8 @@ and using environment variables with
 +
 [source, bash]
 ----
-HEIMDALL_RULES_DEFAULT_METHODS_0=GET
-HEIMDALL_RULES_DEFAULT_METHODS_1=POST
+HEIMDALLCFG_RULES_DEFAULT_METHODS_0=GET
+HEIMDALLCFG_RULES_DEFAULT_METHODS_1=POST
 ----
 +
 For structured configuration, like the definition of the authenticators in the example above
@@ -133,8 +135,8 @@ The corresponding environment variables would be
 +
 [source, bash]
 ----
-HEIMDALL_PIPELINE_AUTHENTICATORS_0_ID=anonymous_authenticator
-HEIMDALL_PIPELINE_AUTHENTICATORS_0_TYPE=anonymous
+HEIMDALLCFG_PIPELINE_AUTHENTICATORS_0_ID=anonymous_authenticator
+HEIMDALLCFG_PIPELINE_AUTHENTICATORS_0_TYPE=anonymous
 ----
 
 * If a name of a property has `\_` it must be escaped with an additional `_`.
@@ -151,6 +153,6 @@ and using the environment variables with
 +
 [source, bash]
 ----
-HEIMDALL_TRACING_SERVICE__NAME=foobar
+HEIMDALLCFG_TRACING_SERVICE__NAME=foobar
 ----
 

--- a/docs/content/docs/getting_started/configuration_introduction.adoc
+++ b/docs/content/docs/getting_started/configuration_introduction.adoc
@@ -80,7 +80,7 @@ Every configuration property, which can be defined in a link:{{< relref "#_confi
 
 * If not specified while starting heimdall, all variables start with `HEIMDALLCFG_` prefix.
 +
-NOTE: If for whatever reason, your environment configuration contains variables starting with `HEIMDALLCFG_`, which do not define heimdall specific configuration, heimdall will refuse starting if such configuration variable clashes (has an unexpected type) with heimdall's configuration properties (even for environment variables, the configuration is type safe). You can overcome such situation, by ether renaming such variables, or, if this is not possible, make use of the `--env-config-prefix` flag with heimdall's `serve` command.
+CAUTION: If for whatever reason, your environment configuration contains variables starting with `HEIMDALLCFG_`, which do not define heimdall specific configuration, heimdall will refuse starting if such configuration variable clashes (has an unexpected type) with heimdall's configuration properties (even for environment variables, the configuration is type safe). You can overcome such situation, by ether renaming such variables, or, if this is not possible, make use of the `--env-config-prefix` flag with heimdall's `serve` command.
 
 * Properties in a hierarchy are separated by `_`
 +

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/dadrus/heimdall/internal/config/parser"
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/dadrus/heimdall/internal/config/parser"
 )
 
 type Configuration struct {
@@ -19,7 +20,7 @@ type Configuration struct {
 	Rules    RulesConfig    `koanf:"rules,omitempty"`
 }
 
-func NewConfiguration(envPrefix EnvPrefix, configFile ConfigPath) (Configuration, error) {
+func NewConfiguration(envPrefix EnvVarPrefix, configFile ConfigurationPath) (Configuration, error) {
 	// copy defaults
 	result := defaultConfig
 

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mitchellh/mapstructure"
-
 	"github.com/dadrus/heimdall/internal/config/parser"
+	"github.com/mitchellh/mapstructure"
 )
 
 type Configuration struct {
@@ -20,7 +19,7 @@ type Configuration struct {
 	Rules    RulesConfig    `koanf:"rules,omitempty"`
 }
 
-func NewConfiguration(configFile string) (Configuration, error) {
+func NewConfiguration(envPrefix EnvPrefix, configFile ConfigPath) (Configuration, error) {
 	// copy defaults
 	result := defaultConfig
 
@@ -29,9 +28,9 @@ func NewConfiguration(configFile string) (Configuration, error) {
 		parser.WithDecodeHookFunc(mapstructure.StringToSliceHookFunc(",")),
 		parser.WithDecodeHookFunc(logLevelDecodeHookFunc),
 		parser.WithDecodeHookFunc(logFormatDecodeHookFunc),
-		parser.WithEnvPrefix("HEIMDALL_"),
+		parser.WithEnvPrefix(string(envPrefix)),
 		parser.WithDefaultConfigFilename("heimdall.yaml"),
-		parser.WithConfigFile(configFile),
+		parser.WithConfigFile(string(configFile)),
 		parser.WithConfigValidator(ValidateConfig),
 	}
 

--- a/internal/config/configuration_test.go
+++ b/internal/config/configuration_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestNewConfigurationFromStructWithDefaultsOnly(t *testing.T) {
 	// WHEN
-	config, err := NewConfiguration("")
+	config, err := NewConfiguration("HEIMDALLCFG_", "")
 
 	// THEN
 	require.NoError(t, err)
@@ -18,7 +18,7 @@ func TestNewConfigurationFromStructWithDefaultsOnly(t *testing.T) {
 
 func TestNewConfigurationWithConfigFile(t *testing.T) {
 	// WHEN
-	config, err := NewConfiguration("./test_data/test_config.yaml")
+	config, err := NewConfiguration("HEIMDALLCFG_", "./test_data/test_config.yaml")
 
 	// THEN
 	require.NoError(t, err)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,5 +1,6 @@
 package config
 
-type ConfigPath string
-
-type EnvPrefix string
+type (
+	ConfigurationPath string
+	EnvVarPrefix      string
+)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1,0 +1,5 @@
+package config
+
+type ConfigPath string
+
+type EnvPrefix string


### PR DESCRIPTION
closes #219 