### PR TITLE
feat: Support for log, trace and request correlation

### DIFF
--- a/docs/content/docs/operations/observability.adoc
+++ b/docs/content/docs/operations/observability.adoc
@@ -14,17 +14,17 @@ Hemdall implements different observability to support easier operation and integ
 
 == Logging in Heimdall
 
-Heimdall's implementation uses https://github.com/rs/zerolog[zerolog] - Zero Allocation JSON Logger, which can however also log in plain text.
+Heimdall's implementation uses https://github.com/rs/zerolog[zerolog] - Zero Allocation JSON Logger, which can however also log in plain text. All emitted log statements include information related to distributed tracing (if tracing is enabled) so that not only log statements can be correlated to traces, but also all log statements belonging to single request/transaction can be correlated as well.
 
 Available Logging configuration options are described in link:{{< relref "/docs/configuration/observability/logging.adoc" >}}[Logging Configuration].
 
 === Regular Log Events
 
-If you configure Heimdall to log in `text` format, you can expect output as shown below:
+If you configure Heimdall to log in `text` format, you can expect output similar to the one shown below:
 
 [source, log]
 ----
-2022-08-03T12:51:48+02:00 INF Opentracing tracer initialized.
+2022-08-03T12:51:48+02:00 INF Opentelemetry tracing initialized.
 2022-08-03T12:51:48+02:00 INF Instantiating in memory cache
 2022-08-03T12:51:48+02:00 DBG Creating rule set event queue.
 2022-08-03T12:51:48+02:00 INF Loading pipeline definitions
@@ -39,6 +39,8 @@ If you configure Heimdall to log in `text` format, you can expect output as show
 2022-08-03T12:51:52+02:00 DBG Generating new JWT
 2022-08-03T12:51:52+02:00 DBG Finalizing request
 ----
+
+WARNING: Usage of this format is not recommended for production deployments as it requires more computational resources and is hence slow.
 
 Otherwise, if you configure it to use `gelf` (see https://docs.graylog.org/v1/docs/gelf[GELF] for format details) format, the output will look as follows:
 
@@ -64,18 +66,30 @@ Otherwise, if you configure it to use `gelf` (see https://docs.graylog.org/v1/do
 ...
 
 {"_level_name": "DEBUG", "version": "1.1", "host": "unknown", "timestamp": 1659523295,
- "level": 7, "short_message": "Decision endpoint called"}
+ "level": 7, "_parent_id": "3449bda63ed70206", "_span_id": "f57c007257fee0ed",
+ "_trace_id": "00000000000000000a5af97bffe6a8a2", "short_message": "Decision endpoint called"}
 {"_level_name": "DEBUG", "version": "1.1", "host": "unknown", "timestamp":1659523295,
- "level": 7, "short_message": "Executing default rule"}
+ "level": 7, "_parent_id": "3449bda63ed70206", "_span_id": "f57c007257fee0ed",
+ "_trace_id": "00000000000000000a5af97bffe6a8a2", "short_message": "Executing default rule"}
 {"_level_name": "DEBUG", "version":"1.1", "host": "unknown", "timestamp":1659523295,
- "level": 7, "short_message": "Authenticating using anonymous authenticator"}
+ "level": 7, "_parent_id": "3449bda63ed70206", "_span_id": "f57c007257fee0ed",
+ "_trace_id": "00000000000000000a5af97bffe6a8a2", "short_message": "Authenticating using anonymous authenticator"}
 {"_level_name": "DEBUG", "version": "1.1", "host": "unknown", "timestamp": 1659523295,
- "level": 7, "short_message": "Mutating using JWT mutator"}
+ "level": 7, "_parent_id": "3449bda63ed70206", "_span_id": "f57c007257fee0ed",
+ "_trace_id": "00000000000000000a5af97bffe6a8a2", "short_message": "Mutating using JWT mutator"}
 {"_level_name": "DEBUG", "version": "1.1", "host": "unknown", "timestamp": 1659523295,
- "level": 7, "short_message": "Generating new JWT"}
+ "level": 7, "_parent_id": "3449bda63ed70206", "_span_id": "f57c007257fee0ed",
+ "_trace_id": "00000000000000000a5af97bffe6a8a2", "short_message": "Generating new JWT"}
 {"_level_name": "DEBUG", "version": "1.1", "host": "unknown", "timestamp": 1659523295,
- "level": 7, "short_message": "Finalizing request"}
+ "level": 7, "_parent_id": "3449bda63ed70206", "_span_id": "f57c007257fee0ed",
+ "_trace_id": "00000000000000000a5af97bffe6a8a2", "short_message": "Finalizing request"}
 ----
