### PR TITLE
feat: Simpler endpoint configuration

### DIFF
--- a/docs/content/docs/configuration/reference/types.adoc
+++ b/docs/content/docs/configuration/reference/types.adoc
@@ -308,6 +308,8 @@ So with `10s` you can define the duration of 10 seconds and with `2h` you can sa
 
 The Endpoint type defines properties required for the communication with an endpoint.
 
+If only the URL is required to be set, you can specify it by using just a string. If more than the URL is required to be specified, following properties are available:
+
 * *`url`* _string_ (mandatory)
 +
 The actual url of the endpoint.
@@ -336,7 +338,15 @@ Whether HTTP caching according to https://www.rfc-editor.org/rfc/rfc7234[RFC 723
 +
 NOTE: If the endpoint referenced by the URL does not provide any explicit expiration time, no heuristic freshness lifetime is calculated. Heimdall treats such responses as not cacheable.
 
-.Endpoint configuration
+.Endpoint configuration as string
+====
+[source, text]
+----
+http://foo.bar
+----
+====
+
+.Structured Endpoint configuration
 ====
 
 [source, yaml]

--- a/docs/content/docs/configuration/rules/pipeline_mechanisms/authenticators.adoc
+++ b/docs/content/docs/configuration/rules/pipeline_mechanisms/authenticators.adoc
@@ -144,8 +144,7 @@ This example shows how to configure this authenticator to work with an authentic
 id: session_cookie
 type: generic
 config:
-  identity_info_endpoint:
-    url: http://my-auth.system/sessions/whoami
+  identity_info_endpoint: http://my-auth.system/sessions/whoami
   authentication_data_source:
     - cookie: my_session
   subject:
@@ -159,6 +158,9 @@ config:
     time_format: "2006-01-02T15:04:05.999999Z07"
     validity_leeway: 10s
 ----
+
+This example does also show how an endpoint can be configured by just specifying the URL as string, which is the simplest way for endpoint configuration.
+
 ====
 
 .Configuration of Generic authenticator to work with a Bearer token

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -164,7 +164,7 @@ rules:
             attributes: "@this"
             id: sub
           allow_fallback_on_error: true
-      - id: jwt_authenticator
+      - id: jwt_authenticator1
         type: jwt
         config:
           jwks_endpoint:
@@ -190,6 +190,21 @@ rules:
           allow_fallback_on_error: true
           validate_jwk: true
           trust_store: /opt/heimdall/trust_store.pem
+      - id: jwt_authenticator2
+        type: jwt
+        config:
+          jwks_endpoint: http://bar/token
+          assertions:
+             audience:
+               - bla
+             scopes:
+               - foo
+             allowed_algorithms:
+               - RSA
+             issuers:
+               - bla
+          allow_fallback_on_error: true
+          validate_jwk: true
       - id: basic_auth_authenticator
         type: basic_auth
         config:

--- a/internal/endpoint/mapstructure_decoder.go
+++ b/internal/endpoint/mapstructure_decoder.go
@@ -17,10 +17,6 @@ func DecodeEndpointHookFunc() mapstructure.DecodeHookFunc {
 			return data, nil
 		}
 
