### PR TITLE
feat: Configuration of minimal TLS version and the required cipher suites

### DIFF
--- a/docs/content/docs/configuration/services/configuration_types.adoc
+++ b/docs/content/docs/configuration/services/configuration_types.adoc
@@ -84,7 +84,7 @@ max_age: 10s
 ====
 
 == TLS
-As of today, the available configuration options are however limited to setting up the private key, as well as the corresponding certificate. TLSv1.2 and TLSv1.3 can however be used by the clients, with TLSv1.2 cipher spec usage limited to what the Go Language supports.
+Following are the supported TLS configuration options:
 
 * *`key`*: _string_ (mandatory)
 +
@@ -93,3 +93,23 @@ Path to the private key in PEM format. PKCS#1, as well as PKCS#8 formats are sup
 * *`cert`*: _string_ (mandatory)
 +
 Path to the certificate in PEM format. The certificate file may contain intermediate certificates following the leaf certificate to form a certificate chain
+
+* *`min_version`*: _string_ (optional)
++
+The minimal TLS version to support. Can be either `TLS1.2` or `TLS1.3`. Defaults to `TLS1.3`.
+
+* *`cipher_suites`*: _string array_ (optional)
++
+Can be configured if `min_version` is set to `TLS1.2`. If `min_version` is set to `TLS1.3` the configured values are ignored. Only the following PFS cipher suites are supported:
+
+** `TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256`
+** `TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256`
+** `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`
+** `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`
+** `TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`
+** `TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`
+** `TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256`
+** `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256`
+
++
+Defaults to the last six cipher suites if `min_version` is set to `TLS1.2` and `cipher_suites` is not configured.

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -29,6 +29,8 @@ func NewConfiguration(envPrefix EnvVarPrefix, configFile ConfigurationPath) (Con
 		parser.WithDecodeHookFunc(mapstructure.StringToSliceHookFunc(",")),
 		parser.WithDecodeHookFunc(logLevelDecodeHookFunc),
 		parser.WithDecodeHookFunc(logFormatDecodeHookFunc),
+		parser.WithDecodeHookFunc(decodeTLSCipherSuiteHookFunc),
+		parser.WithDecodeHookFunc(decodeTLSMinVersionHookFunc),
 		parser.WithEnvPrefix(string(envPrefix)),
 		parser.WithDefaultConfigFilename("heimdall.yaml"),
 		parser.WithConfigFile(string(configFile)),

--- a/internal/config/mapstructure_decoder.go
+++ b/internal/config/mapstructure_decoder.go
@@ -1,11 +1,14 @@
 package config
 
 import (
+	"crypto/tls"
 	"reflect"
 
 	"github.com/rs/zerolog"
 
+	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/x"
+	"github.com/dadrus/heimdall/internal/x/errorchain"
 )
 
 // Decode zeroLog LogLevels from strings.
@@ -49,4 +52,72 @@ func logFormatDecodeHookFunc(from reflect.Type, to reflect.Type, val any) (any, 
 	}
 
 	return val, nil
+}
+
+//nolint:cyclop
+func decodeTLSCipherSuiteHookFunc(from reflect.Type, to reflect.Type, data any) (any, error) {
+	var suites TLSCipherSuites
+
+	if from.Kind() != reflect.Slice {
+		return data, nil
+	}
+
+	dect := reflect.ValueOf(&suites).Elem().Type()
+	if !dect.AssignableTo(to) {
+		return data, nil
+	}
+
+	// nolint: forcetypeassert
+	// already checked above
+	for _, val := range data.([]any) {
+		var alg uint16
+
+		switch val {
+		case "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256":
+			alg = tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+		case "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256":
+			alg = tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+		case "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":
+			alg = tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+		case "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256":
+			alg = tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+		case "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":
+			alg = tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+		case "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384":
+			alg = tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+		case "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256":
+			alg = tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+		case "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256":
+			alg = tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+		default:
+			return 0, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
+				"TLS cipher suite %s is unsupported", val)
+		}
+
+		suites = append(suites, alg)
+	}
+
+	return suites, nil
+}
+
+func decodeTLSMinVersionHookFunc(from reflect.Type, to reflect.Type, data any) (any, error) {
+	var minVersion TLSMinVersion
+
+	if from.Kind() != reflect.String {
+		return data, nil
+	}
+
+	dect := reflect.ValueOf(&minVersion).Elem().Type()
+	if !dect.AssignableTo(to) {
+		return data, nil
+	}
+
+	switch data {
+	case "TLS1.2":
+		return tls.VersionTLS12, nil
+	case "TLS1.3":
+		return tls.VersionTLS13, nil
+	default:
+		return 0, errorchain.NewWithMessagef(heimdall.ErrConfiguration, "TLS version %s is unsupported", data)
+	}
 }