+
+Each log statement does also include the following fields in both log formats for incoming requests if tracing is enabled:
+
+* `_trace_id` - The trace id as defined by OpenTelemetry.
+* `_span_id` - The span id as defined by OpenTelemetry of the current transaction.
+* `_parent_id` - The span id of the callee, which started the given transaction. Only present if the callee set the corresponding tracing header.
 
 === Access Log Events
 
@@ -114,18 +128,26 @@ Following are the fields, which are set in the transaction finalization event in
 * `_subject` - The subject identifier if the access was granted.
 * `error` - The information about an error, which e.g. led to the denial of the request.
 
+Following are the fields, which are set if tracing is enabled:
+
+* `_trace_id` - The trace id as defined by OpenTelemetry.
+* `_span_id` - The span id as defined by OpenTelemetry of the current transaction.
+* `_parent_id` - The span id of the callee, which started the given transaction. Only present if the callee set the corresponding tracing header.
+
 If you configure Heimdall to log in `text` format, you can expect output as shown below:
 
 [source, text]
 ----
 2022-08-03T12:40:16+02:00 INF TX started _client_ip=127.0.0.1 _http_host=127.0.0.1:4468 _http_method=GET
- _http_path=/foo _http_scheme=http _http_user_agent=curl/7.74.0 _tx_start=1659523216
+ _http_path=/foo _http_scheme=http _http_user_agent=curl/7.74.0 _parent_id=3449bda63ed70206
+ _span_id=f57c007257fee0ed _trace_id=00000000000000000a5af97bffe6a8a2 _tx_start=1659523216
 
 ....
 
 2022-08-03T12:40:16+02:00 INF TX finished _access_granted=true _body_bytes_sent=0 _client_ip=127.0.0.1
  _http_host=127.0.0.1:4468 _http_method=GET _http_path=/foo _http_scheme=http _http_status_code=202
- _http_user_agent=curl/7.74.0 _subject=anonymous _tx_duration_ms=0 _tx_start=1659523216
+ _http_user_agent=curl/7.74.0 _subject=anonymous _parent_id=3449bda63ed70206 _span_id=f57c007257fee0ed
+ _trace_id=00000000000000000a5af97bffe6a8a2 _tx_duration_ms=0 _tx_start=1659523216
 ----
 
 Otherwise, if you configure it to use `gelf` format, the output will look as follows:
@@ -135,7 +157,9 @@ Otherwise, if you configure it to use `gelf` format, the output will look as fol
 {"_level_name": "INFO", "version":"1.1", "host":"unknown", "_tx_start":1659523295,
  "_client_ip": "127.0.0.1", "_http_method": "GET", "_http_path":"/foo",
  "_http_user_agent": "curl/7.74.0", "_http_host": "127.0.0.1:4468", "_http_scheme": "http",
- "timestamp": 1659523295, "level": 6,"short_message": "TX started"}
+ "timestamp": 1659523295, "level": 6, "_parent_id": "3449bda63ed70206",
+ "_span_id": "f57c007257fee0ed", "_trace_id": "00000000000000000a5af97bffe6a8a2",
+ "short_message": "TX started"}
 
 ....
 
