### PR TITLE
chore: Last polishings for the next release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -293,7 +293,7 @@ jobs:
           replace: "${{ needs.prepare-release.outputs.tag_name }}"
           regex: false
           include: docs/**
-      - name: Update versions.json
+      - name: Update versions JSON document
         id: update-version-json
         if: needs.prepare-release.outputs.release_created
         run: |

--- a/DockerHub-README.md
+++ b/DockerHub-README.md
@@ -42,7 +42,7 @@ Start heimdall:
 
 ```bash
 docker run -t -p 4456:4456 -v $PWD:/heimdall/conf \
-  dadrus/heimdall:latest serve api -c /heimdall/conf/heimdall.yaml
+  dadrus/heimdall:latest serve decision -c /heimdall/conf/heimdall.yaml
 ```
 
 Call the decision service endpoint to emulate behavior of an API-Gateway:

--- a/README.md
+++ b/README.md
@@ -8,15 +8,27 @@
 
 ## Background
 
-Heimdall is inspired by the ZeroTrust idea and also by [Ory's OAthkeeper](https://www.ory.sh/docs/oathkeeper). Some experience with the latter and my inability to update it to include the desired functionality and behavior was Heimdall's born hour. 
+Heimdall is inspired by the ZeroTrust idea and also by [Promerium](https://www.pomerium.com/docs) and [Ory's OAthkeeper](https://www.ory.sh/docs/oathkeeper). Some experience with both and my inability to update the latter one to include the desired functionality and behavior was Heimdall's born hour. 
 
 ## Heimdall's Promise
 
-Heimdall authenticates and authorizes incoming HTTP requests as well as enriches these with further contextual information and finally transforms resulting subject information into a format, required by the upstream services. And all of that can be controlled by each and every backend service individually.
+Heimdall authenticates and authorizes incoming HTTP requests as well as enriches these with further contextual information and finally transforms resulting subject information into a format, required by the upstream services.
 
-It is supposed to be used either as 
-* a **Reverse Proxy** in front of your upstream API or web server that rejects unauthorized requests and forwards authorized ones to your end points, or as 
+This decision and transformation process can be controlled by each and every upstream service individually via rules, respectively rule sets, which heimdall can load from different sources. That way, these rule sets can be deployed together with each particular upstream service without the need to restart or redeploy heimdall. Indeed, these rule sets are optional first class citizens of the upstream service and allow:
+
+* implementation of secure defaults. If no rule matches the incoming request, a default decision and transformation, if configured, is applied. This is the reason for "optional first class citizens" above.
+* configuration of as many authentication, authorization, enrichment/contextualization and transformation methods, supported by heimdall, as required for the particular system. So, if your system requires integration with multiple authentication providers, or you want to migrate from one to another - it is just a matter of configuring them in heimdall.
+* reuse and combination of these methods in as many rules, as  required for the particular system.
+* partial reconfiguration of a particular mechanism in a rule if required by the upstream service.
+* authentication mechanism fall backs
+* implementation of different decision process schemes by combining e.g. authentication mechanisms with error handlers to drive authentication mechanism specific error handling strategies.
+* execution of authorization and contextualization mechanisms in any order.
+
+In sense of a deployment, heimdall is supposed to be used either as
+* a **Reverse Proxy** in front of your upstream service/API or web server that rejects unauthorized requests and forwards authorized ones to your end points, or as
 * a **Decision API**, which integrates with your API Gateway (Kong, NGNIX, Envoy, Traefik, etc) and then acts as a Policy Decision Point.
+
+Head over to the [documentation](https://dadrus.github.io/heimdall/) for details or if you would like to give it a try.
 
 ## Beyond the Functionality
 
@@ -29,4 +41,6 @@ Heimdall's main focus points beyond its functionality are:
 
 The current implementation is an alpha version. That means it does not solve all the problems heimdall aims to solve. With other words a lot of functionality is missing. In addition, alpha version means, there will be breaking changes. Nevertheless, the code base is stable and pretty good tested. Functionality already supported can be found in [Release descriptions](https://github.com/dadrus/heimdall/releases). Planned features can be found in the defined [Milestones](https://github.com/dadrus/heimdall/milestones).
 
-If you like to give it a try, checkout out the [documentation](https://dadrus.github.io/heimdall/).
+If you like the project - please give it a :star:. \
+If you miss something, or found a bug, you're very welcome to contribute. \
+If you would like to support, reach out to me :wink:.

--- a/docs/content/docs/configuration/reference/configuration_reference.adoc
+++ b/docs/content/docs/configuration/reference/configuration_reference.adoc
@@ -288,7 +288,7 @@ rules:
       - error_handler: authenticate_with_kratos
 
   providers:
-    file:
+    file_system:
       src: test_rules.yaml
       watch: true
 

--- a/docs/content/docs/configuration/reference/configuration_types.adoc
+++ b/docs/content/docs/configuration/reference/configuration_types.adoc
@@ -293,8 +293,8 @@ CAUTION: These headers are not analyzed by heimdall and are just forwarded to th
 
 * *`enable_http_cache`* _bool_ (optional)
 +
-Whether HTTP caching according to [RFC 7234](https://www.rfc-editor.org/rfc/rfc7234) should be used. Defaults to `false` if not otherwise stated in the description of the configuration type, making use of the `endpoint` property. If set to `true` heimdall will strictly follow the requirements from RFC 7234 and cache the responses if possible and reuse these if still valid.
-
+Whether HTTP caching according to https://www.rfc-editor.org/rfc/rfc7234[RFC 7234] should be used. Defaults to `false` if not otherwise stated in the description of the configuration type, making use of the `endpoint` property. If set to `true` heimdall will strictly follow the requirements from RFC 7234 and cache the responses if possible and reuse these if still valid.
++
 NOTE: If the endpoint referenced by the URL does not provide any explicit expiration time, no heuristic freshness lifetime is calculated. Heimdall treats such responses as not cacheable.
 
 .Endpoint configuration

--- a/docs/content/docs/configuration/rules/providers.adoc
+++ b/docs/content/docs/configuration/rules/providers.adoc
@@ -74,7 +74,7 @@ Each entry of that array supports all the properties defined by link:{{< relref 
 +
 This property can be used to create kind of a namespace for the rule sets retrieved from the different endpoints. If set, the provider checks whether the urls specified in all rules retrieved from the referenced endpoint have the defined path prefix. If not, a warning is emitted and the rule set is ignored. This can be used to ensure a rule retrieved from one endpoint does not collide with a rule from another endpoint.
 
-NOTE: HTTP caching according to [RFC 7234](https://www.rfc-editor.org/rfc/rfc7234) is enabled by default. It can be disabled by setting `enable_http_cache` to `false`.
+NOTE: HTTP caching according to https://www.rfc-editor.org/rfc/rfc7234[RFC 7234] is enabled by default. It can be disabled by setting `enable_http_cache` to `false`.
 
 This provider doesn't need any additional configuration for a rule set. So the contents of files can be just a list of rules as described in link:{{< relref "rule_configuration.adoc#_rule_set" >}}[Rule Sets].
 

--- a/docs/content/docs/operations/cli.adoc
+++ b/docs/content/docs/operations/cli.adoc
@@ -46,6 +46,10 @@ Generates the autocompletion script for the specified shell.
 +
 Calls heimdall's healthcheck endpoint to verify the status of the deployment.
 
+* `help`
++
+Provides an overview about the available commands and their descriptions.
+
 * `serve`
 +
 Starts heimdall in the decision, or the reverse proxy operation mode.

--- a/docs/content/docs/operations/security.adoc
+++ b/docs/content/docs/operations/security.adoc
@@ -21,9 +21,21 @@ As documented in link:{{< relref "/docs/getting_started/concepts.adoc" >}}[Conce
 
 Both is required to enable heimdall building the certificate chain for TLS server certificate verification purpose. If heimdall fails doing so, the connection will be dropped.
 
+As written above, heimdall makes use of the OS wide trust store to build the certificate chain. The most common installation directory on a Linux system for that trust store is the `/etc/ssl/certs` directory. In addition to the separate root and intermediate CA certificates, it also contains a `ca-certificates.crt` file, containing all installed certificates as well. This file is used by heimdall for the aforesaid purpose.
+
 [NOTE]
 ====
-heimdall Docker image is shipped without any certificates by intention to ensure you take care about the up-to-date status of the trust store. This way, you have to mount the OS trust store into heimdall's container to enable its usage.
+heimdall Docker image is shipped without any certificates by intention to ensure you take care about the up-to-date status of the trust store. This way, you use heimdall in a Docker image, you have to mount the OS trust store into heimdall's container to enable its usage.
+
+E.g.
+[source, bash]
+----
+docker run -t -p 4456:4456 \
+  -v $PWD:/heimdall/conf \
+  -v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro \
+   dadrus/heimdall:latest serve decision \
+  -c /heimdall/conf/heimdall.yaml
+----
 ====
 
 The verification of TLS server certificates is not the single configuration option. You should also ensure heimdall's services, you're using, are configured to be available via TLS as well. See link:{{< relref "/docs/configuration/services/configuration_types.adoc#_tls" >}}[TLS Configuration] for all available options.

--- a/go.sum
+++ b/go.sum
@@ -568,8 +568,6 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=
-github.com/go-co-op/gocron v1.17.1 h1:oEu3xGNVn9IGukN3JPzOsfaBoTGYmUVHtR9d1cv1cq8=
-github.com/go-co-op/gocron v1.17.1/go.mod h1:IpDBSaJOVfFw7hXZuTag3SCSkqazXBBUkbQ1m1aesBs=
 github.com/go-co-op/gocron v1.18.0 h1:SxTyJ5xnSN4byCq7b10LmmszFdxQlSQJod8s3gbnXxA=
 github.com/go-co-op/gocron v1.18.0/go.mod h1:sD/a0Aadtw5CpflUJ/lpP9Vfdk979Wl1Sg33HPHg0FY=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
@@ -1270,7 +1268,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
-github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021 h1:0XM1XL/OFFJjXsYXlG30spTkV/E9+gmd5GD1w2HE8xM=
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/pquerna/cachecontrol v0.1.0 h1:yJMy84ti9h/+OEWa752kBTKv4XC30OtVVHYv/8cTqKc=
 github.com/pquerna/cachecontrol v0.1.0/go.mod h1:NrUG3Z7Rdu85UNR3vm7SOsl1nFIeSiQnrHV5K9mBcUI=
@@ -1704,8 +1701,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20221106115401-f9659909a136 h1:Fq7F/w7MAa1KJ5bt2aJ62ihqp9HDcRuyILskkpIAurw=
-golang.org/x/exp v0.0.0-20221106115401-f9659909a136/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/exp v0.0.0-20221108204230-3ae49d0fc9cf h1:Uf/fWQzwBe27XVZotR+pJ9BCzYXz60I3rBZgBxq6JAo=
 golang.org/x/exp v0.0.0-20221108204230-3ae49d0fc9cf/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=


### PR DESCRIPTION
addresses:
* typos found in documentation or other things forgotten to write
* readme updates
* flickering tests
* ci job misconfigurations found during the last release