### PR TITLE
refactor!: Remote authorizer uses CEL instead of ECMAScript for response verification purposes

### DIFF
--- a/docs/content/docs/configuration/pipeline/authorizers.adoc
+++ b/docs/content/docs/configuration/pipeline/authorizers.adoc
@@ -159,7 +159,7 @@ The usage of this type of configuration makes sense in a pipeline, which combine
 
 This authorizer allows communication with other systems, like https://www.openpolicyagent.org/[Open Policy Agent], https://www.ory.sh/docs/keto/[Ory Keto], etc. for the actual authorization purpose. If the used endpoint answers with a not 2xx HTTP response code, this authorizer assumes, the authorization has failed and denies the request. So, the successful execution of the pipeline stops, resulting in the execution of the error handlers. Otherwise, if no script for the verification of the response if defined, the authorizer assumes, the request has been authorized. If a script is defined and does not fail, the authorization succeeds.
 
-If your authorization system provides a payload in the response, Heimdall inspects the `Content-Type` header to prepare the payload for further usage, e.g. in the payload verification script, or in a link:{{< relref "#_local" >}}[Local] authorizer. It can however deal only with a content type, which either ends with `json` or which is `application/x-www-form-urlencoded`. In these two cases, the payload is decoded and made available for the script as well as a map in the `.Subject.Attributes`. Otherwise, the payload is treated as string and made also available for the script and in the `.Subject.Attributes` property. To avoid overwriting of existing attributes, this object is however not available on the top level, but under a key named by the `id` of the authorizer (See also the example below).
+If your authorization system provides a payload in the response, heimdall inspects the `Content-Type` header to prepare the payload for further usage, e.g. for payload verification expressions, or for a link:{{< relref "#_local_cel" >}}[Local (CEL)] authorizer. If the content type does either end with `json` or is `application/x-www-form-urlencoded`, the payload is decoded, so key based access to the corresponding attributes is possible, otherwise it is made available as well, but as a simple string. In all cases this value is available for the authorization expressions as well as in the `Subject.Attributes` property under a key named by the `id` of the authorizer (See also the example below).
 
 To enable the usage of this authorizer, you have to set the `type` property to `remote`.
 
@@ -173,9 +173,13 @@ The API endpoint of your authorization system. At least the `url` must be config
 +
 Your template with definitions required to communicate to the authorization endpoint. See also link:{{< relref "overview.adoc#_templating" >}}[Templating].
 
-* *`script`*:  _string_ (optional, overridable)
+* *`expressions`*: _link:{{< relref "/docs/configuration/reference/configuration_types.adoc#_authorization_expression">}}[Authorization Expression] array_ (optional, overridable)
 +
-ECMAScript which executed further authorization logic on the given response from the authorization endpoint (See also link:{{< relref "overview.adoc#_scripting" >}}[Scripting]). Heimdall expects the script to return either `true`, if the authorization was successful, or otherwise `false`, or to raise an error. In latter case the message from the raised error will also be logged. Compared to the link:{{< relref "#_local" >}}[Local] authorizer, only `heimdall.Payload` object is available, which contains the response from the authorization endpoint, as well as the `console.log` function, which enables logging from the script. Latter can become handy during development of debugging. The output is only available if debug log level is set.
+List of https://github.com/google/cel-spec[CEL] expressions which define the logic to be applied to the response returned by the endpoint. All expressions are expected to evaluate to `true` if the authorization was successful. If any of the expressions evaluates to `false`, the authorization fails and the message defined by the failed expression will be logged.
++
+Each expression has access to the following link:{{< relref "overview.adoc#_evaluation_objects" >}}[Evaluation Objects]:
+
+** `Payload` of type link:{{< relref "overview.adoc#_payload" >}}[Payload].
 
 * *`forward_response_headers_to_upstream`*: _string array_ (optional, overridable)
 +
@@ -206,9 +210,11 @@ config:
         password: SuperSecretPassword
   payload: |
     { "input": { "user": {{ quote .Subject.ID }}, "access": "write" } }