-		if to != reflect.TypeOf(Endpoint{}) {
-			return data, nil
-		}
-
 		dect := reflect.ValueOf(&ep).Elem().Type()
 		if !dect.AssignableTo(to) {
 			return data, nil

--- a/internal/endpoint/mapstructure_decoder.go
+++ b/internal/endpoint/mapstructure_decoder.go
@@ -9,6 +9,29 @@ import (
 	"github.com/dadrus/heimdall/internal/x/errorchain"
 )
 
+func DecodeEndpointHookFunc() mapstructure.DecodeHookFunc {
+	return func(from reflect.Type, to reflect.Type, data any) (any, error) {
+		var ep Endpoint
+
+		if from.Kind() != reflect.String {
+			return data, nil
+		}
+
+		if to != reflect.TypeOf(Endpoint{}) {
+			return data, nil
+		}
+
+		dect := reflect.ValueOf(&ep).Elem().Type()
+		if !dect.AssignableTo(to) {
+			return data, nil
+		}
+
+		// Already checked above
+		// nolint: forcetypeassert
+		return Endpoint{URL: data.(string)}, nil
+	}
+}
+
 func DecodeAuthenticationStrategyHookFunc() mapstructure.DecodeHookFunc {
 	return func(from reflect.Type, to reflect.Type, data any) (any, error) {
 		var as AuthenticationStrategy

--- a/internal/rules/mechanisms/authenticators/config_decoder.go
+++ b/internal/rules/mechanisms/authenticators/config_decoder.go
@@ -13,10 +13,11 @@ func decodeConfig(input any, output any) error {
 	dec, err := mapstructure.NewDecoder(
 		&mapstructure.DecoderConfig{
 			DecodeHook: mapstructure.ComposeDecodeHookFunc(
+				endpoint.DecodeAuthenticationStrategyHookFunc(),
+				endpoint.DecodeEndpointHookFunc(),
 				mapstructure.StringToTimeDurationHookFunc(),
 				extractors.DecodeCompositeExtractStrategyHookFunc(),
 				oauth2.DecodeScopesMatcherHookFunc(),
-				endpoint.DecodeAuthenticationStrategyHookFunc(),
 				truststore.DecodeTrustStoreHookFunc(),
 			),
 			Result:      output,

--- a/internal/rules/mechanisms/authorizers/config_decoder.go
+++ b/internal/rules/mechanisms/authorizers/config_decoder.go
@@ -1,6 +1,7 @@
 package authorizers
 
 import (
+	"github.com/dadrus/heimdall/internal/endpoint"
 	"github.com/mitchellh/mapstructure"
 
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/template"
@@ -10,6 +11,8 @@ func decodeConfig(input any, output any) error {
 	dec, err := mapstructure.NewDecoder(
 		&mapstructure.DecoderConfig{
 			DecodeHook: mapstructure.ComposeDecodeHookFunc(
+				endpoint.DecodeAuthenticationStrategyHookFunc(),
+				endpoint.DecodeEndpointHookFunc(),
 				mapstructure.StringToTimeDurationHookFunc(),
 				template.DecodeTemplateHookFunc(),
 			),

--- a/internal/rules/mechanisms/authorizers/config_decoder.go
+++ b/internal/rules/mechanisms/authorizers/config_decoder.go
@@ -1,9 +1,9 @@
 package authorizers
 
 import (
-	"github.com/dadrus/heimdall/internal/endpoint"
 	"github.com/mitchellh/mapstructure"
 
+	"github.com/dadrus/heimdall/internal/endpoint"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/template"
 )
 

--- a/internal/rules/mechanisms/contextualizers/config_decoder.go
+++ b/internal/rules/mechanisms/contextualizers/config_decoder.go
@@ -11,8 +11,9 @@ func decodeConfig(input any, output any) error {
 	dec, err := mapstructure.NewDecoder(
 		&mapstructure.DecoderConfig{
 			DecodeHook: mapstructure.ComposeDecodeHookFunc(
-				mapstructure.StringToTimeDurationHookFunc(),
 				endpoint.DecodeAuthenticationStrategyHookFunc(),
+				endpoint.DecodeEndpointHookFunc(),
+				mapstructure.StringToTimeDurationHookFunc(),
 				template.DecodeTemplateHookFunc(),
 			),
 			Result:      output,

--- a/internal/rules/provider/httpendpoint/config_decoder.go
+++ b/internal/rules/provider/httpendpoint/config_decoder.go
@@ -11,6 +11,7 @@ func decodeConfig(input any, output any) error {
 		&mapstructure.DecoderConfig{
 			DecodeHook: mapstructure.ComposeDecodeHookFunc(
 				endpoint.DecodeAuthenticationStrategyHookFunc(),
+				endpoint.DecodeEndpointHookFunc(),
 				mapstructure.StringToTimeDurationHookFunc(),
 			),
 			Result:      output,

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -419,79 +419,91 @@
     },
     "endpointConfiguration": {
       "description": "Endpoint to to communicate to",
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "url"
-      ],
-      "properties": {
-        "url": {
-          "description": "The URL to communicate to.",
-          "type": "string",
-          "format": "uri",
-          "examples": [
-            "https://session-store-host"
-          ]
-        },
-        "method": {
-          "description": "The HTTP Method to use when communicating with the endpoint",
-          "type": "string",
-          "default": "GET",
-          "examples": [
-            "GET",
-            "POST"
-          ]
-        },
-        "headers": {
-          "description": "The HTTP headers to be send to the end point",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "minLength": 0,
-          "uniqueItems": true,
-          "default": []
-        },
-        "retry": {
-          "description": "How the implementation should behave when trying to access the configured endpoint",
+      "anyOf": [
+        {
           "type": "object",
           "additionalProperties": false,
+          "required": [
+            "url"
+          ],
           "properties": {
-            "give_up_after": {
-              "description": "When the implementation should finally give up, if the endpoint is not answering.",
+            "url": {
+              "description": "The URL to communicate to.",
               "type": "string",
-              "default": "1s",
-              "pattern": "^[0-9]+(ns|us|ms|s|m|h)$"
+              "format": "uri",
+              "examples": [
+                "https://session-store-host"
+              ]
             },
-            "max_delay": {
-              "description": "How long the implementation should wait between the attempts",
+            "method": {
+              "description": "The HTTP Method to use when communicating with the endpoint",
               "type": "string",
-              "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
-              "default": "100ms"
+              "default": "GET",
+              "examples": [
+                "GET",
+                "POST"
+              ]
+            },
+            "headers": {
+              "description": "The HTTP headers to be send to the end point",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              },
+              "minLength": 0,
+              "uniqueItems": true,
+              "default": []
+            },
+            "retry": {
+              "description": "How the implementation should behave when trying to access the configured endpoint",
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "give_up_after": {
+                  "description": "When the implementation should finally give up, if the endpoint is not answering.",
+                  "type": "string",
+                  "default": "1s",
+                  "pattern": "^[0-9]+(ns|us|ms|s|m|h)$"
+                },
+                "max_delay": {
+                  "description": "How long the implementation should wait between the attempts",
+                  "type": "string",
+                  "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
+                  "default": "100ms"
+                }
+              }
+            },
+            "auth": {
+              "description": "How to authenticate against the endpoint",
+              "type": "object",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/endpointAuthApiKeyProperties"
+                },
+                {
+                  "$ref": "#/definitions/endpointAuthBasicAuthProperties"
+                },
+                {
+                  "$ref": "#/definitions/endpointAuthClientCredentialsProperties"
+                }
+              ]
+            },
+            "enable_http_cache": {
+              "description": "Enables or disables http cache usage according to RFC 7234",
+              "type": "boolean",
+              "default": false
             }
           }
         },
-        "auth": {
-          "description": "How to authenticate against the endpoint",
-          "type": "object",
-          "oneOf": [
-            {
-              "$ref": "#/definitions/endpointAuthApiKeyProperties"
-            },
-            {
-              "$ref": "#/definitions/endpointAuthBasicAuthProperties"
-            },
-            {
-              "$ref": "#/definitions/endpointAuthClientCredentialsProperties"
-            }
+        {
+          "type": "string",
+          "description": "If only URL should be configured for the endpoint",
+          "format": "uri-reference",
+          "examples": [
+            "http://some.endpoint"
           ]
-        },
-        "enable_http_cache": {
-          "description": "Enables or disables http cache usage according to RFC 7234",
-          "type": "boolean",
-          "default": false
         }
-      }
+      ]
     },
     "endpointAuthBasicAuthProperties": {
       "properties": {


### PR DESCRIPTION
This PR closes #273

With this PR an endpoint can not only be configured in a structured way, like

```.yaml
endpoint:
  url: http://foo.bar
```

but also like

```.yaml
endpoint: http://foo.bar
```

which will reduce the amount of yaml code, if only the actual URL is required to be configured and the remaining parts of the endpoint configuration can remain mechanism default.