### PR TITLE
refactor!: CORS support for decision service removed

### DIFF
--- a/docs/content/docs/configuration/reference/reference.adoc
+++ b/docs/content/docs/configuration/reference/reference.adoc
@@ -30,18 +30,6 @@ serve:
       read: 2s
       write: 5s
       idle: 2m
-    cors:
-      allowed_origins:
-        - example.org
-      allowed_methods:
-        - GET
-        - POST
-      allowed_headers:
-        - Authorization
-      exposed_headers:
-        - X-My-Header
-      allow_credentials: true
-      max_age: 1m
     tls:
       key_store:
         path: /path/to/key/store.pem

--- a/docs/content/docs/configuration/services/decision.adoc
+++ b/docs/content/docs/configuration/services/decision.adoc
@@ -61,26 +61,6 @@ decision:
 ----
 ====
 
-* *`cors`*: _link:{{< relref "/docs/configuration/reference/types.adoc#_cors" >}}[CORS]_ (optional)
-+
-https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[CORS] (Cross-Origin Resource Sharing) headers can be added and configured by making use of this option. This functionality allows for advanced security features to quickly be set. If CORS headers are set, then the Heimdall does not pass preflight requests to its decision pipeline, instead the response will be generated and sent back to the client directly.
-+
-.Possible CORS configuration
-====
-[source, yaml]
-----
-decision:
-  cors:
-    allowed_origins:
-      - example.org
-    allowed_methods:
-      - HEAD
-      - PATCH
-    allow_credentials: true
-    max_age: 10s
-----
-====
-
 * *`tls`*: _link:{{< relref "/docs/configuration/reference/types.adoc#_tls" >}}[TLS]_ (optional)
 +
 By default, the Decision service accepts HTTP requests. Depending on your deployment scenario, you could require Heimdall to accept HTTPs requests only (which is highly recommended). You can do so by making use of this option.

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -6,18 +6,6 @@ serve:
       read: 2s
       write: 5s
       idle: 2m
-    cors:
-      allowed_origins:
-        - example.org
-      allowed_methods:
-        - GET
-        - POST
-      allowed_headers:
-        - Authorization
-      exposed_headers:
-        - X-My-Header
-      allow_credentials: true
-      max_age: 1m
     tls:
       key_store:
         path: /path/to/keystore/file.pem

--- a/internal/handler/decision/app.go
+++ b/internal/handler/decision/app.go
@@ -17,11 +17,8 @@
 package decision
 
 import (
-	"strings"
-
 	"github.com/goccy/go-json"
 	"github.com/gofiber/fiber/v2"
-	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/fiber/v2/middleware/recover"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
@@ -65,9 +62,12 @@ func newApp(args appArgs) *fiber.App {
 		JSONEncoder: json.Marshal,
 	})
 
