### PR TITLE
docs: Documentation for local authorizer updated to include examples with HTTP method based access enforcement

### DIFF
--- a/docs/content/docs/configuration/pipeline/authorizers.adoc
+++ b/docs/content/docs/configuration/pipeline/authorizers.adoc
@@ -25,7 +25,7 @@ To enable the usage of this authorizer, you have to set the `type` property to `
 ====
 [source, yaml]
 ----
-id: foo
+id: allow_any_request
 type: allow
 ----
 ====
@@ -40,7 +40,7 @@ To enable the usage of this authorizer, you have to set the `type` property to `
 ====
 [source, yaml]
 ----
-id: foo
+id: deny_any_request
 type: deny
 ----
 ====
@@ -57,13 +57,16 @@ Configuration using the `config` property is mandatory. Following properties are
 
 * *`script`*: _string_ (mandatory, overridable)
 +
-ECMAScript wich executes the actual authorization logic (see also link:{{< relref "overview.adoc#_scripting" >}}[Scripting]). Heimdall expects the script to return either `true`, if the authorization was successful, or otherwise `false`, or to raise an error. In latter case the message from the raised error will also be logged.
+ECMAScript which executes the actual authorization logic (see also link:{{< relref "overview.adoc#_scripting" >}}[Scripting]). Heimdall expects the script to return either `true`, if the authorization was successful, or otherwise `false`, or to raise an error. In latter case the message from the raised error will also be logged.
 
-.Configuration of Local authorizer
+.Authorization based on subject properties
 ====
+
+In this example the subject is checked to be member of the "admin" group.
+
 [source, yaml]
 ----
-id: foo
+id: user_is_admin
 type: local
 config:
   script: |
@@ -71,6 +74,27 @@ config:
       raise("user not in admin group")
     }
 ----
+====
+
+.Authorization based on subject and request properties
+====
+
+In this example the authorizer is configured to ensure anonymous access to a resource is possible for read-only requests only.
+
+[source, yaml]
+----
+id: no_modification_allowed_by_anonymous
+type: local
+config:
+  script: |
+    if (heimdall.RequestMethod() !== "GET" &&
+        heimdall.Subject.ID === "anonymous")
+      raise("anonymous access is not allowed")
+    }
+----
+
+The usage of this type of configuration makes sense in a pipeline, which combines multiple link:{{< relref "authenticators.adoc" >}}[Authenticators], allowing anonymous and authenticated access.
+
 ====
 
 === Remote
@@ -93,7 +117,7 @@ Your template with definitions required to communicate to the authorization endp
 
 * *`script`*:  _string_ (optional, overridable)
 +
-ECMAScript wich executed further authorization logic on the given response from the authorization endpoint (See also link:{{< relref "overview.adoc#_scripting" >}}[Scripting]). Heimdall expects the script to return either `true`, if the authorization was successful, or otherwise `false`, or to raise an error. In latter case the message from the raised error will also be logged. Compared to the link:{{< relref "#_local" >}}[Local] authorizer, only `heimdall.Payload` object is available, which contains the response from the authorization endpoint, as well as the `console.log` function, which enables logging from the script. Latter can become handy during development of debugging. The output is only available if debug log level is set.
+ECMAScript which executed further authorization logic on the given response from the authorization endpoint (See also link:{{< relref "overview.adoc#_scripting" >}}[Scripting]). Heimdall expects the script to return either `true`, if the authorization was successful, or otherwise `false`, or to raise an error. In latter case the message from the raised error will also be logged. Compared to the link:{{< relref "#_local" >}}[Local] authorizer, only `heimdall.Payload` object is available, which contains the response from the authorization endpoint, as well as the `console.log` function, which enables logging from the script. Latter can become handy during development of debugging. The output is only available if debug log level is set.
 
 * *`forward_response_headers_to_upstream`*: _string array_ (optional, overridable)
 +
@@ -109,7 +133,7 @@ Here the remote authorizer is configured to communicate with OPA. Since OPA expe
 
 [source, yaml]
 ----
-id: foo
+id: user_can_write
 type: remote
 config:
   endpoint:
@@ -128,5 +152,5 @@ config:
     heimdall.Payload.result === true
 ----
 
-Since an OPA response could look like `{ "result": true }` or `{ "result": false }`, which obviously needs further evaluation, Heimdall makes it available under `.Subject.Attributes["foo"]` as a map, with `"foo"` being the id of the authorizer in this example.
+In this case, since an OPA response could look like `{ "result": true }` or `{ "result": false }`, heimdall makes the response also available under `.Subject.Attributes["user_can_write"]` as a map, with `"user_can_write"` being the id of the authorizer in this example.
 ====

--- a/docs/content/docs/guides/opa.adoc
+++ b/docs/content/docs/guides/opa.adoc
@@ -10,9 +10,7 @@ menu:
     weight: 20
 ---
 
-https://www.openpolicyagent.org/[Open Policy Agent], or OPA, is an open source, general purpose policy engine, which decouples authorization, respectively policy decisions from other responsibilities of an application and can be used to implement fine-grained access control for your application. As such it is a very good fit for integrating with heimdall. And indeed, the integration is very simple. It is just a matter of using a link:{{< relref "/docs/configuration/pipeline/authorizers.adoc#_remote" >}}[Remote Authorizer].
-
-Here some examples demonstrating different possible application requirements and how these can be solved with heimdall:
+https://www.openpolicyagent.org/[Open Policy Agent], or OPA, is an open source, general purpose policy engine, which decouples authorization, respectively policy decisions from other responsibilities of an application and can be used to implement fine-grained access control for your application. As such it is a very good fit for integrating with heimdall. And indeed, the integration is very simple. It is just a matter of using a link:{{< relref "/docs/configuration/pipeline/authorizers.adoc#_remote" >}}[Remote Authorizer] or a link:{{< relref "/docs/configuration/pipeline/hydrators.adoc#_generic" >}}[Generic Hydrator]. Which one is better for a particular use case depends on the specific application requirements. Here some examples demonstrating these and how it can be solved with heimdall:
 
 [[_sharing_service_example]]
 .Sharing Service


### PR DESCRIPTION
closes #296 

Support for #296 is actually already implemented and can be done using a combination of corresponding authenticators and a `local` authorizer. Latter can then be used to implement the required enforcement. Corresponding example has been added by the PR to the documentation.