### PR TITLE
feat: Support for environment variables substitution in config file

### DIFF
--- a/docs/content/docs/getting_started/configuration_introduction.adoc
+++ b/docs/content/docs/getting_started/configuration_introduction.adoc
@@ -45,6 +45,28 @@ At start up, heimdall searches for static configuration in a file named `heimdal
 
 You can also override this using the `config` argument: `heimdall --config <path-to-your-config-file>`.
 
+The values in the configuration file can also make use of environment variables. Access to these happens using Bash syntax. Following expressions are supported:
+
+* `${VAR}`
++
+Evaluates to the value of the env variable named `VAR`.
+* `${VAR=$DEFAULT}`, or `${VAR-$DEFAULT}`
++
+If the env variable `VAR` is not set, evaluates the expression as `$DEFAULT` otherwise to the value of the env variable `VAR`.
+* `${VAR:=$DEFAULT}` or `${VAR:-$DEFAULT}`
++
+If the env variable `VAR` is not set or is empty, evaluates the expression as `$DEFAULT` otherwise to the value of the env variable `VAR`.
+* `${VAR=OTHER}`
++
+If the env variable `VAR` is not set, evaluates the expression to `OTHER` otherwise to the value of the env variable `VAR`.
+* `${VAR:=OTHER}`
++
+If if the env variable `VAR` is not set or is empty, evaluates the expression to `OTHER` otherwise to the value of the env variable `VAR`.
+
+* `${VAR+$OTHER}` or `${VAR:+$OTHER}`
++
+If the env variable `VAR` is set, evaluates the expression as `$OTHER` otherwise as empty string.
+
 .Possible minimal fully working configuration
 ====
 
@@ -71,6 +93,29 @@ rules:
     execute:
       - authenticator: anonymous_authenticator
       - unifier: create_jwt
+----
+====
+
+.Configuration with a mechanism defined using environment variables substitution
+====
+[source, yaml]
+----
+rules:
+  mechanisms:
+    authenticators:
+    - id: hydra_authenticator
+      type: oauth2_introspection
+      config:
+        introspection_endpoint:
+          url: http://hydra:4445/oauth2/introspect
+          auth:
+            type: basic_auth
+            config:
+              user: ${INTROSPECT_EP_USER}
+              password: ${INTROSPECT_EP_PASSWORD}
+    unifiers:
+    - id: create_jwt
+      type: jwt
 ----
 ====
 
@@ -156,4 +201,3 @@ and using the environment variables with
 ----
 HEIMDALLCFG_TRACING_SERVICE__NAME=foobar
 ----
-

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3
+	github.com/a8m/envsubst v1.3.0
 	github.com/dlclark/regexp2 v1.7.0
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-co-op/gocron v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -184,6 +184,8 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:H
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/a8m/envsubst v1.3.0 h1:GmXKmVssap0YtlU3E230W98RWtWCyIZzjtf1apWWyAg=
+github.com/a8m/envsubst v1.3.0/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/internal/config/parser/yaml.go
+++ b/internal/config/parser/yaml.go
@@ -1,9 +1,10 @@
 package parser
 
 import (
+	"github.com/a8m/envsubst"
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/yaml"
-	"github.com/knadh/koanf/providers/file"
+	"github.com/knadh/koanf/providers/rawbytes"
 
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
@@ -12,10 +13,15 @@ import (
 func koanfFromYaml(configFile string) (*koanf.Koanf, error) {
 	parser := koanf.New(".")
 
-	err := parser.Load(file.Provider(configFile), yaml.Parser())
+	buf, err := envsubst.ReadFile(configFile)
 	if err != nil {
 		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
 			"failed to read yaml config from %s", configFile).CausedBy(err)
+	}
+
+	if err = parser.Load(rawbytes.Provider(buf), yaml.Parser()); err != nil {
+		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
+			"failed to load yaml config from %s", configFile).CausedBy(err)
 	}
 
 	return parser, nil

--- a/internal/config/parser/yaml_test.go
+++ b/internal/config/parser/yaml_test.go
@@ -4,23 +4,22 @@ import (
 	"os"
 	"testing"
 
+	"github.com/knadh/koanf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestKoanfFromYaml(t *testing.T) {
-	t.Parallel()
+	t.Setenv("FOO", "BAR")
 
-	// GIVEN
-	tempFile, err := os.CreateTemp("", "config-test-*")
-	require.NoError(t, err)
-
-	defer tempFile.Close()
-
-	fileName := tempFile.Name()
-	defer os.Remove(fileName)
-
-	_, err = tempFile.Write([]byte(`
+	for _, tc := range []struct {
+		uc     string
+		config []byte
+		assert func(t *testing.T, err error, kanf *koanf.Koanf)
+	}{
+		{
+			uc: "without env substitution",
+			config: []byte(`
 some_string: foo
 someint: 3
 nested1:
@@ -29,21 +28,82 @@ nested1:
 nested_2:
   - somebool: false
     some_string: baz
-`))
-	require.NoError(t, err)
+`),
+			assert: func(t *testing.T, err error, konf *koanf.Koanf) {
+				t.Helper()
 
-	// WHEN
-	konf, err := koanfFromYaml(fileName)
+				require.NoError(t, err)
+				assert.Equal(t, "foo", konf.Get("some_string"))
+				assert.Equal(t, 3, konf.Get("someint"))
+				assert.Equal(t, "bar", konf.Get("nested1.some_string"))
+				assert.Equal(t, true, konf.Get("nested1.somebool"))
+				assert.Len(t, konf.Get("nested_2"), 1)
+				assert.Contains(t, konf.Get("nested_2"), map[string]any{"some_string": "baz", "somebool": false})
+			},
+		},
+		{
+			uc: "with env substitution",
+			config: []byte(`
+some_string: ${FOO}
+someint: 3
+nested1:
+  somebool: true
+  some_string: bar
+nested_2:
+  - somebool: false
+    some_string: ${BAZ:=zab}
+`),
+			assert: func(t *testing.T, err error, konf *koanf.Koanf) {
+				t.Helper()
 
-	// THEN
-	require.NoError(t, err)
+				require.NoError(t, err)
+				assert.Equal(t, "BAR", konf.Get("some_string"))
+				assert.Equal(t, 3, konf.Get("someint"))
+				assert.Equal(t, "bar", konf.Get("nested1.some_string"))
+				assert.Equal(t, true, konf.Get("nested1.somebool"))
+				assert.Len(t, konf.Get("nested_2"), 1)
+				assert.Contains(t, konf.Get("nested_2"), map[string]any{"some_string": "zab", "somebool": false})
+			},
+		},
+		{
+			uc:     "with invalid yaml content",
+			config: []byte("foobar"),
+			assert: func(t *testing.T, err error, kanf *koanf.Koanf) {
+				t.Helper()
 
-	konf.Print()
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to load")
+			},
+		},
+		{
+			uc:     "with invalid env substitution content",
+			config: []byte("${:}"),
+			assert: func(t *testing.T, err error, kanf *koanf.Koanf) {
+				t.Helper()
 
-	assert.Equal(t, "foo", konf.Get("some_string"))
-	assert.Equal(t, 3, konf.Get("someint"))
-	assert.Equal(t, "bar", konf.Get("nested1.some_string"))
-	assert.Equal(t, true, konf.Get("nested1.somebool"))
-	assert.Len(t, konf.Get("nested_2"), 1)
-	assert.Contains(t, konf.Get("nested_2"), map[string]any{"some_string": "baz", "somebool": false})
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to read")
+			},
+		},
+	} {
+		t.Run(tc.uc, func(t *testing.T) {
+			// GIVEN
+			tempFile, err := os.CreateTemp("", "config-test-*")
+			require.NoError(t, err)
+
+			defer tempFile.Close()
+
+			fileName := tempFile.Name()
+			defer os.Remove(fileName)
+
+			_, err = tempFile.Write(tc.config)
+			require.NoError(t, err)
+
+			// WHEN
+			konf, err := koanfFromYaml(fileName)
+
+			// THEN
+			tc.assert(t, err, konf)
+		})
+	}
 }

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -147,8 +147,8 @@ rules:
             auth:
               type: basic_auth
               config:
-                user: foo
-                password: bar
+                user: ${INTROSPECT_EP_USER}
+                password: ${INTROSPECT_EP_PASSWORD}
           token_source:
             - header: Authorization
               schema: Bearer


### PR DESCRIPTION
This PR closes #67 

Example configuration which shows the new possibility.

```.yaml
id: hydra_authenticator
type: oauth2_introspection
config:
  introspection_endpoint:
    url: http://hydra:4445/oauth2/introspect
    auth:
      type: basic_auth
      config:
        user: ${INTROSPECT_EP_USER}
        password: ${INTROSPECT_EP_PASSWORD}
```