-  script: |
-    heimdall.Payload.result === true
+  expressions:
+    - expression: |
+        Payload.result == true
+      message: User does not have write access
 ----
 
-In this case, since an OPA response could look like `{ "result": true }` or `{ "result": false }`, heimdall makes the response also available under `.Subject.Attributes["user_can_write"]` as a map, with `"user_can_write"` being the id of the authorizer in this example.
+In this case, since an OPA response could look like `{ "result": true }` or `{ "result": false }`, heimdall makes the response also available under `Subject.Attributes["user_can_write"]` as a map, with `"user_can_write"` being the id of the authorizer in this example.
 ====

--- a/docs/content/docs/configuration/reference/configuration_reference.adoc
+++ b/docs/content/docs/configuration/reference/configuration_reference.adoc
@@ -207,16 +207,18 @@ pipeline:
       type: allow
     - id: deny_all_authorizer
       type: deny
-    - id: keto_authorizer
+    - id: remote_authorizer
       type: remote
       config:
         endpoint:
-          url: http://keto
+          url: http://my-authz-system
           method: POST
           headers:
             foo-bar: "{{ .Subject.ID }}"
         payload: "https://bla.bar"
-        script: "heimdall.Payload.response === true"
+        expressions:
+          - expression: |
+              Payload.response == true
         forward_response_headers_to_upstream:
           - bla-bar
     - id: attributes_based_authorizer

--- a/docs/content/docs/configuration/reference/configuration_reference.adoc
+++ b/docs/content/docs/configuration/reference/configuration_reference.adoc
@@ -225,6 +225,11 @@ pipeline:
       type: local
       config:
         script: "console.log('New JS script')"
+    - id: user_is_admin_authz
+      type: cel
+      config:
+        expressions:
+          - expression: "'admin' in Subject.Attributes.groups"
 
   hydrators:
     - id: subscription_hydrator

--- a/docs/content/docs/guides/opa.adoc
+++ b/docs/content/docs/guides/opa.adoc
@@ -54,8 +54,9 @@ pipeline:
          url: https://opa.local/v1/data/share_photos/policy/allow
        payload: |
          { "input": { "user": {{ quote .Subject.ID }}, "path": {{ quote .RequestURL.Path }} } }
-       script: |
-         heimdall.Payload.result === true
+       expressions:
+         - expression: |
+             Payload.result == true
 ----
 
 Here the entire authorization happens within heimdall and is completely outsourced from the business logic of our sharing service.

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -211,11 +211,17 @@ pipeline:
         payload: https://bla.bar
         forward_response_headers_to_upstream:
           - bla-bar
-        script: "throw 'foobar'"
+        expressions:
+          - expression: "Payload.foo == 'bar'"
     - id: attributes_based_authorizer
       type: local
       config:
         script: "console.log('New JS script')"
+    - id: attributes_based_authorizer_2
+      type: cel
+      config:
+        expressions:
+          - expression: "'admin' in Subject.Attributes.groups"
   hydrators:
     - id: subscription_hydrator
       type: generic

--- a/internal/pipeline/authorizers/cel_authorizer.go
+++ b/internal/pipeline/authorizers/cel_authorizer.go
@@ -2,6 +2,7 @@ package authorizers
 
 import (
 	"fmt"
+
 	"github.com/google/cel-go/cel"
 	"github.com/rs/zerolog"
 

--- a/internal/pipeline/authorizers/cel_authorizer_test.go
+++ b/internal/pipeline/authorizers/cel_authorizer_test.go
@@ -103,7 +103,6 @@ expressions:
 
 				require.NoError(t, err)
 				assert.Equal(t, "authz", auth.HandlerID())
-				assert.NotNil(t, auth.env)
 				assert.NotEmpty(t, auth.expressions)
 			},
 		},

--- a/internal/pipeline/authorizers/cellib/library.go
+++ b/internal/pipeline/authorizers/cellib/library.go
@@ -22,6 +22,7 @@ func (heimdallLibrary) CompileOptions() []cel.EnvOption {
 			reflect.TypeOf(&subject.Subject{}),
 			reflect.TypeOf(&Request{}),
 			reflect.TypeOf(&URL{})),