--- a/internal/config/mapstructure_decoder.go
+++ b/internal/config/mapstructure_decoder.go
@@ -58,12 +58,7 @@ func logFormatDecodeHookFunc(from reflect.Type, to reflect.Type, val any) (any, 
 func decodeTLSCipherSuiteHookFunc(from reflect.Type, to reflect.Type, data any) (any, error) {
 	var suites TLSCipherSuites
 
-	if from.Kind() != reflect.Slice {
-		return data, nil
-	}
-
-	dect := reflect.ValueOf(&suites).Elem().Type()
-	if !dect.AssignableTo(to) {
+	if from.Kind() != reflect.Slice || to != reflect.TypeOf(TLSCipherSuites{}) {
 		return data, nil
 	}
 
@@ -101,14 +96,7 @@ func decodeTLSCipherSuiteHookFunc(from reflect.Type, to reflect.Type, data any) 
 }
 
 func decodeTLSMinVersionHookFunc(from reflect.Type, to reflect.Type, data any) (any, error) {
-	var minVersion TLSMinVersion
-
-	if from.Kind() != reflect.String {
-		return data, nil
-	}
-
-	dect := reflect.ValueOf(&minVersion).Elem().Type()
-	if !dect.AssignableTo(to) {
+	if from.Kind() != reflect.String || to != reflect.TypeOf(TLSMinVersion(0)) {
 		return data, nil
 	}
 
@@ -118,6 +106,6 @@ func decodeTLSMinVersionHookFunc(from reflect.Type, to reflect.Type, data any) (
 	case "TLS1.3":
 		return tls.VersionTLS13, nil
 	default:
-		return 0, errorchain.NewWithMessagef(heimdall.ErrConfiguration, "TLS version %s is unsupported", data)
+		return data, errorchain.NewWithMessagef(heimdall.ErrConfiguration, "TLS version %s is unsupported", data)
 	}
 }

--- a/internal/config/mapstructure_decoder_test.go
+++ b/internal/config/mapstructure_decoder_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"testing"
 
 	"github.com/mitchellh/mapstructure"
@@ -197,6 +198,71 @@ func TestDecodeLogFormat(t *testing.T) {
 
 			// THEN
 			tc.assert(t, err, typ.Format)
+		})
+	}
+}
+
+func TestDecodeTLSMinVersion(t *testing.T) {
+	t.Parallel()
+
+	type Type struct {
+		MinVersion TLSMinVersion `mapstructure:"min_version"`
+	}
+
+	for _, tc := range []struct {
+		uc     string
+		config []byte
+		assert func(t *testing.T, err error, minVersion TLSMinVersion)
+	}{
+		{
+			uc:     "unsupported version",
+			config: []byte(`min_version: foo`),
+			assert: func(t *testing.T, err error, minVersion TLSMinVersion) {
+				t.Helper()
+
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unsupported")
+			},
+		},
+		{
+			uc:     "TLS v1.2 version",
+			config: []byte(`min_version: TLS1.2`),
+			assert: func(t *testing.T, err error, minVersion TLSMinVersion) {
+				t.Helper()
+
+				require.NoError(t, err)
+				assert.Equal(t, TLSMinVersion(tls.VersionTLS12), minVersion)
+			},
+		},
+		{
+			uc:     "TLS v1.3 version",
+			config: []byte(`min_version: TLS1.3`),
+			assert: func(t *testing.T, err error, minVersion TLSMinVersion) {
+				t.Helper()
+
+				require.NoError(t, err)
+				assert.Equal(t, TLSMinVersion(tls.VersionTLS13), minVersion)
+			},
+		},
+	} {
+		t.Run(tc.uc, func(t *testing.T) {
+			// GIVEN
+			var typ Type
+
+			dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+				DecodeHook: decodeTLSMinVersionHookFunc,
+				Result:     &typ,
+			})
+			require.NoError(t, err)
+
+			conf, err := testsupport.DecodeTestConfig(tc.config)
+			require.NoError(t, err)
+
+			// WHEN
+			err = dec.Decode(conf)
+
+			// THEN
+			tc.assert(t, err, typ.MinVersion)
 		})
 	}
 }