@@ -143,7 +167,9 @@ Otherwise, if you configure it to use `gelf` format, the output will look as fol
  "_client_ip": "127.0.0.1", "_http_method": "GET", "_http_path": "/foo",
  "_http_user_agent": "curl/7.74.0", "_http_host": "127.0.0.1:4468", "_http_scheme": "http",
  "_body_bytes_sent": 0, "_http_status_code":202, "_tx_duration_ms":0, "_subject": "anonymous",
- "_access_granted": true, "timestamp":1659523295, "level": 6, "short_message": "TX finished"}
+ "_access_granted": true, "timestamp":1659523295, "level": 6, "_parent_id": "3449bda63ed70206",
+ "_span_id": "f57c007257fee0ed", "_trace_id": "00000000000000000a5af97bffe6a8a2",
+ "short_message": "TX finished"}
 ----
 
 == Tracing in Heimdall

--- a/internal/fiber/middleware/accesslog/accesslog_handler_test.go
+++ b/internal/fiber/middleware/accesslog/accesslog_handler_test.go
@@ -1,0 +1,248 @@
+package accesslog
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+
+	tracingmiddleware "github.com/dadrus/heimdall/internal/fiber/middleware/opentelemetry"
+	"github.com/dadrus/heimdall/internal/testsupport"
+)
+
+func TestLoggerHandler(t *testing.T) {
+	// GIVEN
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}))
+
+	parentCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{1}, SpanID: trace.SpanID{2}, TraceFlags: trace.FlagsSampled,
+	})
+
+	for _, tc := range []struct {
+		uc               string
+		setHeader        func(t *testing.T, req *http.Request)
+		configureHandler func(t *testing.T, ctx *fiber.Ctx) error
+		assert           func(t *testing.T, logEvent1, logEvent2 map[string]any)
+	}{
+		{
+			uc:        "without tracing, x-* header and errors",
+			setHeader: func(t *testing.T, req *http.Request) { t.Helper() },
+			configureHandler: func(t *testing.T, ctx *fiber.Ctx) error {
+				t.Helper()
+
+				AddSubject(ctx.UserContext(), "foo")
+
+				return nil
+			},
+			assert: func(t *testing.T, logEvent1, logEvent2 map[string]any) {
+				t.Helper()
+
+				require.Len(t, logEvent1, 11)
+				assert.Equal(t, "info", logEvent1["level"])
+				assert.Contains(t, logEvent1, "_tx_start")
+				assert.Contains(t, logEvent1, "_client_ip")
+				assert.Contains(t, logEvent1, "_http_user_agent")
+				assert.Equal(t, "GET", logEvent1["_http_method"])
+				assert.Equal(t, "example.com", logEvent1["_http_host"])
+				assert.Equal(t, "/test", logEvent1["_http_path"])
+				assert.Equal(t, "http", logEvent1["_http_scheme"])
+				assert.Contains(t, logEvent1, "_trace_id")
+				assert.Contains(t, logEvent1, "_trace_id")
+				assert.NotEqual(t, parentCtx.TraceID().String(), logEvent1["_trace_id"])
+				assert.NotEqual(t, parentCtx.SpanID().String(), logEvent1["_parent_id"])
+				assert.Equal(t, "TX started", logEvent1["message"])
+
+				require.Len(t, logEvent2, 16)
+				assert.Equal(t, "info", logEvent2["level"])
+				assert.Contains(t, logEvent2, "_tx_start")
+				assert.Contains(t, logEvent2, "_tx_duration_ms")
+				assert.Contains(t, logEvent2, "_client_ip")
+				assert.Equal(t, "GET", logEvent2["_http_method"])
+				assert.Equal(t, "example.com", logEvent2["_http_host"])
+				assert.Equal(t, "/test", logEvent2["_http_path"])
+				assert.Equal(t, "http", logEvent2["_http_scheme"])
+				assert.Contains(t, logEvent2, "_trace_id")
+				assert.Contains(t, logEvent2, "_trace_id")
+				assert.Equal(t, logEvent2["_trace_id"], logEvent2["_trace_id"])
+				assert.Equal(t, logEvent2["_parent_id"], logEvent2["_parent_id"])
+				assert.Contains(t, logEvent2, "_body_bytes_sent")
+				assert.Equal(t, float64(200), logEvent2["_http_status_code"])
+				assert.Equal(t, true, logEvent2["_access_granted"])
+				assert.Equal(t, "foo", logEvent2["_subject"])
+				assert.Contains(t, logEvent2, "_http_user_agent")
+				assert.Equal(t, "TX finished", logEvent2["message"])
+			},
+		},
+		{
+			uc: "with tracing, x-* header and error",
+			setHeader: func(t *testing.T, req *http.Request) {
+				t.Helper()
+
+				// nolint: contextcheck
+				otel.GetTextMapPropagator().Inject(
+					trace.ContextWithRemoteSpanContext(context.Background(), parentCtx),
+					propagation.HeaderCarrier(req.Header))
+
+				req.Header.Set("X-Forwarded-Proto", "https")
+				req.Header.Set("X-Forwarded-Host", "foobar.com")
+				req.Header.Set("X-Forwarded-Path", "/bar")
+				req.Header.Set("X-Forwarded-Uri", "https://foobar.com/bar")
+				req.Header.Set("X-Forwarded-For", "127.0.0.1")
+				req.Header.Set("Forwarded", "for=127.0.0.1")
+			},
+			configureHandler: func(t *testing.T, ctx *fiber.Ctx) error {
+				t.Helper()
+
+				return fmt.Errorf("test error") // nolint: goerr113
+			},
+			assert: func(t *testing.T, logEvent1, logEvent2 map[string]any) {
+				t.Helper()
+
+				require.Len(t, logEvent1, 18)
+				assert.Equal(t, "info", logEvent1["level"])
+				assert.Contains(t, logEvent1, "_tx_start")
+				assert.Contains(t, logEvent1, "_client_ip")
+				assert.Contains(t, logEvent1, "_http_user_agent")
+				assert.Equal(t, "GET", logEvent1["_http_method"])
+				assert.Equal(t, "example.com", logEvent1["_http_host"])
+				assert.Equal(t, "/test", logEvent1["_http_path"])
+				assert.Equal(t, "http", logEvent1["_http_scheme"])
+				assert.Contains(t, logEvent1, "_span_id")
+				assert.Equal(t, parentCtx.TraceID().String(), logEvent1["_trace_id"])
+				assert.Equal(t, parentCtx.SpanID().String(), logEvent1["_parent_id"])
+				assert.Equal(t, "TX started", logEvent1["message"])
+				assert.Equal(t, "https", logEvent1["_http_x_forwarded_proto"])
+				assert.Equal(t, "foobar.com", logEvent1["_http_x_forwarded_host"])
+				assert.Equal(t, "/bar", logEvent1["_http_x_forwarded_path"])
+				assert.Equal(t, "https://foobar.com/bar", logEvent1["_http_x_forwarded_uri"])
+				assert.Equal(t, "127.0.0.1", logEvent1["_http_x_forwarded_for"])
+				assert.Equal(t, "for=127.0.0.1", logEvent1["_http_forwarded"])
+
+				require.Len(t, logEvent2, 23)
+				assert.Equal(t, "info", logEvent2["level"])
+				assert.Contains(t, logEvent2, "_tx_start")
+				assert.Contains(t, logEvent2, "_tx_duration_ms")
+				assert.Contains(t, logEvent2, "_client_ip")
+				assert.Equal(t, "GET", logEvent2["_http_method"])
+				assert.Equal(t, "example.com", logEvent2["_http_host"])
+				assert.Equal(t, "/test", logEvent2["_http_path"])
+				assert.Equal(t, "http", logEvent2["_http_scheme"])
+				assert.Equal(t, logEvent2["_trace_id"], logEvent2["_trace_id"])
+				assert.Equal(t, logEvent2["_parent_id"], logEvent2["_parent_id"])
+				assert.Equal(t, logEvent2["_span_id"], logEvent2["_span_id"])
+				assert.Contains(t, logEvent2, "_body_bytes_sent")
+				assert.Equal(t, float64(200), logEvent2["_http_status_code"])
+				assert.Equal(t, false, logEvent2["_access_granted"])
+				assert.Equal(t, "test error", logEvent2["error"])
+				assert.Contains(t, logEvent2, "_http_user_agent")
+				assert.Equal(t, "TX finished", logEvent2["message"])
+				assert.Equal(t, "https", logEvent1["_http_x_forwarded_proto"])
+				assert.Equal(t, "foobar.com", logEvent1["_http_x_forwarded_host"])
+				assert.Equal(t, "/bar", logEvent1["_http_x_forwarded_path"])
+				assert.Equal(t, "https://foobar.com/bar", logEvent1["_http_x_forwarded_uri"])
+				assert.Equal(t, "127.0.0.1", logEvent1["_http_x_forwarded_for"])
+				assert.Equal(t, "for=127.0.0.1", logEvent1["_http_forwarded"])
+			},
+		},
+		{
+			uc:        "without tracing and x-* header, but with subject and error set on context",
+			setHeader: func(t *testing.T, req *http.Request) { t.Helper() },
+			configureHandler: func(t *testing.T, ctx *fiber.Ctx) error {
+				t.Helper()
+
+				AddSubject(ctx.UserContext(), "bar")
+				AddError(ctx.UserContext(), fmt.Errorf("test error")) // nolint: goerr113
+
+				return nil
+			},
+			assert: func(t *testing.T, logEvent1, logEvent2 map[string]any) {
+				t.Helper()
+
+				require.Len(t, logEvent1, 11)
+				assert.Equal(t, "info", logEvent1["level"])
+				assert.Contains(t, logEvent1, "_tx_start")
+				assert.Contains(t, logEvent1, "_client_ip")
+				assert.Contains(t, logEvent1, "_http_user_agent")
+				assert.Equal(t, "GET", logEvent1["_http_method"])
+				assert.Equal(t, "example.com", logEvent1["_http_host"])
+				assert.Equal(t, "/test", logEvent1["_http_path"])
+				assert.Equal(t, "http", logEvent1["_http_scheme"])
+				assert.Contains(t, logEvent1, "_trace_id")
+				assert.Contains(t, logEvent1, "_trace_id")
+				assert.NotEqual(t, parentCtx.TraceID().String(), logEvent1["_trace_id"])
+				assert.NotEqual(t, parentCtx.SpanID().String(), logEvent1["_parent_id"])
+				assert.Equal(t, "TX started", logEvent1["message"])
+
+				require.Len(t, logEvent2, 17)
+				assert.Equal(t, "info", logEvent2["level"])
+				assert.Contains(t, logEvent2, "_tx_start")
+				assert.Contains(t, logEvent2, "_tx_duration_ms")
+				assert.Contains(t, logEvent2, "_client_ip")
+				assert.Equal(t, "GET", logEvent2["_http_method"])
+				assert.Equal(t, "example.com", logEvent2["_http_host"])
+				assert.Equal(t, "/test", logEvent2["_http_path"])
+				assert.Equal(t, "http", logEvent2["_http_scheme"])
+				assert.Contains(t, logEvent2, "_trace_id")
+				assert.Contains(t, logEvent2, "_trace_id")
+				assert.Equal(t, logEvent2["_trace_id"], logEvent2["_trace_id"])
+				assert.Equal(t, logEvent2["_parent_id"], logEvent2["_parent_id"])
+				assert.Contains(t, logEvent2, "_body_bytes_sent")
+				assert.Equal(t, float64(200), logEvent2["_http_status_code"])
+				assert.Equal(t, false, logEvent2["_access_granted"])
+				assert.Equal(t, "bar", logEvent2["_subject"])
+				assert.Equal(t, "test error", logEvent2["error"])
+				assert.Contains(t, logEvent2, "_http_user_agent")
+				assert.Equal(t, "TX finished", logEvent2["message"])
+			},
+		},
+	} {
+		t.Run(tc.uc, func(t *testing.T) {
+			// GIVEN
+			tb := &testsupport.TestingLog{TB: t}
+			logger := zerolog.New(zerolog.TestWriter{T: tb})
+
+			app := fiber.New()
+			app.Use(tracingmiddleware.New())
+			app.Use(New(logger))
+			app.Get("/test", func(ctx *fiber.Ctx) error { return tc.configureHandler(t, ctx) })
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			tc.setHeader(t, req)
+
+			// WHEN
+			resp, err := app.Test(req, 1000000)
+			require.NoError(t, app.Shutdown())
+
+			// THEN
+			require.NoError(t, err)
+			require.NoError(t, resp.Body.Close())
+
+			events := strings.Split(tb.CollectedLog(), "}")
+			require.Len(t, events, 3)
+
+			var (
+				logLine1 map[string]any
+				logLine2 map[string]any
+			)
+
+			require.NoError(t, json.Unmarshal([]byte(events[0]+"}"), &logLine1))
+			require.NoError(t, json.Unmarshal([]byte(events[1]+"}"), &logLine2))
+
+			tc.assert(t, logLine1, logLine2)
+		})
+	}
+}

