### PR TITLE
chore: build recipe in Justfile fixed to reference the proper module for embedding version information

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -36,7 +36,7 @@ coverage: test
 build: dependencies
   #!/usr/bin/env bash
   git_ref=$(git rev-parse --short HEAD)
-  CGO_ENABLED=0 go build -trimpath -ldflags="-buildid= -w -s -X github.com/dadrus/heimdall/cmd.Version=${git_ref}"
+  CGO_ENABLED=0 go build -trimpath -ldflags="-buildid= -w -s -X github.com/dadrus/heimdall/version.Version=${git_ref}"
 
 build-image:
   #!/usr/bin/env bash


### PR DESCRIPTION
## Related issue(s)

Not related to any documented issue

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).

## Description

After moving the `Version` type into its own module, the `build` recipe in Justfile has not been updated. That rendered local builds useless regarding the embedded version information - it was just not set until this PR.