--- a/internal/config/serve.go
+++ b/internal/config/serve.go
@@ -42,7 +42,7 @@ type TLSMinVersion uint16
 
 func (v TLSMinVersion) OrDefault() uint16 {
 	if v == 0 {
-		return tls.VersionTLS12
+		return tls.VersionTLS13
 	}
 
 	return uint16(v)

--- a/internal/config/serve.go
+++ b/internal/config/serve.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/tls"
 	"fmt"
 	"time"
 )
@@ -20,9 +21,38 @@ type CORS struct {
 	MaxAge           time.Duration `koanf:"max_age,string"`
 }
 
+type TLSCipherSuites []uint16
+
+func (s TLSCipherSuites) OrDefault() []uint16 {
+	if len(s) == 0 {
+		return []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		}
+	}
+
+	return s
+}
+
+type TLSMinVersion uint16
+
+func (v TLSMinVersion) OrDefault() uint16 {
+	if v == 0 {
+		return tls.VersionTLS12
+	}
+
+	return uint16(v)
+}
+
 type TLS struct {
-	Key  string `koanf:"key"`
-	Cert string `koanf:"cert"`
+	Key          string          `koanf:"key"`
+	Cert         string          `koanf:"cert"`
+	CipherSuites TLSCipherSuites `koanf:"cipher_suites"`
+	MinVersion   TLSMinVersion   `koanf:"min_version"`
 }
 
 type ServiceConfig struct {

--- a/internal/config/serve_test.go
+++ b/internal/config/serve_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTLSMinVersionOrDefault(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		uc       string
+		version  TLSMinVersion
+		expected uint16
+	}{
+		{uc: "not configured", expected: tls.VersionTLS13},
+		{uc: "configured", version: tls.VersionTLS12, expected: tls.VersionTLS12},
+	} {
+		t.Run(tc.uc, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.version.OrDefault())
+		})
+	}
+}
+
+func TestTLSCipherSuitesOrDefault(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		uc       string
+		suites   TLSCipherSuites
+		expected []uint16
+	}{
+		{
+			uc: "not configured",
+			expected: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+			},
+		},
+		{
+			uc:     "configured",
+			suites: TLSCipherSuites{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
+			expected: []uint16{
+				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			},
+		},
+	} {
+		t.Run(tc.uc, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.suites.OrDefault())
+		})
+	}
+}

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -22,6 +22,7 @@ serve:
     tls:
       key: /path/to/key/file.pem
       cert: /path/to/cert/file.pem
+      min_version: TLS1.3
     trusted_proxies:
       - 192.168.1.0/24
 
@@ -48,6 +49,16 @@ serve:
     tls:
       key: /path/to/key/file.pem
       cert: /path/to/cert/file.pem
+      min_version: TLS1.2
+      cipher_suites:
+        - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
     trusted_proxies:
       - 192.168.1.0/24
 

--- a/internal/handler/listener/listener.go
+++ b/internal/handler/listener/listener.go
@@ -29,17 +29,16 @@ func newTLSListener(conf config.ServiceConfig, listener net.Listener) (net.Liste
 	}
 
 	tlsHandler := &fiber.TLSHandler{}
-	tlsVersion := conf.TLS.MinVersion.OrDefault()
 
 	// nolint:gosec
 	// configuration ensures, TLS versions below 1.2 are not possible
 	cfg := &tls.Config{
 		Certificates:   []tls.Certificate{cert},
-		MinVersion:     tlsVersion,
+		MinVersion:     conf.TLS.MinVersion.OrDefault(),
 		GetCertificate: tlsHandler.GetClientInfo,
 	}
 