--- a/internal/fiber/middleware/logger/logger.go
+++ b/internal/fiber/middleware/logger/logger.go
@@ -3,11 +3,23 @@ package logger
 import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func New(logger zerolog.Logger) fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		c.SetUserContext(logger.WithContext(c.UserContext()))
+		spanCtx := trace.SpanContextFromContext(c.UserContext())
+		logCtx := logger.With()
+
+		if spanCtx.TraceID().IsValid() {
+			logCtx = logCtx.Str("_trace_id", spanCtx.TraceID().String())
+		}
+
+		if spanCtx.SpanID().IsValid() {
+			logCtx = logCtx.Str("_span_id", spanCtx.SpanID().String())
+		}
+
+		c.SetUserContext(logCtx.Logger().WithContext(c.UserContext()))
 
 		return c.Next()
 	}

--- a/internal/fiber/middleware/logger/logger.go
+++ b/internal/fiber/middleware/logger/logger.go
@@ -1,9 +1,10 @@
 package logger
 
 import (
-	"github.com/dadrus/heimdall/internal/x/opentelemetry/tracecontext"
 	"github.com/gofiber/fiber/v2"
 	"github.com/rs/zerolog"
+
+	"github.com/dadrus/heimdall/internal/x/opentelemetry/tracecontext"
 )
 
 func New(logger zerolog.Logger) fiber.Handler {

--- a/internal/fiber/middleware/logger/logger_handler.go
+++ b/internal/fiber/middleware/logger/logger_handler.go
@@ -10,7 +10,8 @@ import (
 func New(logger zerolog.Logger) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		logCtx := logger.With()
-		traceCtx := tracecontext.Extract(c.UserContext())
+		ctx := c.UserContext()
+		traceCtx := tracecontext.Extract(ctx)
 
 		if traceCtx != nil {
 			logCtx = logCtx.
@@ -22,7 +23,7 @@ func New(logger zerolog.Logger) fiber.Handler {
 			}
 		}
 
-		c.SetUserContext(logCtx.Logger().WithContext(c.UserContext()))
+		c.SetUserContext(logCtx.Logger().WithContext(ctx))
 
 		return c.Next()
 	}

--- a/internal/fiber/middleware/logger/logger_handler_test.go
+++ b/internal/fiber/middleware/logger/logger_handler_test.go
@@ -1,0 +1,105 @@
+package logger
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/gofiber/fiber/v2"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+
+	tracingmiddleware "github.com/dadrus/heimdall/internal/fiber/middleware/opentelemetry"
+	"github.com/dadrus/heimdall/internal/testsupport"
+)
+
+func TestLoggerHandler(t *testing.T) {
+	// GIVEN
+	otel.SetTracerProvider(sdktrace.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}))
+
+	parentCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{1}, SpanID: trace.SpanID{2}, TraceFlags: trace.FlagsSampled,
+	})
+	ctx := trace.ContextWithRemoteSpanContext(context.Background(), parentCtx)
+
+	for _, tc := range []struct {
+		uc        string
+		setHeader func(t *testing.T, req *http.Request)
+		assert    func(t *testing.T, logstring string)
+	}{
+		{
+			uc:        "without tracing",
+			setHeader: func(t *testing.T, req *http.Request) { t.Helper() },
+			assert: func(t *testing.T, logstring string) {
+				t.Helper()
+
+				assert.Contains(t, logstring, "test called")
+				assert.Contains(t, logstring, "_span_id")
+				assert.Contains(t, logstring, "_trace_id")
+				assert.NotContains(t, logstring, "_parent_id")
+
+				var logData map[string]string
+				require.NoError(t, json.Unmarshal([]byte(logstring), &logData))
+				assert.NotEqual(t, parentCtx.TraceID().String(), logData["_trace_id"])
+				assert.NotEqual(t, parentCtx.SpanID().String(), logData["_parent_id"])
+			},
+		},
+		{
+			uc: "with tracing",
+			setHeader: func(t *testing.T, req *http.Request) {
+				t.Helper()
+
+				otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+			},
+			assert: func(t *testing.T, logstring string) {
+				t.Helper()
+
+				assert.Contains(t, logstring, "test called")
+				assert.Contains(t, logstring, "_span_id")
+				assert.Contains(t, logstring, "_trace_id")
+				assert.Contains(t, logstring, "_parent_id")
+
+				var logData map[string]string
+				require.NoError(t, json.Unmarshal([]byte(logstring), &logData))
+				assert.Equal(t, parentCtx.TraceID().String(), logData["_trace_id"])
+				assert.Equal(t, parentCtx.SpanID().String(), logData["_parent_id"])
+			},
+		},
+	} {
+		t.Run(tc.uc, func(t *testing.T) {
+			// GIVEN
+			tb := &testsupport.TestingLog{TB: t}
+			logger := zerolog.New(zerolog.TestWriter{T: tb})
+
+			app := fiber.New()
+			app.Use(tracingmiddleware.New())
+			app.Use(New(logger))
+			app.Get("/test", func(ctx *fiber.Ctx) error {
+				zerolog.Ctx(ctx.UserContext()).Info().Msg("test called")
+
+				return nil
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+
+			tc.setHeader(t, req)
+
+			// WHEN
+			resp, err := app.Test(req)
+			require.NoError(t, app.Shutdown())
+
+			// THEN
+			require.NoError(t, err)
+			resp.Body.Close()
+			tc.assert(t, tb.CollectedLog())
+		})
+	}
+}

--- a/internal/handler/decision/module.go
+++ b/internal/handler/decision/module.go
@@ -48,10 +48,10 @@ func newFiberApp(conf config.Configuration, cache cache.Cache, logger zerolog.Lo
 	})
 
 	app.Use(recover.New(recover.Config{EnableStackTrace: true}))