-	app.Use(recover.New(recover.Config{EnableStackTrace: true}))
-	app.Use(tracingmiddleware.New(
-		tracingmiddleware.WithTracer(otel.GetTracerProvider().Tracer("github.com/dadrus/heimdall/decision"))))
+	app.Use(
+		recover.New(recover.Config{EnableStackTrace: true}),
+		tracingmiddleware.New(
+			tracingmiddleware.WithTracer(otel.GetTracerProvider().Tracer("github.com/dadrus/heimdall/decision")),
+		),
+	)
 
 	if args.Config.Metrics.Enabled {
 		app.Use(prometheusmiddleware.New(
@@ -76,31 +76,21 @@ func newApp(args appArgs) *fiber.App {
 		))
 	}
 
-	app.Use(accesslogmiddleware.New(args.Logger))
-	app.Use(loggermiddlerware.New(args.Logger))
-
-	if service.CORS != nil {
-		app.Use(cors.New(cors.Config{
-			AllowOrigins:     strings.Join(service.CORS.AllowedOrigins, ","),
-			AllowMethods:     strings.Join(service.CORS.AllowedMethods, ","),
-			AllowHeaders:     strings.Join(service.CORS.AllowedHeaders, ","),
-			AllowCredentials: service.CORS.AllowCredentials,
-			ExposeHeaders:    strings.Join(service.CORS.ExposedHeaders, ","),
-			MaxAge:           int(service.CORS.MaxAge.Seconds()),
-		}))
-	}
-
-	app.Use(errormiddleware.New(
-		errormiddleware.WithVerboseErrors(service.Respond.Verbose),
-		errormiddleware.WithPreconditionErrorCode(service.Respond.With.ArgumentError.Code),
-		errormiddleware.WithAuthenticationErrorCode(service.Respond.With.AuthenticationError.Code),
-		errormiddleware.WithAuthorizationErrorCode(service.Respond.With.AuthorizationError.Code),
-		errormiddleware.WithCommunicationErrorCode(service.Respond.With.CommunicationError.Code),
-		errormiddleware.WithMethodErrorCode(service.Respond.With.BadMethodError.Code),
-		errormiddleware.WithNoRuleErrorCode(service.Respond.With.NoRuleError.Code),
-		errormiddleware.WithInternalServerErrorCode(service.Respond.With.InternalError.Code),
-	))
-	app.Use(cachemiddleware.New(args.Cache))
+	app.Use(
+		accesslogmiddleware.New(args.Logger),
+		loggermiddlerware.New(args.Logger),
+		errormiddleware.New(
+			errormiddleware.WithVerboseErrors(service.Respond.Verbose),
+			errormiddleware.WithPreconditionErrorCode(service.Respond.With.ArgumentError.Code),
+			errormiddleware.WithAuthenticationErrorCode(service.Respond.With.AuthenticationError.Code),
+			errormiddleware.WithAuthorizationErrorCode(service.Respond.With.AuthorizationError.Code),
+			errormiddleware.WithCommunicationErrorCode(service.Respond.With.CommunicationError.Code),
+			errormiddleware.WithMethodErrorCode(service.Respond.With.BadMethodError.Code),
+			errormiddleware.WithNoRuleErrorCode(service.Respond.With.NoRuleError.Code),
+			errormiddleware.WithInternalServerErrorCode(service.Respond.With.InternalError.Code),
+		),
+		cachemiddleware.New(args.Cache),
+	)
 
 	return app
 }

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -205,121 +205,7 @@
         }
       }
     },