-	if tlsVersion < tls.VersionTLS13 {
+	if cfg.MinVersion < tls.VersionTLS13 {
 		cfg.CipherSuites = conf.TLS.CipherSuites.OrDefault()
 	}
 

--- a/internal/handler/listener/listener.go
+++ b/internal/handler/listener/listener.go
@@ -1,0 +1,47 @@
+package listener
+
+import (
+	"crypto/tls"
+	"net"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/dadrus/heimdall/internal/config"
+)
+
+func New(network string, conf config.ServiceConfig) (net.Listener, error) {
+	listener, err := net.Listen(network, conf.Address())
+	if err != nil {
+		return nil, err
+	}
+
+	if conf.TLS != nil {
+		return newTLSListener(conf, listener)
+	}
+
+	return listener, nil
+}
+
+func newTLSListener(conf config.ServiceConfig, listener net.Listener) (net.Listener, error) {
+	cert, err := tls.LoadX509KeyPair(conf.TLS.Cert, conf.TLS.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsHandler := &fiber.TLSHandler{}
+	tlsVersion := conf.TLS.MinVersion.OrDefault()
+
+	// nolint:gosec
+	// configuration ensures, TLS versions below 1.2 are not possible
+	cfg := &tls.Config{
+		Certificates:   []tls.Certificate{cert},
+		MinVersion:     tlsVersion,
+		GetCertificate: tlsHandler.GetClientInfo,
+	}
+
+	if tlsVersion < tls.VersionTLS13 {
+		cfg.CipherSuites = conf.TLS.CipherSuites.OrDefault()
+	}
+
+	return tls.NewListener(listener, cfg), nil
+}

--- a/internal/handler/listener/listener.go
+++ b/internal/handler/listener/listener.go
@@ -2,6 +2,8 @@ package listener
 
 import (
 	"crypto/tls"
+	"github.com/dadrus/heimdall/internal/heimdall"
+	"github.com/dadrus/heimdall/internal/x/errorchain"
 	"net"
 
 	"github.com/gofiber/fiber/v2"
@@ -12,7 +14,8 @@ import (
 func New(network string, conf config.ServiceConfig) (net.Listener, error) {
 	listener, err := net.Listen(network, conf.Address())
 	if err != nil {
-		return nil, err
+		return nil, errorchain.NewWithMessage(heimdall.ErrInternal, "failed creating listener").
+			CausedBy(err)
 	}
 
 	if conf.TLS != nil {
@@ -25,7 +28,8 @@ func New(network string, conf config.ServiceConfig) (net.Listener, error) {
 func newTLSListener(conf config.ServiceConfig, listener net.Listener) (net.Listener, error) {
 	cert, err := tls.LoadX509KeyPair(conf.TLS.Cert, conf.TLS.Key)
 	if err != nil {
-		return nil, err
+		return nil, errorchain.NewWithMessage(heimdall.ErrInternal, "failed loading key and certificate").
+			CausedBy(err)
 	}
 
 	tlsHandler := &fiber.TLSHandler{}

--- a/internal/handler/listener/listener.go
+++ b/internal/handler/listener/listener.go
@@ -42,7 +42,7 @@ func newTLSListener(conf config.ServiceConfig, listener net.Listener) (net.Liste
 		GetCertificate: tlsHandler.GetClientInfo,
 	}
 
-	if cfg.MinVersion < tls.VersionTLS13 {
+	if cfg.MinVersion != tls.VersionTLS13 {
 		cfg.CipherSuites = conf.TLS.CipherSuites.OrDefault()
 	}
 

--- a/internal/handler/listener/listener.go
+++ b/internal/handler/listener/listener.go
@@ -2,13 +2,13 @@ package listener
 
 import (
 	"crypto/tls"
-	"github.com/dadrus/heimdall/internal/heimdall"
-	"github.com/dadrus/heimdall/internal/x/errorchain"
 	"net"
 
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/dadrus/heimdall/internal/config"
+	"github.com/dadrus/heimdall/internal/heimdall"
+	"github.com/dadrus/heimdall/internal/x/errorchain"
 )
 
 func New(network string, conf config.ServiceConfig) (net.Listener, error) {

--- a/internal/handler/listener/listener_test.go
+++ b/internal/handler/listener/listener_test.go
@@ -1,0 +1,159 @@
+package listener
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dadrus/heimdall/internal/config"
+	"github.com/dadrus/heimdall/internal/heimdall"
+	"github.com/dadrus/heimdall/internal/testsupport"
+)
+
+func freePort() (int, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+
+	ln, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+
+	defer ln.Close()
+
+	return ln.Addr().(*net.TCPAddr).Port, nil // nolint: forcetypeassert
+}
+
+func TestCreateNewListener(t *testing.T) {
+	t.Parallel()
+
+	testDir := t.TempDir()
+
+	privKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	require.NoError(t, err)
+
+	privKeyPEMBytes, err := testsupport.BuildPEM(testsupport.WithECDSAPrivateKey(privKey))
+	require.NoError(t, err)
+
+	keyFile, err := os.Create(filepath.Join(testDir, "key.pem"))
+	require.NoError(t, err)
+	_, err = keyFile.Write(privKeyPEMBytes)
+	require.NoError(t, err)
+
+	cert, err := testsupport.NewCertificateBuilder(testsupport.WithValidity(time.Now(), 10*time.Hour),
+		testsupport.WithSerialNumber(big.NewInt(1)),
+		testsupport.WithSubject(pkix.Name{
+			CommonName:   "test cert",
+			Organization: []string{"Test"},
+			Country:      []string{"EU"},
+		}),
+		testsupport.WithSubjectPubKey(&privKey.PublicKey, x509.ECDSAWithSHA384),
+		testsupport.WithSelfSigned(),
+		testsupport.WithSignaturePrivKey(privKey)).
+		Build()
+	require.NoError(t, err)
+
+	certPEMBytes, err := testsupport.BuildPEM(testsupport.WithX509Certificate(cert))
+	require.NoError(t, err)
+
+	certFile, err := os.Create(filepath.Join(testDir, "cert.pem"))
+	require.NoError(t, err)
+	_, err = certFile.Write(certPEMBytes)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		uc          string
+		network     string
+		serviceConf config.ServiceConfig
+		assert      func(t *testing.T, err error, ln net.Listener, port string)
+	}{
+		{
+			uc:          "creation fails",
+			network:     "foo",
+			serviceConf: config.ServiceConfig{},
+			assert: func(t *testing.T, err error, ln net.Listener, port string) {
+				t.Helper()
+
+				require.Error(t, err)
+				assert.ErrorIs(t, err, heimdall.ErrInternal)
+				assert.Contains(t, err.Error(), "failed creating listener")
+			},
+		},
+		{
+			uc:          "listener without TLS",
+			network:     "tcp",
+			serviceConf: config.ServiceConfig{Host: "127.0.0.1"},
+			assert: func(t *testing.T, err error, ln net.Listener, port string) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.NotNil(t, ln)
+
+				assert.Equal(t, "tcp", ln.Addr().Network())
+				assert.Equal(t, "127.0.0.1:"+port, ln.Addr().String())
+			},
+		},
+		{
+			uc:      "creation of listener with TLS fails",
+			network: "tcp",
+			serviceConf: config.ServiceConfig{
+				TLS: &config.TLS{Key: "/no/such/key", Cert: "/no/such/cert"},
+			},
+			assert: func(t *testing.T, err error, ln net.Listener, port string) {
+				t.Helper()
+
+				require.Error(t, err)
+				assert.ErrorIs(t, err, heimdall.ErrInternal)
+				assert.Contains(t, err.Error(), "failed loading")
+			},
+		},
+		{
+			uc:      "listener with TLS",
+			network: "tcp",
+			serviceConf: config.ServiceConfig{
+				TLS: &config.TLS{Key: keyFile.Name(), Cert: certFile.Name()},
+			},
+			assert: func(t *testing.T, err error, ln net.Listener, port string) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.NotNil(t, ln)
+				assert.Equal(t, "tcp", ln.Addr().Network())
+				assert.Contains(t, ln.Addr().String(), port)
+			},
+		},
+	} {
+		t.Run(tc.uc, func(t *testing.T) {
+			// GIVEN
+			port, err := freePort()
+			require.NoError(t, err)
+			tc.serviceConf.Port = port
+
+			// WHEN
+			ln, err := New(tc.network, tc.serviceConf)
+
+			// THEN
+			defer func() {
+				if ln != nil {
+					ln.Close()
+				}
+			}()
+
+			tc.assert(t, err, ln, strconv.Itoa(port))
+		})
+	}
+}

--- a/internal/handler/listener/listener_test.go
+++ b/internal/handler/listener/listener_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"math/big"
@@ -125,7 +126,7 @@ func TestCreateNewListener(t *testing.T) {
 			uc:      "listener with TLS",
 			network: "tcp",
 			serviceConf: config.ServiceConfig{
-				TLS: &config.TLS{Key: keyFile.Name(), Cert: certFile.Name()},
+				TLS: &config.TLS{Key: keyFile.Name(), Cert: certFile.Name(), MinVersion: tls.VersionTLS12},
 			},
 			assert: func(t *testing.T, err error, ln net.Listener, port string) {
 				t.Helper()

--- a/internal/handler/management/module.go
+++ b/internal/handler/management/module.go
@@ -17,6 +17,7 @@ import (
 	errorhandlermiddleware "github.com/dadrus/heimdall/internal/fiber/middleware/errorhandler"
 	loggermiddlerware "github.com/dadrus/heimdall/internal/fiber/middleware/logger"
 	tracingmiddleware "github.com/dadrus/heimdall/internal/fiber/middleware/opentelemetry"
+	"github.com/dadrus/heimdall/internal/handler/listener"
 )
 
 var Module = fx.Options( // nolint: gochecknoglobals
@@ -70,23 +71,21 @@ type fiberApp struct {
 }
 
 func registerHooks(lifecycle fx.Lifecycle, logger zerolog.Logger, app fiberApp, conf config.Configuration) {
-	service := conf.Serve.Management
+	ln, err := listener.New(app.App.Config().Network, conf.Serve.Management)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("Could not create listener for the Management service")
+
+		return
+	}
 
 	lifecycle.Append(
 		fx.Hook{
 			OnStart: func(ctx context.Context) error {
 				go func() {
-					// service connections
-					addr := service.Address()
-					logger.Info().Str("_address", addr).Msg("Management service starts listening")
-					if service.TLS != nil {
-						if err := app.App.ListenTLS(addr, service.TLS.Cert, service.TLS.Key); err != nil {
-							logger.Fatal().Err(err).Msg("Could not start Management service")
-						}
-					} else {
-						if err := app.App.Listen(addr); err != nil {
-							logger.Fatal().Err(err).Msg("Could not start Management service")
-						}
+					logger.Info().Str("_address", ln.Addr().String()).Msg("Management service starts listening")
+
+					if err = app.App.Listener(ln); err != nil {
+						logger.Fatal().Err(err).Msg("Could not start Management service")
 					}
 				}()
 

--- a/internal/testsupport/test_decoder.go
+++ b/internal/testsupport/test_decoder.go
@@ -1,12 +1,15 @@
 package testsupport
 
 import (
+	"github.com/knadh/koanf/maps"
 	"gopkg.in/yaml.v3"
 )
 
 func DecodeTestConfig(data []byte) (map[string]any, error) {
 	var out map[string]any
 	err := yaml.Unmarshal(data, &out)
+
+	maps.IntfaceKeysToStrings(out)
 
 	return out, err
 }

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -23,6 +23,42 @@
           "examples": [
             "/path/to/cert.pem"
           ]
+        },
+        "min_version": {
+          "title": "minimum TLS version to support",
+          "description": "Only TLS 1.2 and TLS 1.3 are supported",
+          "type": "string",
+          "enum": [
+            "TLS1.2",
+            "TLS1.3"
+          ],
+          "default": "TLS1.3"
+        },
+        "cipher_suites": {
+          "description": "TLS cipher suites to support. Are only used if TLS v1.2 is configured as minimum version",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+              "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+              "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+              "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+              "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+              "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+              "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+              "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+            ]
+          },
+          "uniqueItems": true,
+          "default": [
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+          ]
         }
       }
     },

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -6,6 +6,15 @@ serve:
       - 0.0.0.0/0
   proxy:
     port: 4469
+    tls:
+      key: /path/to/key/file.pem
+      cert: /path/to/cert/file.pem
+      min_version: TLS1.2
+      cipher_suites:
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+        - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
     trusted_proxies:
       - 0.0.0.0/0
 


### PR DESCRIPTION
closes #152 

Minimal supported version is TLS 1.2 and only PFS cipher suites can be configured (see below). 

The tls configuration has been extended and looks now as follows:

```.yaml
key: <path to the private key in PEM format>
cert: <path to the PEM file containing the certificate and optionally the intermediate CA certificates>
cipher_suites:
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
 - ...
min_version: TLS1.2 # or TLS1.3
```

`cipher_suites` can be configured with the following values:
- TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256


If `min_version` is not configured, it defaults to TLS1.3. If `min_version` is set to "TLS1.2" and `cipher_suites` is not configured, it defaults to the following list:
- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
- TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
- TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
- TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256

**TODOs:**
- [x] implementation & tests
- [x] schema update
- [x] documentation