### PR TITLE
refactor: file system provider rename

### DIFF
--- a/docs/content/docs/configuration/rules/providers.adoc
+++ b/docs/content/docs/configuration/rules/providers.adoc
@@ -15,7 +15,7 @@ Supported providers, including the corresponding configuration options are descr
 
 == Filesystem
 
-The filesystem provider allows loading of rule sets from a file system. The configuration of this provider goes into the `file` property. This provider is handy for e.g. starting playing around with Heimdall, e.g. locally, or using Docker, as well as if your deployment strategy considers deploying a Heimdall instance as a Side-Car for each of your services.
+The filesystem provider allows loading of rule sets from a file system. The configuration of this provider goes into the `file_system` property. This provider is handy for e.g. starting playing around with Heimdall, e.g. locally, or using Docker, as well as if your deployment strategy considers deploying a Heimdall instance as a Side-Car for each of your services.
 
 Following configuration options are supported:
 
@@ -33,7 +33,7 @@ This provider doesn't need any additional configuration for a rule set. So the c
 ====
 [source, yaml]
 ----
-file:
+file_system:
   src: /path/to/rules/dir
   watch: true
 ----
@@ -43,7 +43,7 @@ file:
 ====
 [source, yaml]
 ----
-file:
+file_system:
   src: /path/to/rules.yaml
 ----
 ====

--- a/internal/config/rule_provider.go
+++ b/internal/config/rule_provider.go
@@ -1,7 +1,7 @@
 package config
 
 type RuleProviders struct {
-	FileSystem   *FileBasedRuleProviderConfig `koanf:"file,omitempty"`
+	FileSystem   *FileBasedRuleProviderConfig `koanf:"file_system,omitempty"`
 	HTTPEndpoint map[string]any               `koanf:"http_endpoint,omitempty"`
 }
 

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -267,7 +267,7 @@ rules:
       - error_handler: authenticate_with_kratos
 
   providers:
-    file:
+    file_system:
       src: test_rules.yaml
       watch: true
 

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -1685,7 +1685,7 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "file": {
+            "file_system": {
               "$ref": "#/definitions/fileSystemProvider"
             },
             "http_endpoint": {

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -169,7 +169,7 @@ rules:
       - error_handler: authenticate_with_kratos
 
   providers:
-    file:
+    file_system:
       src: test_rules.yaml
       watch: true
 


### PR DESCRIPTION
This PR renames the property for configuring the file system provider from `file` to `file_system` to better reflect its meaning