### PR TITLE
ci: Made helm chart release job dependent on docker images release job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -275,6 +275,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - prepare-release
+      - release-docker-images
     if: needs.prepare-release.outputs.release_created
     steps:
       - name: Prepare image version


### PR DESCRIPTION
... otherwise the helm chart is released before the docker images are available on docker hub