### PR TITLE
feat: Support for environment variables substitution in config file

### DIFF
--- a/docs/content/docs/getting_started/configuration_introduction.adoc
+++ b/docs/content/docs/getting_started/configuration_introduction.adoc
@@ -52,8 +52,8 @@ You can also override this using the `config` argument: `heimdall --config <path
 The values in the configuration file can also make use of environment variables. Access to these happens using Bash syntax. Following expressions are supported:
 
 * `${var}` - Value of `$var`
-* `${var=default` - If `$var` is not set, evaluate expression as `$default`
-* `${var:=default` - If `$var` is not set or is empty, evaluate expression as `$default`
+* `${var=default}` - If `$var` is not set, evaluate expression as `default`
+* `${var:=default}` - If `$var` is not set or is empty, evaluate expression as `default`
 
 .Possible minimal fully working configuration
 ====

--- a/docs/content/docs/getting_started/configuration_introduction.adoc
+++ b/docs/content/docs/getting_started/configuration_introduction.adoc
@@ -16,7 +16,8 @@ Configuration in heimdall can refer to two different things:
 
 Elements in the static configuration set up the services, like link:{{< relref "/docs/configuration/services/decision.adoc" >}}[decision api], which basically define the entry points, heimdall will listen to, the observability capabilities, like link:{{< relref "/docs/configuration/observability/logging.adoc" >}}[logging], the supported link:{{< relref "/docs/configuration/rules/pipeline_mechanisms/overview.adoc" >}}[pipeline mechanisms], the link:{{< relref "/docs/configuration/rules/default.adoc" >}}[default rule], as well as the link:{{< relref "/docs/configuration/rules/providers.adoc" >}}[rule providers] (these elements are not expected to change often).
 
-The rule set contains everything that defines how the requests are handled by heimdall for your system. This configuration can change and is seamlessly hot-reloaded, without any request interruption or connection loss.
+The rule set contains everything that defines how the requests are handled by heimdall for your system.
+This configuration can change and is seamlessly hot-reloaded, without any request interruption or connection loss.
 
 == Rule Set Configuration
 
@@ -31,9 +32,12 @@ There are two different, not mutually exclusive (you can combine them), ways to 
 . in a link:{{< relref "#_configuration_file" >}}[configuration file] (only https://yaml.org/spec/1.2.2/[YAML] is supported as format)
 . as link:{{< relref "#_environment_variables" >}}[environment variables]
 
-The evaluation happens also in the order stated above. That also means, you can always overwrite configuration options defined in a configuration file with corresponding environment variables.
+The evaluation happens also in the order stated above.
+That also means, you can always overwrite configuration options defined in a configuration file with corresponding environment variables.
 
-If no configuration is provided, heimdall will set useful defaults. These are however not enough, as heimdall doesn't know your context - which mechanisms are required for the one or the other of your upstream services. So, you'll not really be able to use heimdall as all requests will be answered with an HTTP `405 Method Not Allowed` response code.
+If no configuration is provided, heimdall will set useful defaults.
+These are however not enough, as heimdall doesn't know your context - which mechanisms are required for the one or the other of your upstream services.
+So, you'll not really be able to use heimdall as all requests will be answered with an HTTP `405 Method Not Allowed` response code.
 
 === Configuration File
 
@@ -45,12 +49,19 @@ At start up, heimdall searches for static configuration in a file named `heimdal
 
 You can also override this using the `config` argument: `heimdall --config <path-to-your-config-file>`.
 
+The values in the configuration file can also make use of environment variables. Access to these happens using Bash syntax. Following expressions are supported:
+
+* `${var}` - Value of `$var`
+* `${var=default` - If `$var` is not set, evaluate expression as `$default`
+* `${var:=default` - If `$var` is not set or is empty, evaluate expression as `$default`
+
 .Possible minimal fully working configuration
 ====
 
-The configuration below defines a link:{{< relref "/docs/configuration/rules/default.adoc" >}}[default rule] which lets heimdall create a JSON Web Token (JWT) with `sub` claim set to `anonymous` for every request on every URL for the HTTP methods GET and POST. The JWT itself will be put into the `Authorization` header as a bearer token.
+The configuration below defines a link:{{< relref "/docs/configuration/rules/default.adoc" >}}[default rule] which lets heimdall create a JSON Web Token (JWT) with `sub` claim set to `anonymous` for every request on every URL for the HTTP methods GET and POST.
+The JWT itself will be put into the `Authorization` header as a bearer token.
 
-[source, yaml]
+[source,yaml]
 ----
 log:
   level: info
@@ -74,19 +85,44 @@ rules:
 ----
 ====
 
+.Configuration with a mechanism defined using environment variables substitution
+====
+[source,yaml]
+----
+rules:
+  mechanisms:
+    authenticators:
+    - id: hydra_authenticator
+      type: oauth2_introspection
+      config:
+        introspection_endpoint:
+          url: http://hydra:4445/oauth2/introspect
+          auth:
+            type: basic_auth
+            config:
+              user: ${INTROSPECT_EP_USER}
+              password: ${INTROSPECT_EP_PASSWORD}
+    unifiers:
+    - id: create_jwt
+      type: jwt
+----
+====
+
 === Environment Variables
 
-Every configuration property, which can be defined in a link:{{< relref "#_configuration_file" >}}[configuration file] can also be defined as environment variable. Following rules apply:
+Every configuration property, which can be defined in a link:{{< relref "#_configuration_file" >}}[configuration file] can also be defined as environment variable.
+Following rules apply:
 
 * If not specified while starting heimdall, all variables start with `HEIMDALLCFG_` prefix.
 +
-CAUTION: If for whatever reason, your environment configuration contains variables starting with `HEIMDALLCFG_`, which do not define heimdall specific configuration, heimdall will refuse starting if such configuration variable clashes (has an unexpected type) with heimdall's configuration properties (even for environment variables, the configuration is type safe). You can overcome such situation, by ether renaming such variables, or, if this is not possible, make use of the `--env-config-prefix` flag with heimdall's `serve` command.
+CAUTION: If for whatever reason, your environment configuration contains variables starting with `HEIMDALLCFG_`, which do not define heimdall specific configuration, heimdall will refuse starting if such configuration variable clashes (has an unexpected type) with heimdall's configuration properties (even for environment variables, the configuration is type safe).
+You can overcome such situation, by ether renaming such variables, or, if this is not possible, make use of the `--env-config-prefix` flag with heimdall's `serve` command.
 
 * Properties in a hierarchy are separated by `_`
 +
 E.g. the log level can be set to `info` in a config file as also shown in the above example with
 +
-[source, yaml]
+[source,yaml]
 ----
 log:
   level: info
@@ -94,7 +130,7 @@ log:
 +
 and using an environment variable with
 +
-[source, bash]
+[source,bash]
 ----
 HEIMDALLCFG_LOG_LEVEL=info
 ----
@@ -104,7 +140,7 @@ HEIMDALLCFG_LOG_LEVEL=info
 +
 E.g. the `methods` of the link:{{< relref "/docs/configuration/rules/default.adoc" >}}[default rule] can be configured in a config file as
 +
-[source, yaml]
+[source,yaml]
 ----
 rules:
   default:
@@ -115,7 +151,7 @@ rules:
 +
 and using environment variables with
 +
-[source, bash]
+[source,bash]
 ----
 HEIMDALLCFG_RULES_DEFAULT_METHODS_0=GET
 HEIMDALLCFG_RULES_DEFAULT_METHODS_1=POST
@@ -123,7 +159,7 @@ HEIMDALLCFG_RULES_DEFAULT_METHODS_1=POST
 +
 For structured configuration, like the definition of the authenticators in the example above
 +
-[source, yaml]
+[source,yaml]
 ----
 rules:
   mechanisms:
@@ -134,7 +170,7 @@ rules:
 +
 The corresponding environment variables would be
 +
-[source, bash]
+[source,bash]
 ----
 HEIMDALLCFG_RULES_MECHANISMS_AUTHENTICATORS_0_ID=anonymous_authenticator
 HEIMDALLCFG_RULES_MECHANISMS__AUTHENTICATORS_0_TYPE=anonymous
@@ -144,7 +180,7 @@ HEIMDALLCFG_RULES_MECHANISMS__AUTHENTICATORS_0_TYPE=anonymous
 +
 E.g. the service name, appearing for heimdall for your tracing backend can be configured in a configuration file with
 +
-[source, yaml]
+[source,yaml]
 ----
 tracing:
   service_name: foobar
@@ -152,7 +188,7 @@ tracing:
 +
 and using the environment variables with
 +
-[source, bash]
+[source,bash]
 ----
 HEIMDALLCFG_TRACING_SERVICE__NAME=foobar
 ----

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/a8m/envsubst v1.3.0
 	github.com/dlclark/regexp2 v1.7.0
+	github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-co-op/gocron v1.18.0
 	github.com/go-logr/zerologr v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,6 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:H
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
-github.com/a8m/envsubst v1.3.0 h1:GmXKmVssap0YtlU3E230W98RWtWCyIZzjtf1apWWyAg=
-github.com/a8m/envsubst v1.3.0/go.mod h1:MVUTQNGQ3tsjOOtKCNd+fl8RzhsXcDvvAEzkhGtlsbY=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -513,6 +511,8 @@ github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNEkKy96OOhEzfZl+yxihPEzKnqJwvfuSUqbZE=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46 h1:7QPwrLT79GlD5sizHf27aoY2RTvw62mO6x7mxkScNk0=
+github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46/go.mod h1:esf2rsHFNlZlxsqsZDojNBcnNs5REqIvRrWRHqX0vEU=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
@@ -1723,8 +1723,6 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20221212164502-fae10dda9338 h1:OvjRkcNHnf6/W5FZXSxODbxwD+X7fspczG7Jn/xQVD4=
-golang.org/x/exp v0.0.0-20221212164502-fae10dda9338/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/exp v0.0.0-20221215174704-0915cd710c24 h1:6w3iSY8IIkp5OQtbYj8NeuKG1jS9d+kYaubXqsoOiQ8=
 golang.org/x/exp v0.0.0-20221215174704-0915cd710c24/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=

--- a/internal/config/parser/yaml.go
+++ b/internal/config/parser/yaml.go
@@ -1,9 +1,12 @@
 package parser
 
 import (
+	"os"
+
+	"github.com/drone/envsubst/v2"
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/yaml"
-	"github.com/knadh/koanf/providers/file"
+	"github.com/knadh/koanf/providers/rawbytes"
 
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
@@ -12,7 +15,19 @@ import (
 func koanfFromYaml(configFile string) (*koanf.Koanf, error) {
 	parser := koanf.New(".")
 
-	if err := parser.Load(file.Provider(configFile), yaml.Parser()); err != nil {
+	raw, err := os.ReadFile(configFile)
+	if err != nil {
+		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
+			"failed to read yaml config from %s", configFile).CausedBy(err)
+	}
+
+	content, err := envsubst.EvalEnv(string(raw))
+	if err != nil {
+		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
+			"failed to parse yaml config from %s", configFile).CausedBy(err)
+	}
+
+	if err = parser.Load(rawbytes.Provider([]byte(content)), yaml.Parser()); err != nil {
 		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
 			"failed to load yaml config from %s", configFile).CausedBy(err)
 	}

--- a/internal/config/parser/yaml_test.go
+++ b/internal/config/parser/yaml_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/knadh/koanf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dadrus/heimdall/internal/x"
 )
 
 func TestKoanfFromYaml(t *testing.T) {
@@ -15,10 +17,11 @@ func TestKoanfFromYaml(t *testing.T) {
 	for _, tc := range []struct {
 		uc     string
 		config []byte
+		chmod  func(t *testing.T, file *os.File)
 		assert func(t *testing.T, err error, kanf *koanf.Koanf)
 	}{
 		{
-			uc: "valid content",
+			uc: "valid content without env substitution",
 			config: []byte(`
 some_string: foo
 someint: 3
@@ -42,7 +45,35 @@ nested_2:
 			},
 		},
 		{
-			uc:     "invalid content",
+			uc: "valid content with env substitution and templates",
+			config: []byte(`
+some_string: ${FOO}
+someint: 3
+nested1:
+  somebool: true
+  some_string: bar
+nested_2:
+  - somebool: false
+    some_string: '{ "name": {{ if $user_name }}{{ quote $user_name }}{{ else }}{{ quote $email }}{{ end }} }'
+`),
+			assert: func(t *testing.T, err error, konf *koanf.Koanf) {
+				t.Helper()
+
+				require.NoError(t, err)
+				assert.Equal(t, "BAR", konf.Get("some_string"))
+				assert.Equal(t, 3, konf.Get("someint"))
+				assert.Equal(t, "bar", konf.Get("nested1.some_string"))
+				assert.Equal(t, true, konf.Get("nested1.somebool"))
+				assert.Len(t, konf.Get("nested_2"), 1)
+				assert.Contains(t, konf.Get("nested_2"),
+					map[string]any{
+						"some_string": `{ "name": {{ if $user_name }}{{ quote $user_name }}{{ else }}{{ quote $email }}{{ end }} }`,
+						"somebool":    false,
+					})
+			},
+		},
+		{
+			uc:     "invalid yaml content",
 			config: []byte("foobar"),
 			assert: func(t *testing.T, err error, kanf *koanf.Koanf) {
 				t.Helper()
@@ -51,9 +82,37 @@ nested_2:
 				assert.Contains(t, err.Error(), "failed to load")
 			},
 		},
+		{
+			uc:     "invalid yaml env substitution",
+			config: []byte("${:}"),
+			assert: func(t *testing.T, err error, kanf *koanf.Koanf) {
+				t.Helper()
+
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to parse")
+			},
+		},
+		{
+			uc:     "can't read file",
+			config: []byte(`foo: bar`),
+			chmod: func(t *testing.T, file *os.File) {
+				t.Helper()
+
+				err := file.Chmod(0o222)
+				require.NoError(t, err)
+			},
+			assert: func(t *testing.T, err error, kanf *koanf.Koanf) {
+				t.Helper()
+
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to read")
+			},
+		},
 	} {
 		t.Run(tc.uc, func(t *testing.T) {
 			// GIVEN
+			chmod := x.IfThenElse(tc.chmod != nil, tc.chmod, func(t *testing.T, file *os.File) { t.Helper() })
+
 			tempFile, err := os.CreateTemp("", "config-test-*")
 			require.NoError(t, err)
 
@@ -64,6 +123,8 @@ nested_2:
 
 			_, err = tempFile.Write(tc.config)
 			require.NoError(t, err)
+
+			chmod(t, tempFile)
 
 			// WHEN
 			konf, err := koanfFromYaml(fileName)


### PR DESCRIPTION
This PR closes #67

Example configuration which shows the new possibility.

```.yaml
id: hydra_authenticator
type: oauth2_introspection
config:
  introspection_endpoint:
    url: http://hydra:4445/oauth2/introspect
    auth:
      type: basic_auth
      config:
        user: ${INTROSPECT_EP_USER}
        password: ${INTROSPECT_EP_PASSWORD}
```

This PR is a replacement for #378, which tried to implement the same functionality, unfortunately using a library, which clashed with go templates. Template support is now covered by the tests as well