+		cel.Variable("Payload", cel.DynType),
 		cel.Variable("Subject", cel.DynType),
 		cel.Variable("Request", cel.ObjectType(requestType.TypeName())),
 		cel.Function("Header", cel.MemberOverload("Header",

--- a/internal/pipeline/authorizers/expression.go
+++ b/internal/pipeline/authorizers/expression.go
@@ -1,0 +1,48 @@
+package authorizers
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+)
+
+var errCELResultType = errors.New("result type error")
+
+type Expression struct {
+	Value   string `mapstructure:"expression"`
+	Message string `mapstructure:"message"`
+
+	program cel.Program
+}
+
+func (e *Expression) Compile(env *cel.Env) error {
+	ast, iss := env.Compile(e.Value)
+	if iss.Err() != nil {
+		return iss.Err()
+	}
+
+	ast, iss = env.Check(ast)
+	if iss != nil && iss.Err() != nil {
+		return iss.Err()
+	}
+
+	if !reflect.DeepEqual(ast.OutputType(), cel.BoolType) {
+		return fmt.Errorf("%w: wanted bool, got %v", errCELResultType, ast.OutputType())
+	}
+
+	prg, err := env.Program(ast, cel.EvalOptions(cel.OptOptimize))
+	e.program = prg
+
+	return err
+}
+
+func (e *Expression) Eval(obj any) (bool, error) {
+	out, _, err := e.program.Eval(obj)
+	if err != nil {
+		return false, err
+	}
+
+	return out.Value() == true, nil
+}

--- a/internal/pipeline/authorizers/remote_authorizer_test.go
+++ b/internal/pipeline/authorizers/remote_authorizer_test.go
@@ -109,6 +109,24 @@ payload: "{{ .Subject.ID }}"
 			},
 		},
 		{
+			uc: "configuration with invalid expression",
+			id: "authz",
+			config: []byte(`
+endpoint:
+  url: http://foo.bar
+payload: "{{ .Subject.ID }}"
+expressions:
+  - expression: "foo == 'bar'"
+`),
+			assert: func(t *testing.T, err error, auth *remoteAuthorizer) {
+				t.Helper()
+
+				require.Error(t, err)
+				assert.ErrorIs(t, err, heimdall.ErrConfiguration)
+				assert.Contains(t, err.Error(), "failed to compile")
+			},
+		},
+		{
 			uc: "full configuration",
 			id: "authz",
 			config: []byte(`
@@ -253,6 +271,26 @@ cache_ttl: 1s
 				assert.Empty(t, configured.headersForUpstream)
 				assert.NotNil(t, configured.ttl)
 				assert.Equal(t, "authz3", configured.HandlerID())
+			},
+		},
+		{
+			uc: "configuration with invalid new expression",
+			id: "authz",
+			prototypeConfig: []byte(`
+endpoint:
+  url: http://foo.bar
+payload: bar
+`),
+			config: []byte(`
+expressions:
+  - expression: "foo == 'bar'"
+`),
+			assert: func(t *testing.T, err error, prototype *remoteAuthorizer, configured *remoteAuthorizer) {
+				t.Helper()
+
+				require.Error(t, err)
+				assert.ErrorIs(t, err, heimdall.ErrConfiguration)
+				assert.Contains(t, err.Error(), "failed to compile")
 			},
 		},
 		{

--- a/internal/pipeline/authorizers/remote_authorizer_test.go
+++ b/internal/pipeline/authorizers/remote_authorizer_test.go
@@ -607,8 +607,7 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 			configureCache: func(t *testing.T, cch *mocks.MockCache, auth *remoteAuthorizer, sub *subject.Subject) {
 				t.Helper()
 
-				cacheKey, err := auth.calculateCacheKey(sub)
-				require.NoError(t, err)
+				cacheKey := auth.calculateCacheKey(sub)
 
 				cch.On("Get", cacheKey).Return(nil)
 				cch.On("Set", cacheKey,
@@ -658,8 +657,7 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 			configureCache: func(t *testing.T, cch *mocks.MockCache, auth *remoteAuthorizer, sub *subject.Subject) {
 				t.Helper()
 
-				cacheKey, err := auth.calculateCacheKey(sub)
-				require.NoError(t, err)
+				cacheKey := auth.calculateCacheKey(sub)
 
 				cch.On("Get", cacheKey).Return(nil)
 				cch.On("Set", cacheKey, mock.Anything, auth.ttl)

--- a/internal/pipeline/subject/subject.go
+++ b/internal/pipeline/subject/subject.go
@@ -1,6 +1,21 @@
 package subject
 
+import (
+	"crypto/sha256"
+
+	"github.com/goccy/go-json"
+)
+
 type Subject struct {
 	ID         string         `json:"id"`
 	Attributes map[string]any `json:"attributes"`
+}
+
+func (s *Subject) Hash() []byte {
+	hash := sha256.New()
+	rawSub, _ := json.Marshal(s)
+
+	hash.Write(rawSub)
+
+	return hash.Sum(nil)
 }

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -319,6 +319,30 @@
         }
       }
     },
+    "expressionList": {
+      "description": "A list of authorization expressions to evaluate",
+      "type": "array",
+      "uniqueItems": true,
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["expression"],
+        "properties": {
+          "expression": {
+            "description": "The actual expression",
+            "type": "string",
+            "examples": [
+              "Subject.ID == foo"
+            ]
+          },
+          "message": {
+            "description": "Message to log if the expression fails",
+            "type": "string"
+          }
+        }
+      }
+    },
     "ruleSetEndpointConfiguration": {
       "description": "Endpoint to load rule sets from",
       "type": "object",
@@ -1034,6 +1058,33 @@
         }
       }
     },
+    "authorizerLocalCEL": {
+      "description": "Authorizer, which acts on subject attributes and the request context by using a CEL",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "cel"
+        },
+        "id": {
+          "description": "The unique id of the authorizer to be used in the rule definition",
+          "type": "string"
+        },
+        "config": {
+          "description": "Local Authorizer Configuration",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "expressions"
+          ],
+          "properties": {
+            "expressions": {
+              "$ref": "#/definitions/expressionList"
+            }
+          }
+        }
+      }
+    },
     "authorizerRemote": {
       "description": "Remote Authorizer",
       "type": "object",
@@ -1061,9 +1112,8 @@
               "description": "The Go template with access to heimdall.Context and Subject used for request's HTTP body generation",
               "type": "string"
             },
-            "script": {
-              "description": "JavaScript which defines the required logic to verify the response from the endpoint",
-              "type": "string"
+            "expressions": {
+              "$ref": "#/definitions/expressionList"
             },
             "forward_response_headers_to_upstream": {
               "description": "A list of headers to forward to the upstream service.",
@@ -1753,6 +1803,9 @@
               },
               {
                 "$ref": "#/definitions/authorizerLocal"
+              },
+              {
+                "$ref": "#/definitions/authorizerLocalCEL"
               }
             ]
           }


### PR DESCRIPTION
addresses #329 

This PR introduces a **breaking change** and changes the way how the `remote` authorizer can handle structured responses from the endpoint (authorization system) it uses. Before this PR, one could optionally use a `script` property to check the response. With this PR this property is replaced by the `expressions` property (still optional), which can have a list of CEL expressions.

The following example shows the changes in detail:

Given an OPA policy available under `https://opa.local/v1/data/share_photos/policy/allow` which results in `{"result": true}` if authorization was successful.

**Old Config**:
```.yaml
id: photos_access
type: remote
config:
  endpoint:
    url: https://opa.local/v1/data/share_photos/policy/allow
  payload: |
    { "input": { "user": {{ quote .Subject.ID }}, "path": {{ quote .RequestURL.Path }} } }
  script: |
    heimdall.Payload.result === true
```

**New Config**
```.yaml
id: photos_access
type: remote
config:
  endpoint:
    url: https://opa.local/v1/data/share_photos/policy/allow
  payload: |
    { "input": { "user": {{ quote .Subject.ID }}, "path": {{ quote .RequestURL.Path }} } }
  expressions:
    - expression: |
        Payload.result == true
```