-	app.Use(accesslogmiddleware.New(logger))
-	app.Use(loggermiddlerware.New(logger))
 	app.Use(tracingmiddleware.New(
 		tracingmiddleware.WithTracer(otel.GetTracerProvider().Tracer("github.com/dadrus/heimdall/decision"))))
+	app.Use(accesslogmiddleware.New(logger))
+	app.Use(loggermiddlerware.New(logger))
 
 	if service.CORS != nil {
 		app.Use(cors.New(cors.Config{

--- a/internal/handler/management/module.go
+++ b/internal/handler/management/module.go
@@ -41,11 +41,11 @@ func newFiberApp(conf config.Configuration, logger zerolog.Logger) *fiber.App {
 		JSONEncoder:             json.Marshal,
 	})
 	app.Use(recover.New(recover.Config{EnableStackTrace: true}))
-	app.Use(accesslogmiddleware.New(logger))
-	app.Use(loggermiddlerware.New(logger))
 	app.Use(tracingmiddleware.New(
 		tracingmiddleware.WithTracer(otel.GetTracerProvider().Tracer("github.com/dadrus/heimdall/management")),
 		tracingmiddleware.WithOperationFilter(func(ctx *fiber.Ctx) bool { return ctx.Path() == EndpointHealth })))
+	app.Use(accesslogmiddleware.New(logger))
+	app.Use(loggermiddlerware.New(logger))
 
 	if service.CORS != nil {
 		app.Use(cors.New(cors.Config{

--- a/internal/handler/proxy/module.go
+++ b/internal/handler/proxy/module.go
@@ -48,10 +48,10 @@ func newFiberApp(conf config.Configuration, cache cache.Cache, logger zerolog.Lo
 		JSONEncoder: json.Marshal,
 	})
 	app.Use(recover.New(recover.Config{EnableStackTrace: true}))
-	app.Use(accesslogmiddleware.New(logger))
-	app.Use(loggermiddlerware.New(logger))
 	app.Use(tracingmiddleware.New(
 		tracingmiddleware.WithTracer(otel.GetTracerProvider().Tracer("github.com/dadrus/heimdall/proxy"))))
+	app.Use(accesslogmiddleware.New(logger))
+	app.Use(loggermiddlerware.New(logger))
 
 	if service.CORS != nil {
 		app.Use(cors.New(cors.Config{

--- a/internal/testsupport/testing_log.go
+++ b/internal/testsupport/testing_log.go
@@ -1,0 +1,28 @@
+package testsupport
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+type TestingLog struct {
+	testing.TB
+	buf bytes.Buffer
+}
+
+func (t *TestingLog) Log(args ...interface{}) {
+	if _, err := t.buf.WriteString(fmt.Sprint(args...)); err != nil {
+		t.Error(err)
+	}
+}
+
+func (t *TestingLog) Logf(format string, args ...interface{}) {
+	if _, err := t.buf.WriteString(fmt.Sprintf(format, args...)); err != nil {
+		t.Error(err)
+	}
+}
+
+func (t *TestingLog) CollectedLog() string {
+	return t.buf.String()
+}

--- a/internal/x/opentelemetry/tracecontext/tracecontext.go
+++ b/internal/x/opentelemetry/tracecontext/tracecontext.go
@@ -1,0 +1,34 @@
+package tracecontext
+
+import (
+	"context"
+
+	trace2 "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type TraceContext struct {
+	TraceID  string
+	SpanID   string
+	ParentID string
+}
+
+func Extract(ctx context.Context) *TraceContext {
+	span := trace.SpanFromContext(ctx)
+	spanCtx := span.SpanContext()
+
+	if spanCtx.IsValid() {
+		ctxInfo := &TraceContext{}
+
+		if roSpan, ok := span.(trace2.ReadOnlySpan); ok && roSpan.Parent().IsValid() {
+			ctxInfo.ParentID = roSpan.Parent().SpanID().String()
+		}
+
+		ctxInfo.TraceID = spanCtx.TraceID().String()
+		ctxInfo.SpanID = spanCtx.SpanID().String()
+
+		return ctxInfo
+	}
+
+	return nil
+}


### PR DESCRIPTION
closes #142 

This PR adds `_trace_id`, `_span_id` and `_parent_id` (parent span id) to any emitted log event if tracing is enabled.