### PR TITLE
feat: Helm chart supports setting of arbitrary environment variables

### DIFF
--- a/charts/heimdall/README.adoc
+++ b/charts/heimdall/README.adoc
@@ -42,7 +42,7 @@ $ helm repo update
 
 == Installing the Chart
 
-This chart expects a https://dadrus.github.io/heimdall/dev/docs/configuration/reference/configuration_reference/[heimdall configuration file] with authentication, authorization and so on mechanisms, required for your particular setup. This file can be passed by using the `-f heimdall.yaml` flag during the installation.
+This chart supports setting of any environment variables for the deployment, e.g. to provide OTEL configuration. All environment variables must be configured under an `env` key. E.g. `helm install my-release --set env.MY_ENV=env-value dadrus/heimdall`
 
 If you need to override the name of the heimdall resources such as the deployment or services, the traditional `nameOverride` and `fullnameOverride` properties are supported.
 
@@ -390,4 +390,16 @@ a| `service.management.name`
 
 The name of the port exposed by the k8s Service created for heimdall's management endpoint.
 a| `management`
+
+a| `env`
+
+Environment variables, which should be made available to the heimdall deployment. E.g.
+
+```.yaml
+env:
+  OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc
+  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://tempo.tempo.svc.cluster.local:4317
+```
+
+a| `{}` (empty map)
 |===

--- a/charts/heimdall/templates/demo/configmap.yaml
+++ b/charts/heimdall/templates/demo/configmap.yaml
@@ -25,6 +25,7 @@ metadata:
 data:
   heimdall.yaml: |
     log:
+      format: gelf
       level: info
 
     rules:

--- a/charts/heimdall/templates/heimdall/deployment.yaml
+++ b/charts/heimdall/templates/heimdall/deployment.yaml
@@ -88,6 +88,13 @@ spec:
             - name: {{ include "heimdall.name" . }}-config-volume
               mountPath: /etc/heimdall
               readOnly: true
+          {{- if .Values.env }}
+          env:
+            {{- range $key, $val := .Values.env }}
+              - name: {{ $key }}
+                value: {{ $val }}
+            {{- end }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /.well-known/health

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -119,6 +119,9 @@ service:
     # Service port name
     name: management
 
+# Configures arbitrary environment variables for the deployment
+env: {}
+
 # heimdall config defaults
 # DO NOT OVERRIDE the values here. Use heimdall config yaml file instead!
 # If you create your own values.yaml file, copy the below contents to it as well.


### PR DESCRIPTION
## Related issue(s)

Does not relate to any

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have updated the documentation.

## Description
This PR enables configuration of arbitrary environment variables for heimdall deployments. E.g. if you can't rely on defaults and have to set OTEL specific variables, you can either create an additional values yaml file like shown below and provide it via the `-f` flag to helm, or just set the required variables via CLI as also shown below.

In addition this PR changes the log format for the demo deployment from text to gelf

**Example 1:** Providing OTEL environment variables via CLI
```.bash
helm install heimdall -n heimdall --create-namespace  \
  --set env.OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc  \
  --set env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://tempo.tempo.svc.cluster.local:4317 \
  dadrus/heimdall
```

**Example 2:** Providing OTEL environment variables via config file
```.yaml
# values.yaml
env:
  OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc
  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://tempo.tempo.svc.cluster.local:4317
```

```.bash
helm install heimdall -n heimdall --create-namespace  -f values.yaml dadrus/heimdall
```