-    "serviceConfig": {
-      "description": "Service Configuration",
-      "additionalProperties": false,
-      "type": "object",
-      "properties": {
-        "port": {
-          "description": "The port to listen on.",
-          "type": "integer"
-        },
-        "host": {
-          "description": "The network interface to listen on.",
-          "type": "string",
-          "default": "",
-          "examples": [
-            "localhost",
-            "127.0.0.1"
-          ]
-        },
-        "timeout": {
-          "$ref": "#/definitions/timeoutConfig"
-        },
-        "cors": {
-          "$ref": "#/definitions/corsConfig"
-        },
-        "tls": {
-          "$ref": "#/definitions/tlsConfig"
-        },
-        "trusted_proxies": {
-          "description": "The list IPs or CIDRs heimdall should trust and thus make use of headers, like X-Forwarded-*, Forwarded, etc",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "ruleExecutorServiceConfig": {
-      "description": "Service Configuration for Proxy and Decision services",
-      "additionalProperties": false,
-      "type": "object",
-      "properties": {
-        "port": {
-          "description": "The port to listen on.",
-          "type": "integer"
-        },
-        "host": {
-          "description": "The network interface to listen on.",
-          "type": "string",
-          "default": "",
-          "examples": [
-            "localhost",
-            "127.0.0.1"
-          ]
-        },
-        "timeout": {
-          "$ref": "#/definitions/timeoutConfig"
-        },
-        "cors": {
-          "$ref": "#/definitions/corsConfig"
-        },
-        "tls": {
-          "$ref": "#/definitions/tlsConfig"
-        },
-        "trusted_proxies": {
-          "description": "The list IPs or CIDRs heimdall should trust and thus make use of headers, like X-Forwarded-*, Forwarded, etc",
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "respond": {
-          "type": "object",
-          "description": "How the service should response",
-          "additionalProperties": false,
-          "properties": {
-            "verbose": {
-              "type": "boolean",
-              "description": "Whether the response should be verbose in error cases",
-              "default": false
-            },
-            "with": {
-              "type": "object",
-              "description": "Overrides for the status codes",
-              "additionalProperties": false,
-              "properties": {
-                "accepted": {
-                  "$ref": "#/definitions/responseOverride"
-                },
-                "precondition_error": {
-                  "$ref": "#/definitions/responseOverride"
-                },
-                "authentication_error": {
-                  "$ref": "#/definitions/responseOverride"
-                },
-                "authorization_error": {
-                  "$ref": "#/definitions/responseOverride"
-                },
-                "method_error": {
-                  "$ref": "#/definitions/responseOverride"
-                },
-                "communication_error": {
-                  "$ref": "#/definitions/responseOverride"
-                },
-                "internal_error": {
-                  "$ref": "#/definitions/responseOverride"
-                },
-                "no_rule_error": {
-                  "$ref": "#/definitions/responseOverride"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
+
     "responseOverride": {
       "type": "object",
       "description": "Overrides the defaults for responses",
@@ -328,6 +214,49 @@
         "code": {
           "type": "integer",
           "description": "The HTTP status code"
+        }
+      }
+    },
+    "respondWithConfig": {
+      "type": "object",
+      "description": "How the service should response",
+      "additionalProperties": false,
+      "properties": {
+        "verbose": {
+          "type": "boolean",
+          "description": "Whether the response should be verbose in error cases",
+          "default": false
+        },
+        "with": {
+          "type": "object",
+          "description": "Overrides for the status codes",
+          "additionalProperties": false,
+          "properties": {
+            "accepted": {
+              "$ref": "#/definitions/responseOverride"
+            },
+            "precondition_error": {
+              "$ref": "#/definitions/responseOverride"
+            },
+            "authentication_error": {
+              "$ref": "#/definitions/responseOverride"
+            },
+            "authorization_error": {
+              "$ref": "#/definitions/responseOverride"
+            },
+            "method_error": {
+              "$ref": "#/definitions/responseOverride"
+            },
+            "communication_error": {
+              "$ref": "#/definitions/responseOverride"
+            },
+            "internal_error": {
+              "$ref": "#/definitions/responseOverride"
+            },
+            "no_rule_error": {
+              "$ref": "#/definitions/responseOverride"
+            }
+          }
         }
       }
     },
@@ -1790,13 +1719,115 @@
       "type": "object",
       "properties": {
         "decision": {
-          "$ref": "#/definitions/ruleExecutorServiceConfig"
+          "description": "Decision service Configuration",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "port": {
+              "description": "The port to listen on.",
+              "type": "integer"
+            },
+            "host": {
+              "description": "The network interface to listen on.",
+              "type": "string",
+              "default": "",
+              "examples": [
+                "localhost",
+                "127.0.0.1"
+              ]
+            },
+            "timeout": {
+              "$ref": "#/definitions/timeoutConfig"
+            },
+            "tls": {
+              "$ref": "#/definitions/tlsConfig"
+            },
+            "trusted_proxies": {
+              "description": "The list IPs or CIDRs heimdall should trust and thus make use of headers, like X-Forwarded-*, Forwarded, etc",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "respond": {
+              "$ref": "#/definitions/respondWithConfig"
+            }
+          }
         },
         "proxy": {
-          "$ref": "#/definitions/ruleExecutorServiceConfig"
+          "description": "Proxy service configuration",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "port": {
+              "description": "The port to listen on.",
+              "type": "integer"
+            },
+            "host": {
+              "description": "The network interface to listen on.",
+              "type": "string",
+              "default": "",
+              "examples": [
+                "localhost",
+                "127.0.0.1"
+              ]
+            },
+            "timeout": {
+              "$ref": "#/definitions/timeoutConfig"
+            },
+            "cors": {
+              "$ref": "#/definitions/corsConfig"
+            },
+            "tls": {
+              "$ref": "#/definitions/tlsConfig"
+            },
+            "trusted_proxies": {
+              "description": "The list IPs or CIDRs heimdall should trust and thus make use of headers, like X-Forwarded-*, Forwarded, etc",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "respond": {
+              "$ref": "#/definitions/respondWithConfig"
+            }
+          }
         },
         "management": {
-          "$ref": "#/definitions/serviceConfig"
+          "description": "Management service configuration",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "port": {
+              "description": "The port to listen on.",
+              "type": "integer"
+            },
+            "host": {
+              "description": "The network interface to listen on.",
+              "type": "string",
+              "default": "",
+              "examples": [
+                "localhost",
+                "127.0.0.1"
+              ]
+            },
+            "timeout": {
+              "$ref": "#/definitions/timeoutConfig"
+            },
+            "cors": {
+              "$ref": "#/definitions/corsConfig"
+            },
+            "tls": {
+              "$ref": "#/definitions/tlsConfig"
+            },
+            "trusted_proxies": {
+              "description": "The list IPs or CIDRs heimdall should trust and thus make use of headers, like X-Forwarded-*, Forwarded, etc",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Related issue(s)

None

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

CORS just doesn't make any sense for APIs used by backend services only. And the API exposed by the decision service falls exactly into this category.
