### PR TITLE
refactor!: `demo.enable` in helm chart renamed to `demo.enabled`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,11 +91,11 @@ jobs:
         run: helm lint ./charts/heimdall
       - name: Kubeconform decision mode deployment
         run: |
-          helm template --set demo.enable=true ./charts/heimdall > decision-demo.yaml
+          helm template --set demo.enabled=true ./charts/heimdall > decision-demo.yaml
           kubeconform --skip RuleSet -kubernetes-version ${{ env.KUBERNETES_API_VERSION }} decision-demo.yaml
       - name: Kubeconform proxy mode deployment
         run: |
-          helm template --set operationMode=proxy --set demo.enable=true ./charts/heimdall > proxy-demo.yaml
+          helm template --set operationMode=proxy --set demo.enabled=true ./charts/heimdall > proxy-demo.yaml
           kubeconform --skip RuleSet -kubernetes-version ${{ env.KUBERNETES_API_VERSION }} decision-demo.yaml
 
   test:

--- a/Justfile
+++ b/Justfile
@@ -16,8 +16,8 @@ lint-dockerfile:
 
 lint-helmchart:
   helm lint ./charts/heimdall
-  helm template --set demo.enable=true ./charts/heimdall > /tmp/decision-demo.yaml
-  helm template --set operationMode=proxy --set demo.enable=true ./charts/heimdall > /tmp/proxy-demo.yaml
+  helm template --set demo.enabled=true ./charts/heimdall > /tmp/decision-demo.yaml
+  helm template --set operationMode=proxy --set demo.enabled=true ./charts/heimdall > /tmp/proxy-demo.yaml
   kubeconform --skip RuleSet -kubernetes-version 1.23.0 /tmp/decision-demo.yaml
   kubeconform --skip RuleSet -kubernetes-version 1.23.0 /tmp/proxy-demo.yaml
   rm /tmp/decision-demo.yaml

--- a/charts/heimdall/templates/NOTES.txt
+++ b/charts/heimdall/templates/NOTES.txt
@@ -12,13 +12,13 @@ services. Consult the Ingress Controller documentation of your choice on how to 
 {{- else }}
 Heimdall is installed and configured to operate in proxy mode.
 
-  {{- if not .Values.demo.enable }}
+  {{- if not .Values.demo.enabled }}
 
 The actual integration depends pretty much on your requirements and setup.
   {{- end }}
 {{- end }}
 
-{{- if .Values.demo.enable }}
+{{- if .Values.demo.enabled }}
 
 The setup includes a demo app (which just echoes the request) and a rule set. If you're using NGINX as Ingress Controller, the abovesaid annotations are already added to the demo app ingress rule. So, to see heimdall in actions, just do.
 

--- a/charts/heimdall/templates/demo/configmap.yaml
+++ b/charts/heimdall/templates/demo/configmap.yaml
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.demo.enable }}
+{{- if .Values.demo.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/heimdall/templates/demo/deployment.yaml
+++ b/charts/heimdall/templates/demo/deployment.yaml
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.demo.enable }}
+{{- if .Values.demo.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/heimdall/templates/demo/ingress.yaml
+++ b/charts/heimdall/templates/demo/ingress.yaml
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{ if .Values.demo.enable -}}
+{{ if .Values.demo.enabled -}}
 {{- $service := "unset" -}}
 {{- $port := "unset" -}}
   {{- if eq .Values.operationMode "decision" -}}

--- a/charts/heimdall/templates/demo/namespace.yaml
+++ b/charts/heimdall/templates/demo/namespace.yaml
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.demo.enable }}
+{{- if .Values.demo.enabled }}
 kind: Namespace
 apiVersion: v1
 metadata:

--- a/charts/heimdall/templates/demo/service.yaml
+++ b/charts/heimdall/templates/demo/service.yaml
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.demo.enable }}
+{{- if .Values.demo.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/heimdall/templates/demo/test-rule.yaml
+++ b/charts/heimdall/templates/demo/test-rule.yaml
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.demo.enable }}
+{{- if .Values.demo.enabled }}
 apiVersion: heimdall.dadrus.github.com/v1alpha1
 kind: RuleSet
 metadata:

--- a/charts/heimdall/templates/heimdall/configmap.yaml
+++ b/charts/heimdall/templates/heimdall/configmap.yaml
@@ -14,7 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if not .Values.demo.enable }}
+{{- if not .Values.demo.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -23,7 +23,7 @@ operationMode: "decision" # decision or proxy
 # If set to true, a demo deployment with exemplary rules, as these can be found in the documentation,
 # will be done
 demo:
-  enable: false
+  enabled: false
 
   # the demo setup assumes nginx ingress controller and will use the
   # following values to configure the ingress rule


### PR DESCRIPTION
## Related issue(s)

None

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have updated the documentation.

## Description

This PR streamlines the names of properties, which enable or disable something. Here the affected property is `demo.enable`, which has been renamed to `demo.enabled`.

