### PR TITLE
feat: Contextualizer can be configured not to cancel the pipeline execution if it runs into an error

### DIFF
--- a/docs/content/docs/configuration/reference/reference.adoc
+++ b/docs/content/docs/configuration/reference/reference.adoc
@@ -256,6 +256,7 @@ rules:
           url: http://profile
           headers:
             foo: bar
+        continue_pipeline_on_error: true
 
     unifiers:
     - id: jwt

--- a/docs/content/docs/configuration/rules/pipeline_mechanisms/contextualizers.adoc
+++ b/docs/content/docs/configuration/rules/pipeline_mechanisms/contextualizers.adoc
@@ -17,7 +17,7 @@ As of today, there is just one contextualizer type, which is described below.
 
 === Generic
 
-This mechanism allows you to communicate to any API you want to fetch further information about the subject. Typical scenario is getting specific attributes for later authorization purposes which are not known to the authentication system and thus were not made available in link:{{< relref "overview.adoc#_subject" >}}[`Subject's`] `Attributes` property. If the API responses with a 2xx HTTP response code, the payload is made available in the `Attributes` property of the `Subject`. To avoid overwriting of existing attributes, this object is however not available on the top level, but under a key named by the `id` of the authorizer (See also the example below). If the `Content-Type` of the response is either ending with `json` or is `application/x-www-form-urlencoded`, the payload is decoded and made available as map, otherwise it is treated as string, but, as written above, is made available as well.
+This mechanism allows you to communicate to any API you want to fetch further information about the subject. Typical scenario is getting specific attributes for later authorization purposes which are not known to the authentication system and thus were not made available in link:{{< relref "overview.adoc#_subject" >}}[`Subject's`] `Attributes` property. If the API responses with a 2xx HTTP response code, the payload is made available in the `Attributes` property of the `Subject`, otherwise, if not overridden, an error is thrown and the execution of the regular pipeline stops. To avoid overwriting of existing attributes, this object is however not available on the top level, but under a key named by the `id` of the authorizer (See also the example below). If the `Content-Type` of the response is either ending with `json` or is `application/x-www-form-urlencoded`, the payload is decoded and made available as map, otherwise it is treated as string, but, as written above, is made available as well.
 
 To enable the usage of this contextualizer, you have to set the `type` property to `generic`.
 
@@ -42,6 +42,10 @@ Your link:{{< relref "overview.adoc#_templating" >}}[template] with definitions 
 * *`cache_ttl`*: _link:{{< relref "/docs/configuration/reference/types.adoc#_duration" >}}[Duration]_ (optional, overridable)
 +
 Allows caching of the API responses. Defaults to 10 seconds. The cache key is calculated from the entire configuration of the contextualizer instance and the available information about the current subject.
+
+* *`continue_on_error`*: _boolean_ (optional, overridable)
++
+If set to `true`, allows the pipeline to continue with the execution of the next mechanisms. So the error, if thrown, is ignored. Defaults to `false`, which means the execution of the regular pipeline is stopped and the execution of the error pipeline is started.
 
 .Contextualizer configuration
 ====

--- a/docs/content/docs/configuration/rules/pipeline_mechanisms/contextualizers.adoc
+++ b/docs/content/docs/configuration/rules/pipeline_mechanisms/contextualizers.adoc
@@ -43,7 +43,7 @@ Your link:{{< relref "overview.adoc#_templating" >}}[template] with definitions 
 +
 Allows caching of the API responses. Defaults to 10 seconds. The cache key is calculated from the entire configuration of the contextualizer instance and the available information about the current subject.
 
-* *`continue_on_error`*: _boolean_ (optional, overridable)
+* *`continue_pipeline_on_error`*: _boolean_ (optional, overridable)
 +
 If set to `true`, allows the pipeline to continue with the execution of the next mechanisms. So the error, if thrown, is ignored. Defaults to `false`, which means the execution of the regular pipeline is stopped and the execution of the error pipeline is started.
 

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -263,6 +263,7 @@ rules:
             headers:
               bla: bla
           payload: http://foo
+          continue_on_error: true
       - id: profile_data_contextualizer
         type: generic
         config:

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -263,7 +263,7 @@ rules:
             headers:
               bla: bla
           payload: http://foo
-          continue_on_error: true
+          continue_pipeline_on_error: true
       - id: profile_data_contextualizer
         type: generic
         config:

--- a/internal/rules/composite_subject_creator_test.go
+++ b/internal/rules/composite_subject_creator_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/dadrus/heimdall/internal/x/testsupport"
 )
 
-func TestCompositeAuthenticatorExecution(t *testing.T) {
+func TestCompositeSubjectCreatorExecution(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {

--- a/internal/rules/composite_subject_handler.go
+++ b/internal/rules/composite_subject_handler.go
@@ -31,9 +31,13 @@ func (cm compositeSubjectHandler) Execute(ctx heimdall.Context, sub *subject.Sub
 	for _, m := range cm {
 		err := m.Execute(ctx, sub)
 		if err != nil {
-			logger.Debug().Err(err).Msg("Pipeline step execution failed")
+			logger.Info().Err(err).Msg("Pipeline step execution failed")
 
-			return err
+			if m.ContinueOnError() {
+				logger.Info().Msg("Error ignored. Continuing pipeline execution")
+			} else {
+				return err
+			}
 		}
 	}
 

--- a/internal/rules/composite_subject_handler_test.go
+++ b/internal/rules/composite_subject_handler_test.go
@@ -1,0 +1,135 @@
+package rules
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dadrus/heimdall/internal/heimdall"
+	"github.com/dadrus/heimdall/internal/heimdall/mocks"
+	"github.com/dadrus/heimdall/internal/rules/mechanisms/subject"
+	rulemocks "github.com/dadrus/heimdall/internal/rules/mocks"
+)
+
+func TestCompositeSubjectHandlerExecution(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		uc             string
+		configureMocks func(t *testing.T, ctx heimdall.Context, first *rulemocks.MockSubjectHandler,
+			second *rulemocks.MockSubjectHandler, sub *subject.Subject)
+		assert func(t *testing.T, err error)
+	}{
+		{
+			uc: "All succeeded",
+			configureMocks: func(t *testing.T, ctx heimdall.Context, first *rulemocks.MockSubjectHandler,
+				second *rulemocks.MockSubjectHandler, sub *subject.Subject,
+			) {
+				t.Helper()
+
+				first.On("Execute", ctx, sub).Return(nil)
+				second.On("Execute", ctx, sub).Return(nil)
+			},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+			},
+		},
+		{
+			uc: "First fails without pipeline continuation",
+			configureMocks: func(t *testing.T, ctx heimdall.Context, first *rulemocks.MockSubjectHandler,
+				second *rulemocks.MockSubjectHandler, sub *subject.Subject,
+			) {
+				t.Helper()
+
+				first.On("Execute", ctx, sub).Return(errors.New("first fails")) // nolint: goerr113
+				first.On("ContinueOnError").Return(false)
+			},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				assert.Equal(t, "first fails", err.Error())
+			},
+		},
+		{
+			uc: "First fails with pipeline continuation, second succeeds",
+			configureMocks: func(t *testing.T, ctx heimdall.Context, first *rulemocks.MockSubjectHandler,
+				second *rulemocks.MockSubjectHandler, sub *subject.Subject,
+			) {
+				t.Helper()
+
+				first.On("Execute", ctx, sub).Return(errors.New("first fails")) // nolint: goerr113
+				first.On("ContinueOnError").Return(true)
+				second.On("Execute", ctx, sub).Return(nil)
+			},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+			},
+		},
+		{
+			uc: "Second fails without pipeline continuation",
+			configureMocks: func(t *testing.T, ctx heimdall.Context, first *rulemocks.MockSubjectHandler,
+				second *rulemocks.MockSubjectHandler, sub *subject.Subject,
+			) {
+				t.Helper()
+
+				first.On("Execute", ctx, sub).Return(nil)
+				second.On("Execute", ctx, sub).Return(errors.New("second fails")) // nolint: goerr113
+				second.On("ContinueOnError").Return(false)
+			},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				assert.Equal(t, "second fails", err.Error())
+			},
+		},
+		{
+			uc: "Second fails with pipeline continuation",
+			configureMocks: func(t *testing.T, ctx heimdall.Context, first *rulemocks.MockSubjectHandler,
+				second *rulemocks.MockSubjectHandler, sub *subject.Subject,
+			) {
+				t.Helper()
+
+				first.On("Execute", ctx, sub).Return(nil)
+				second.On("Execute", ctx, sub).Return(errors.New("second fails")) // nolint: goerr113
+				second.On("ContinueOnError").Return(true)
+			},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+			},
+		},
+	} {
+		t.Run(tc.uc, func(t *testing.T) {
+			// GIVEN
+			sub := &subject.Subject{ID: "foo"}
+			ctx := &mocks.MockContext{}
+			ctx.On("AppContext").Return(context.Background())
+
+			handler1 := &rulemocks.MockSubjectHandler{}
+			handler2 := &rulemocks.MockSubjectHandler{}
+			tc.configureMocks(t, ctx, handler1, handler2, sub)
+
+			handler := compositeSubjectHandler{handler1, handler2}
+
+			// WHEN
+			err := handler.Execute(ctx, sub)
+
+			// THEN
+			tc.assert(t, err)
+
+			handler1.AssertExpectations(t)
+			handler2.AssertExpectations(t)
+			ctx.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/rules/mechanisms/authorizers/allow_authorizer.go
+++ b/internal/rules/mechanisms/authorizers/allow_authorizer.go
@@ -27,19 +27,21 @@ import (
 // nolint
 func init() {
 	registerAuthorizerTypeFactory(
-		func(_ string, typ string, conf map[string]any) (bool, Authorizer, error) {
+		func(id string, typ string, conf map[string]any) (bool, Authorizer, error) {
 			if typ != AuthorizerAllow {
 				return false, nil, nil
 			}
 
-			return true, newAllowAuthorizer(), nil
+			return true, newAllowAuthorizer(id), nil
 		})
 }
 
-type allowAuthorizer struct{}
+type allowAuthorizer struct {
+	id string
+}
 
-func newAllowAuthorizer() *allowAuthorizer {
-	return &allowAuthorizer{}
+func newAllowAuthorizer(id string) *allowAuthorizer {
+	return &allowAuthorizer{id: id}
 }
 
 func (*allowAuthorizer) Execute(ctx heimdall.Context, _ *subject.Subject) error {
@@ -52,3 +54,7 @@ func (*allowAuthorizer) Execute(ctx heimdall.Context, _ *subject.Subject) error 
 func (a *allowAuthorizer) WithConfig(map[string]any) (Authorizer, error) {
 	return a, nil
 }
+
+func (a *allowAuthorizer) HandlerID() string { return a.id }
+
+func (a *allowAuthorizer) ContinueOnError() bool { return false }

--- a/internal/rules/mechanisms/authorizers/allow_authorizer_test.go
+++ b/internal/rules/mechanisms/authorizers/allow_authorizer_test.go
@@ -40,6 +40,11 @@ func TestCreateAllowAuthorizerFromPrototype(t *testing.T) {
 
 	assert.Equal(t, prototype, conf1)
 	assert.Equal(t, prototype, conf2)
+
+	assert.Equal(t, "baz", prototype.HandlerID())
+	assert.False(t, conf1.ContinueOnError())
+	assert.False(t, conf2.ContinueOnError())
+	assert.False(t, prototype.ContinueOnError())
 }
 
 func TestAllowAuthorizerExecute(t *testing.T) {

--- a/internal/rules/mechanisms/authorizers/allow_authorizer_test.go
+++ b/internal/rules/mechanisms/authorizers/allow_authorizer_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestCreateAllowAuthorizerFromPrototype(t *testing.T) {
 	// GIVEN
-	prototype := newAllowAuthorizer()
+	prototype := newAllowAuthorizer("baz")
 
 	// WHEN
 	conf1, err1 := prototype.WithConfig(nil)
@@ -47,7 +47,7 @@ func TestAllowAuthorizerExecute(t *testing.T) {
 	ctx := &mocks.MockContext{}
 	ctx.On("AppContext").Return(context.Background())
 
-	auth := newAllowAuthorizer()
+	auth := newAllowAuthorizer("baz")
 
 	// WHEN
 	err := auth.Execute(ctx, nil)

--- a/internal/rules/mechanisms/authorizers/authorizer.go
+++ b/internal/rules/mechanisms/authorizers/authorizer.go
@@ -24,4 +24,5 @@ import (
 type Authorizer interface {
 	Execute(heimdall.Context, *subject.Subject) error
 	WithConfig(config map[string]any) (Authorizer, error)
+	ContinueOnError() bool
 }

--- a/internal/rules/mechanisms/authorizers/cel_authorizer.go
+++ b/internal/rules/mechanisms/authorizers/cel_authorizer.go
@@ -23,7 +23,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/dadrus/heimdall/internal/heimdall"
-	"github.com/dadrus/heimdall/internal/rules/mechanisms/authorizers/cellib"
+	"github.com/dadrus/heimdall/internal/rules/mechanisms/cellib"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/subject"
 	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
@@ -46,12 +46,12 @@ func init() {
 
 type celAuthorizer struct {
 	id          string
-	expressions []*Expression
+	expressions []*cellib.Expression
 }
 
 func newCELAuthorizer(id string, rawConfig map[string]any) (*celAuthorizer, error) {
 	type Config struct {
-		Expressions []*Expression `mapstructure:"expressions"`
+		Expressions []*cellib.Expression `mapstructure:"expressions"`
 	}
 
 	var conf Config

--- a/internal/rules/mechanisms/authorizers/cel_authorizer.go
+++ b/internal/rules/mechanisms/authorizers/cel_authorizer.go
@@ -119,6 +119,6 @@ func (a *celAuthorizer) WithConfig(rawConfig map[string]any) (Authorizer, error)
 	return newCELAuthorizer(a.id, rawConfig)
 }
 
-func (a *celAuthorizer) HandlerID() string {
-	return a.id
-}
+func (a *celAuthorizer) HandlerID() string { return a.id }
+
+func (a *celAuthorizer) ContinueOnError() bool { return false }

--- a/internal/rules/mechanisms/authorizers/cel_authorizer_test.go
+++ b/internal/rules/mechanisms/authorizers/cel_authorizer_test.go
@@ -120,6 +120,7 @@ expressions:
 				require.NoError(t, err)
 				assert.Equal(t, "authz", auth.HandlerID())
 				assert.NotEmpty(t, auth.expressions)
+				assert.False(t, auth.ContinueOnError())
 			},
 		},
 	} {
@@ -192,6 +193,8 @@ expressions:
 				require.NotNil(t, configured)
 				assert.NotEqual(t, prototype.expressions, configured.expressions)
 				assert.Equal(t, "authz", configured.HandlerID())
+				assert.False(t, prototype.ContinueOnError())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 	} {

--- a/internal/rules/mechanisms/authorizers/deny_authorizer.go
+++ b/internal/rules/mechanisms/authorizers/deny_authorizer.go
@@ -58,6 +58,6 @@ func (a *denyAuthorizer) WithConfig(map[string]any) (Authorizer, error) {
 	return a, nil
 }
 
-func (a *denyAuthorizer) HandlerID() string {
-	return a.id
-}
+func (a *denyAuthorizer) HandlerID() string { return a.id }
+
+func (a *denyAuthorizer) ContinueOnError() bool { return false }

--- a/internal/rules/mechanisms/authorizers/deny_authorizer_test.go
+++ b/internal/rules/mechanisms/authorizers/deny_authorizer_test.go
@@ -48,6 +48,9 @@ func TestCreateDenyAuthorizerFromPrototype(t *testing.T) {
 
 	// nolint: forcetypeassert
 	assert.Equal(t, "foo", conf1.(*denyAuthorizer).HandlerID())
+	assert.False(t, conf1.ContinueOnError())
+	assert.False(t, conf2.ContinueOnError())
+	assert.False(t, prototype.ContinueOnError())
 }
 
 func TestDenyAuthorizerExecute(t *testing.T) {

--- a/internal/rules/mechanisms/authorizers/remote_authorizer.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer.go
@@ -230,9 +230,9 @@ func (a *remoteAuthorizer) WithConfig(rawConfig map[string]any) (Authorizer, err
 	}, nil
 }
 
-func (a *remoteAuthorizer) HandlerID() string {
-	return a.id
-}
+func (a *remoteAuthorizer) HandlerID() string { return a.id }
+
+func (a *remoteAuthorizer) ContinueOnError() bool { return false }
 
 func (a *remoteAuthorizer) doAuthorize(ctx heimdall.Context, sub *subject.Subject) (*authorizationInformation, error) {
 	logger := zerolog.Ctx(ctx.AppContext())

--- a/internal/rules/mechanisms/authorizers/remote_authorizer.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer.go
@@ -34,7 +34,7 @@ import (
 	"github.com/dadrus/heimdall/internal/cache"
 	"github.com/dadrus/heimdall/internal/endpoint"
 	"github.com/dadrus/heimdall/internal/heimdall"
-	"github.com/dadrus/heimdall/internal/rules/mechanisms/authorizers/cellib"
+	"github.com/dadrus/heimdall/internal/rules/mechanisms/cellib"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/contenttype"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/subject"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/template"
@@ -61,7 +61,7 @@ type remoteAuthorizer struct {
 	id                 string
 	e                  endpoint.Endpoint
 	payload            template.Template
-	expressions        []*Expression
+	expressions        []*cellib.Expression
 	headersForUpstream []string
 	ttl                time.Duration
 	celEnv             *cel.Env
@@ -89,11 +89,11 @@ func (ai *authorizationInformation) addAttributesTo(key string, sub *subject.Sub
 
 func newRemoteAuthorizer(id string, rawConfig map[string]any) (*remoteAuthorizer, error) {
 	type Config struct {
-		Endpoint                 endpoint.Endpoint `mapstructure:"endpoint"`
-		Payload                  template.Template `mapstructure:"payload"`
-		Expressions              []*Expression     `mapstructure:"expressions"`
-		ResponseHeadersToForward []string          `mapstructure:"forward_response_headers_to_upstream"`
-		CacheTTL                 time.Duration     `mapstructure:"cache_ttl"`
+		Endpoint                 endpoint.Endpoint    `mapstructure:"endpoint"`
+		Payload                  template.Template    `mapstructure:"payload"`
+		Expressions              []*cellib.Expression `mapstructure:"expressions"`
+		ResponseHeadersToForward []string             `mapstructure:"forward_response_headers_to_upstream"`
+		CacheTTL                 time.Duration        `mapstructure:"cache_ttl"`
 	}
 
 	var conf Config
@@ -197,10 +197,10 @@ func (a *remoteAuthorizer) WithConfig(rawConfig map[string]any) (Authorizer, err
 	}
 
 	type Config struct {
-		Payload                  template.Template `mapstructure:"payload"`
-		Expressions              []*Expression     `mapstructure:"expressions"`
-		ResponseHeadersToForward []string          `mapstructure:"forward_response_headers_to_upstream"`
-		CacheTTL                 time.Duration     `mapstructure:"cache_ttl"`
+		Payload                  template.Template    `mapstructure:"payload"`
+		Expressions              []*cellib.Expression `mapstructure:"expressions"`
+		ResponseHeadersToForward []string             `mapstructure:"forward_response_headers_to_upstream"`
+		CacheTTL                 time.Duration        `mapstructure:"cache_ttl"`
 	}
 
 	var conf Config

--- a/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
@@ -122,6 +122,7 @@ payload: "{{ .Subject.ID }}"
 				assert.Zero(t, auth.ttl)
 
 				assert.Equal(t, "authz", auth.HandlerID())
+				assert.False(t, auth.ContinueOnError())
 			},
 		},
 		{
@@ -182,6 +183,7 @@ cache_ttl: 5s
 				assert.Equal(t, 5*time.Second, auth.ttl)
 
 				assert.Equal(t, "authz", auth.HandlerID())
+				assert.False(t, auth.ContinueOnError())
 			},
 		},
 	} {
@@ -223,6 +225,7 @@ payload: bar
 
 				assert.Equal(t, prototype, configured)
 				assert.Equal(t, "authz1", configured.HandlerID())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 		{
@@ -241,6 +244,7 @@ payload: bar
 
 				assert.Equal(t, prototype, configured)
 				assert.Equal(t, "authz2", configured.HandlerID())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 		{
@@ -287,6 +291,7 @@ cache_ttl: 1s
 				assert.Empty(t, configured.headersForUpstream)
 				assert.NotNil(t, configured.ttl)
 				assert.Equal(t, "authz3", configured.HandlerID())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 		{
@@ -359,6 +364,7 @@ cache_ttl: 15s
 				assert.NotEqual(t, prototype.headersForUpstream, configured.headersForUpstream)
 				assert.NotEqual(t, prototype.payload, configured.payload)
 				assert.Equal(t, "authz4", configured.HandlerID())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 	} {

--- a/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/dadrus/heimdall/internal/endpoint"
 	"github.com/dadrus/heimdall/internal/heimdall"
 	heimdallmocks "github.com/dadrus/heimdall/internal/heimdall/mocks"
-	"github.com/dadrus/heimdall/internal/rules/mechanisms/authorizers/cellib"
+	"github.com/dadrus/heimdall/internal/rules/mechanisms/cellib"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/subject"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/template"
 	"github.com/dadrus/heimdall/internal/x"
@@ -947,13 +947,13 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 					return tpl
 				}(),
-				expressions: func() []*Expression {
-					expr := &Expression{Value: "false == true"}
+				expressions: func() []*cellib.Expression {
+					expr := &cellib.Expression{Value: "false == true"}
 
 					err := expr.Compile(env)
 					require.NoError(t, err)
 
-					return []*Expression{expr}
+					return []*cellib.Expression{expr}
 				}(),
 			},
 			subject: &subject.Subject{
@@ -1029,13 +1029,13 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 					return tpl
 				}(),
-				expressions: func() []*Expression {
-					expr := &Expression{Value: "Payload.access_granted == true"}
+				expressions: func() []*cellib.Expression {
+					expr := &cellib.Expression{Value: "Payload.access_granted == true"}
 
 					err := expr.Compile(env)
 					require.NoError(t, err)
 
-					return []*Expression{expr}
+					return []*cellib.Expression{expr}
 				}(),
 			},
 			subject: &subject.Subject{

--- a/internal/rules/mechanisms/cellib/expression.go
+++ b/internal/rules/mechanisms/cellib/expression.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package authorizers
+package cellib
 
 import (
 	"errors"

--- a/internal/rules/mechanisms/cellib/library.go
+++ b/internal/rules/mechanisms/cellib/library.go
@@ -42,13 +42,13 @@ func (heimdallLibrary) CompileOptions() []cel.EnvOption {
 		cel.Variable("Subject", cel.DynType),
 		cel.Variable("Request", cel.ObjectType(requestType.TypeName())),
 		cel.Function("Header", cel.MemberOverload("Header",
-			[]*cel.Type{cel.ObjectType("cellib.Request"), cel.StringType}, cel.StringType)),
+			[]*cel.Type{cel.ObjectType(requestType.TypeName()), cel.StringType}, cel.StringType)),
 		cel.Function("Cookie", cel.MemberOverload("Cookie",
-			[]*cel.Type{cel.ObjectType("cellib.Request"), cel.StringType}, cel.StringType)),
+			[]*cel.Type{cel.ObjectType(requestType.TypeName()), cel.StringType}, cel.StringType)),
 		cel.Function("String", cel.MemberOverload("String",
-			[]*cel.Type{cel.ObjectType("cellib.URL")}, cel.StringType)),
+			[]*cel.Type{cel.ObjectType(urlType.TypeName())}, cel.StringType)),
 		cel.Function("Query", cel.MemberOverload("Query",
-			[]*cel.Type{cel.ObjectType("cellib.URL")}, cel.DynType)),
+			[]*cel.Type{cel.ObjectType(urlType.TypeName())}, cel.DynType)),
 	}
 }
 

--- a/internal/rules/mechanisms/cellib/types.go
+++ b/internal/rules/mechanisms/cellib/types.go
@@ -32,8 +32,8 @@ import (
 var (
 	errTypeConversion = errors.New("type conversion error")
 
-	requestType = types.NewTypeValue("cellib.Request", traits.ReceiverType) //nolint:gochecknoglobals
-	urlType     = types.NewTypeValue("cellib.URL", traits.ReceiverType)     //nolint:gochecknoglobals
+	requestType = types.NewTypeValue(reflect.TypeOf(Request{}).String(), traits.ReceiverType) //nolint:gochecknoglobals
+	urlType     = types.NewTypeValue(reflect.TypeOf(URL{}).String(), traits.ReceiverType)     //nolint:gochecknoglobals
 )
 
 type URL struct {

--- a/internal/rules/mechanisms/contextualizers/contextualizer.go
+++ b/internal/rules/mechanisms/contextualizers/contextualizer.go
@@ -24,4 +24,5 @@ import (
 type Contextualizer interface {
 	Execute(heimdall.Context, *subject.Subject) error
 	WithConfig(config map[string]any) (Contextualizer, error)
+	ContinueOnError() bool
 }

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
@@ -148,12 +148,6 @@ func (h *genericContextualizer) Execute(ctx heimdall.Context, sub *subject.Subje
 	if response == nil {
 		response, err = h.callEndpoint(ctx, sub)
 		if err != nil {
-			if h.continueOnError {
-				logger.Warn().Err(err).Msg("Error while communicating with the contextualizer endpoint")
-
-				return nil
-			}
-
 			return err
 		}
 
@@ -204,9 +198,9 @@ func (h *genericContextualizer) WithConfig(rawConfig map[string]any) (Contextual
 	}, nil
 }
 
-func (h *genericContextualizer) HandlerID() string {
-	return h.id
-}
+func (h *genericContextualizer) HandlerID() string { return h.id }
+
+func (h *genericContextualizer) ContinueOnError() bool { return h.continueOnError }
 
 func (h *genericContextualizer) callEndpoint(ctx heimdall.Context, sub *subject.Subject) (*contextualizerData, error) {
 	logger := zerolog.Ctx(ctx.AppContext())

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
@@ -79,7 +79,7 @@ func newGenericContextualizer(id string, rawConfig map[string]any) (*genericCont
 		ForwardCookies  []string          `mapstructure:"forward_cookies"`
 		Payload         template.Template `mapstructure:"payload"`
 		CacheTTL        *time.Duration    `mapstructure:"cache_ttl"`
-		ContinueOnError bool              `mapstructure:"continue_on_error"`
+		ContinueOnError bool              `mapstructure:"continue_pipeline_on_error"`
 	}
 
 	var conf Config

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
@@ -173,13 +173,13 @@ func (h *genericContextualizer) WithConfig(rawConfig map[string]any) (Contextual
 		ForwardCookies  []string          `mapstructure:"forward_cookies"`
 		Payload         template.Template `mapstructure:"payload"`
 		CacheTTL        *time.Duration    `mapstructure:"cache_ttl"`
-		ContinueOnError *bool             `mapstructure:"continue_on_error"`
+		ContinueOnError *bool             `mapstructure:"continue_pipeline_on_error"`
 	}
 
 	var conf Config
 	if err := decodeConfig(rawConfig, &conf); err != nil {
 		return nil, errorchain.
-			NewWithMessage(heimdall.ErrConfiguration, "failed to unmarshal JWT unifier config").
+			NewWithMessage(heimdall.ErrConfiguration, "failed to unmarshal generic contextualizer config").
 			CausedBy(err)
 	}
 

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer_test.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer_test.go
@@ -296,6 +296,7 @@ forward_headers:
 forward_cookies:
   - My-Foo-Session
 cache_ttl: 5s
+continue_pipeline_on_error: true
 `),
 			config: []byte(`
 payload: foo
@@ -325,8 +326,8 @@ forward_cookies:
 				assert.Contains(t, configured.fwdCookies, "Foo-Session")
 				assert.Equal(t, prototype.ttl, configured.ttl)
 				assert.Equal(t, "contextualizer4", configured.HandlerID())
-				assert.False(t, prototype.ContinueOnError())
-				assert.False(t, configured.ContinueOnError())
+				assert.True(t, prototype.ContinueOnError())
+				assert.True(t, configured.ContinueOnError())
 			},
 		},
 		{
@@ -351,6 +352,7 @@ forward_headers:
 forward_cookies:
   - Foo-Session
 cache_ttl: 15s
+continue_pipeline_on_error: false
 `),
 			assert: func(t *testing.T, err error, prototype *genericContextualizer, configured *genericContextualizer) {
 				t.Helper()
@@ -375,7 +377,7 @@ cache_ttl: 15s
 				assert.Equal(t, 15*time.Second, configured.ttl)
 				assert.Equal(t, "contextualizer5", configured.HandlerID())
 				assert.True(t, prototype.ContinueOnError())
-				assert.True(t, configured.ContinueOnError())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 	} {

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer_test.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer_test.go
@@ -106,6 +106,7 @@ payload: bar
 				assert.False(t, contextualizer.ContinueOnError())
 
 				assert.Equal(t, "contextualizer", contextualizer.HandlerID())
+				assert.False(t, contextualizer.ContinueOnError())
 			},
 		},
 		{
@@ -121,7 +122,7 @@ forward_cookies:
   - My-Foo-Session
 payload: "{{ .Subject.ID }}"
 cache_ttl: 5s
-continue_on_error: true
+continue_pipeline_on_error: true
 `),
 			assert: func(t *testing.T, err error, contextualizer *genericContextualizer) {
 				t.Helper()
@@ -236,6 +237,8 @@ payload: foo
 				assert.Equal(t, prototype.fwdCookies, configured.fwdCookies)
 				assert.Equal(t, prototype.ttl, configured.ttl)
 				assert.Equal(t, "contextualizer2", configured.HandlerID())
+				assert.False(t, prototype.ContinueOnError())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 		{
@@ -276,6 +279,8 @@ forward_headers:
 				assert.Equal(t, prototype.fwdCookies, configured.fwdCookies)
 				assert.Equal(t, prototype.ttl, configured.ttl)
 				assert.Equal(t, "contextualizer3", configured.HandlerID())
+				assert.False(t, prototype.ContinueOnError())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 		{
@@ -320,6 +325,8 @@ forward_cookies:
 				assert.Contains(t, configured.fwdCookies, "Foo-Session")
 				assert.Equal(t, prototype.ttl, configured.ttl)
 				assert.Equal(t, "contextualizer4", configured.HandlerID())
+				assert.False(t, prototype.ContinueOnError())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 		{
@@ -335,6 +342,7 @@ forward_headers:
 forward_cookies:
   - My-Foo-Session
 cache_ttl: 5s
+continue_pipeline_on_error: true
 `),
 			config: []byte(`
 payload: foo
@@ -366,6 +374,8 @@ cache_ttl: 15s
 				assert.NotEqual(t, prototype.ttl, configured.ttl)
 				assert.Equal(t, 15*time.Second, configured.ttl)
 				assert.Equal(t, "contextualizer5", configured.HandlerID())
+				assert.True(t, prototype.ContinueOnError())
+				assert.True(t, configured.ContinueOnError())
 			},
 		},
 	} {

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer_test.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer_test.go
@@ -103,6 +103,7 @@ payload: bar
 				assert.Empty(t, contextualizer.fwdCookies)
 				assert.Empty(t, contextualizer.fwdHeaders)
 				assert.Equal(t, defaultTTL, contextualizer.ttl)
+				assert.False(t, contextualizer.ContinueOnError())
 
 				assert.Equal(t, "contextualizer", contextualizer.HandlerID())
 			},
@@ -120,6 +121,7 @@ forward_cookies:
   - My-Foo-Session
 payload: "{{ .Subject.ID }}"
 cache_ttl: 5s
+continue_on_error: true
 `),
 			assert: func(t *testing.T, err error, contextualizer *genericContextualizer) {
 				t.Helper()
@@ -140,6 +142,7 @@ cache_ttl: 5s
 				assert.Equal(t, 5*time.Second, contextualizer.ttl)
 
 				assert.Equal(t, "contextualizer", contextualizer.HandlerID())
+				assert.True(t, contextualizer.ContinueOnError())
 			},
 		},
 	} {

--- a/internal/rules/mechanisms/errorhandlers/default_error_handler.go
+++ b/internal/rules/mechanisms/errorhandlers/default_error_handler.go
@@ -31,9 +31,7 @@ func init() {
 				return false, nil, nil
 			}
 
-			eh, err := newDefaultErrorHandler(id)
-
-			return true, eh, err
+			return true, newDefaultErrorHandler(id), nil
 		})
 }
 
@@ -41,8 +39,8 @@ type defaultErrorHandler struct {
 	id string
 }
 
-func newDefaultErrorHandler(id string) (*defaultErrorHandler, error) {
-	return &defaultErrorHandler{id: id}, nil
+func newDefaultErrorHandler(id string) *defaultErrorHandler {
+	return &defaultErrorHandler{id: id}
 }
 
 func (eh *defaultErrorHandler) Execute(ctx heimdall.Context, err error) (bool, error) {

--- a/internal/rules/mechanisms/errorhandlers/default_error_handler.go
+++ b/internal/rules/mechanisms/errorhandlers/default_error_handler.go
@@ -26,21 +26,23 @@ import (
 // nolint
 func init() {
 	registerErrorHandlerTypeFactory(
-		func(_ string, typ string, conf map[string]any) (bool, ErrorHandler, error) {
+		func(id string, typ string, conf map[string]any) (bool, ErrorHandler, error) {
 			if typ != ErrorHandlerDefault {
 				return false, nil, nil
 			}
 
-			eh, err := newDefaultErrorHandler()
+			eh, err := newDefaultErrorHandler(id)
 
 			return true, eh, err
 		})
 }
 
-type defaultErrorHandler struct{}
+type defaultErrorHandler struct {
+	id string
+}
 
-func newDefaultErrorHandler() (*defaultErrorHandler, error) {
-	return &defaultErrorHandler{}, nil
+func newDefaultErrorHandler(id string) (*defaultErrorHandler, error) {
+	return &defaultErrorHandler{id: id}, nil
 }
 
 func (eh *defaultErrorHandler) Execute(ctx heimdall.Context, err error) (bool, error) {
@@ -52,6 +54,6 @@ func (eh *defaultErrorHandler) Execute(ctx heimdall.Context, err error) (bool, e
 	return true, nil
 }
 
-func (eh *defaultErrorHandler) WithConfig(_ map[string]any) (ErrorHandler, error) {
-	return eh, nil
-}
+func (eh *defaultErrorHandler) WithConfig(_ map[string]any) (ErrorHandler, error) { return eh, nil }
+
+func (eh *defaultErrorHandler) HandlerID() string { return eh.id }

--- a/internal/rules/mechanisms/errorhandlers/default_error_handler_test.go
+++ b/internal/rules/mechanisms/errorhandlers/default_error_handler_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/heimdall/mocks"
@@ -35,8 +34,7 @@ func TestDefaultErrorHandlerExecution(t *testing.T) {
 	ctx.On("AppContext").Return(context.Background())
 	ctx.On("SetPipelineError", heimdall.ErrConfiguration)
 
-	errorHandler, err := newDefaultErrorHandler("foo")
-	require.NoError(t, err)
+	errorHandler := newDefaultErrorHandler("foo")
 
 	// WHEN
 	wasHandled, err := errorHandler.Execute(ctx, heimdall.ErrConfiguration)
@@ -50,8 +48,7 @@ func TestDefaultErrorHandlerPrototype(t *testing.T) {
 	t.Parallel()
 
 	// GIVEN
-	prototype, err := newDefaultErrorHandler("foo")
-	require.NoError(t, err)
+	prototype := newDefaultErrorHandler("foo")
 
 	// WHEN
 	eh1, err1 := prototype.WithConfig(nil)

--- a/internal/rules/mechanisms/errorhandlers/default_error_handler_test.go
+++ b/internal/rules/mechanisms/errorhandlers/default_error_handler_test.go
@@ -60,4 +60,5 @@ func TestDefaultErrorHandlerPrototype(t *testing.T) {
 
 	assert.NoError(t, err2)
 	assert.Equal(t, prototype, eh2)
+	assert.Equal(t, "foo", prototype.HandlerID())
 }

--- a/internal/rules/mechanisms/errorhandlers/default_error_handler_test.go
+++ b/internal/rules/mechanisms/errorhandlers/default_error_handler_test.go
@@ -35,7 +35,7 @@ func TestDefaultErrorHandlerExecution(t *testing.T) {
 	ctx.On("AppContext").Return(context.Background())
 	ctx.On("SetPipelineError", heimdall.ErrConfiguration)
 
-	errorHandler, err := newDefaultErrorHandler()
+	errorHandler, err := newDefaultErrorHandler("foo")
 	require.NoError(t, err)
 
 	// WHEN
@@ -50,7 +50,7 @@ func TestDefaultErrorHandlerPrototype(t *testing.T) {
 	t.Parallel()
 
 	// GIVEN
-	prototype, err := newDefaultErrorHandler()
+	prototype, err := newDefaultErrorHandler("foo")
 	require.NoError(t, err)
 
 	// WHEN

--- a/internal/rules/mechanisms/errorhandlers/redirect_error_handler_test.go
+++ b/internal/rules/mechanisms/errorhandlers/redirect_error_handler_test.go
@@ -128,6 +128,7 @@ when:
 
 				require.NoError(t, err)
 				require.NotNil(t, redEH)
+				assert.Equal(t, "with minimal valid configuration", redEH.HandlerID())
 
 				toURL, err := redEH.to.Render(nil, nil)
 				require.NoError(t, err)
@@ -176,6 +177,7 @@ when:
 
 				require.NoError(t, err)
 				require.NotNil(t, redEH)
+				assert.Equal(t, "with full complex valid configuration", redEH.HandlerID())
 
 				ctx := &mocks.MockContext{}
 				ctx.On("RequestMethod").Return("POST")
@@ -227,7 +229,7 @@ when:
 			require.NoError(t, err)
 
 			// WHEN
-			errorHandler, err := newRedirectErrorHandler("foo", conf)
+			errorHandler, err := newRedirectErrorHandler(tc.uc, conf)
 
 			// THEN
 			tc.assert(t, err, errorHandler)
@@ -257,6 +259,7 @@ when:
 
 				require.NoError(t, err)
 				assert.Equal(t, prototype, configured)
+				assert.Equal(t, "no new configuration provided", configured.HandlerID())
 			},
 		},
 		{
@@ -273,6 +276,7 @@ when:
 
 				require.NoError(t, err)
 				assert.Equal(t, prototype, configured)
+				assert.Equal(t, "empty configuration provided", configured.HandlerID())
 			},
 		},
 		{
@@ -313,6 +317,7 @@ when:
 				require.NoError(t, err)
 				assert.NotEqual(t, prototype, configured)
 				assert.NotNil(t, configured)
+				assert.Equal(t, "required 'when' field provided", configured.HandlerID())
 				assert.Equal(t, prototype.to, configured.to)
 				assert.Equal(t, prototype.code, configured.code)
 				assert.NotEqual(t, prototype.m, configured.m)
@@ -336,7 +341,7 @@ when:
 			conf, err := testsupport.DecodeTestConfig(tc.config)
 			require.NoError(t, err)
 
-			prototype, err := newRedirectErrorHandler("foo", pc)
+			prototype, err := newRedirectErrorHandler(tc.uc, pc)
 			require.NoError(t, err)
 
 			// WHEN

--- a/internal/rules/mechanisms/errorhandlers/redirect_error_handler_test.go
+++ b/internal/rules/mechanisms/errorhandlers/redirect_error_handler_test.go
@@ -227,7 +227,7 @@ when:
 			require.NoError(t, err)
 
 			// WHEN
-			errorHandler, err := newRedirectErrorHandler(conf)
+			errorHandler, err := newRedirectErrorHandler("foo", conf)
 
 			// THEN
 			tc.assert(t, err, errorHandler)
@@ -336,7 +336,7 @@ when:
 			conf, err := testsupport.DecodeTestConfig(tc.config)
 			require.NoError(t, err)
 
-			prototype, err := newRedirectErrorHandler(pc)
+			prototype, err := newRedirectErrorHandler("foo", pc)
 			require.NoError(t, err)
 
 			// WHEN
@@ -499,7 +499,7 @@ when:
 
 			configureContext(t, mctx)
 
-			errorHandler, err := newRedirectErrorHandler(conf)
+			errorHandler, err := newRedirectErrorHandler("foo", conf)
 			require.NoError(t, err)
 
 			// WHEN

--- a/internal/rules/mechanisms/errorhandlers/www_authenticate_error_handler_test.go
+++ b/internal/rules/mechanisms/errorhandlers/www_authenticate_error_handler_test.go
@@ -100,6 +100,7 @@ when:
 
 				require.NoError(t, err)
 				require.NotNil(t, errorHandler)
+				assert.Equal(t, "with minimum required configuration", errorHandler.HandlerID())
 				assert.Equal(t, "Please authenticate", errorHandler.realm)
 				require.Len(t, errorHandler.m, 1)
 				assert.Nil(t, errorHandler.m[0].CIDR)
@@ -125,6 +126,7 @@ when:
 
 				require.NoError(t, err)
 				require.NotNil(t, errorHandler)
+				assert.Equal(t, "with all possible attributes", errorHandler.HandlerID())
 				assert.Equal(t, "What is your password", errorHandler.realm)
 				require.Len(t, errorHandler.m, 1)
 				assert.Nil(t, errorHandler.m[0].CIDR)
@@ -143,7 +145,7 @@ when:
 			require.NoError(t, err)
 
 			// WHEN
-			errorHandler, err := newWWWAuthenticateErrorHandler("foo", conf)
+			errorHandler, err := newWWWAuthenticateErrorHandler(tc.uc, conf)
 
 			// THEN
 			tc.assert(t, err, errorHandler)
@@ -175,6 +177,7 @@ when:
 
 				require.NoError(t, err)
 				assert.Equal(t, prototype, configured)
+				assert.Equal(t, "no new configuration provided", configured.HandlerID())
 			},
 		},
 		{
@@ -192,6 +195,7 @@ when:
 
 				require.NoError(t, err)
 				assert.Equal(t, prototype, configured)
+				assert.Equal(t, "empty configuration provided", configured.HandlerID())
 			},
 		},
 		{
@@ -233,6 +237,7 @@ when:
 				require.NoError(t, err)
 				assert.NotEqual(t, prototype, configured)
 				assert.NotNil(t, configured)
+				assert.Equal(t, "with 'when' reconfigured", configured.HandlerID())
 				assert.Equal(t, "Please authenticate", prototype.realm)
 				assert.Equal(t, prototype.realm, configured.realm)
 				assert.NotEqual(t, prototype.m, configured.m)
@@ -264,6 +269,7 @@ when:
 				require.NoError(t, err)
 				assert.NotEqual(t, prototype, configured)
 				assert.NotNil(t, configured)
+				assert.Equal(t, "with 'realm' reconfigured", configured.HandlerID())
 				assert.NotEqual(t, prototype.realm, configured.realm)
 				assert.Equal(t, "You password please", configured.realm)
 				assert.Equal(t, prototype.m, configured.m)
@@ -277,7 +283,7 @@ when:
 			conf, err := testsupport.DecodeTestConfig(tc.config)
 			require.NoError(t, err)
 
-			prototype, err := newWWWAuthenticateErrorHandler("foo", pc)
+			prototype, err := newWWWAuthenticateErrorHandler(tc.uc, pc)
 			require.NoError(t, err)
 
 			// WHEN

--- a/internal/rules/mechanisms/errorhandlers/www_authenticate_error_handler_test.go
+++ b/internal/rules/mechanisms/errorhandlers/www_authenticate_error_handler_test.go
@@ -143,7 +143,7 @@ when:
 			require.NoError(t, err)
 
 			// WHEN
-			errorHandler, err := newWWWAuthenticateErrorHandler(conf)
+			errorHandler, err := newWWWAuthenticateErrorHandler("foo", conf)
 
 			// THEN
 			tc.assert(t, err, errorHandler)
@@ -277,7 +277,7 @@ when:
 			conf, err := testsupport.DecodeTestConfig(tc.config)
 			require.NoError(t, err)
 
-			prototype, err := newWWWAuthenticateErrorHandler(pc)
+			prototype, err := newWWWAuthenticateErrorHandler("foo", pc)
 			require.NoError(t, err)
 
 			// WHEN
@@ -396,7 +396,7 @@ when:
 
 			configureContext(t, mctx)
 
-			errorHandler, err := newWWWAuthenticateErrorHandler(conf)
+			errorHandler, err := newWWWAuthenticateErrorHandler("foo", conf)
 			require.NoError(t, err)
 
 			// WHEN

--- a/internal/rules/mechanisms/mocks/authorizer.go
+++ b/internal/rules/mechanisms/mocks/authorizer.go
@@ -42,3 +42,7 @@ func (m *MockAuthorizer) WithConfig(config map[string]any) (authorizers.Authoriz
 
 	return nil, args.Error(1)
 }
+
+func (m *MockAuthorizer) ContinueOnError() bool {
+	return m.Called().Bool(0)
+}

--- a/internal/rules/mechanisms/mocks/contextualizer.go
+++ b/internal/rules/mechanisms/mocks/contextualizer.go
@@ -42,3 +42,7 @@ func (m *MockContextualizer) WithConfig(config map[string]any) (contextualizers.
 
 	return nil, args.Error(1)
 }
+
+func (m *MockContextualizer) ContinueOnError() bool {
+	return m.Called().Bool(0)
+}

--- a/internal/rules/mechanisms/mocks/unifier.go
+++ b/internal/rules/mechanisms/mocks/unifier.go
@@ -42,3 +42,7 @@ func (m *MockUnifier) WithConfig(config map[string]any) (unifiers.Unifier, error
 
 	return nil, args.Error(1)
 }
+
+func (m *MockUnifier) ContinueOnError() bool {
+	return m.Called().Bool(0)
+}

--- a/internal/rules/mechanisms/unifiers/cookie_unifier.go
+++ b/internal/rules/mechanisms/unifiers/cookie_unifier.go
@@ -101,6 +101,6 @@ func (m *cookieUnifier) WithConfig(config map[string]any) (Unifier, error) {
 	return newCookieUnifier(m.id, config)
 }
 
-func (m *cookieUnifier) HandlerID() string {
-	return m.id
-}
+func (m *cookieUnifier) HandlerID() string { return m.id }
+
+func (m *cookieUnifier) ContinueOnError() bool { return false }

--- a/internal/rules/mechanisms/unifiers/cookie_unifier_test.go
+++ b/internal/rules/mechanisms/unifiers/cookie_unifier_test.go
@@ -112,6 +112,8 @@ cookies:
 				val, err = unifier.cookies["bar"].Render(nil, &subject.Subject{ID: "baz"})
 				require.NoError(t, err)
 				assert.Equal(t, "baz", val)
+
+				assert.False(t, unifier.ContinueOnError())
 			},
 		},
 	} {
@@ -188,10 +190,14 @@ cookies:
 				require.NotNil(t, configured)
 				assert.NotEmpty(t, configured.cookies)
 				assert.Equal(t, "cun3", configured.HandlerID())
+				assert.Equal(t, prototype.HandlerID(), configured.HandlerID())
 
 				val, err := configured.cookies["bar"].Render(nil, nil)
 				require.NoError(t, err)
 				assert.Equal(t, "foo", val)
+
+				assert.False(t, prototype.ContinueOnError())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 	} {

--- a/internal/rules/mechanisms/unifiers/header_unifier.go
+++ b/internal/rules/mechanisms/unifiers/header_unifier.go
@@ -101,6 +101,6 @@ func (m *headerUnifier) WithConfig(config map[string]any) (Unifier, error) {
 	return newHeaderUnifier(m.id, config)
 }
 
-func (m *headerUnifier) HandlerID() string {
-	return m.id
-}
+func (m *headerUnifier) HandlerID() string { return m.id }
+
+func (m *headerUnifier) ContinueOnError() bool { return false }

--- a/internal/rules/mechanisms/unifiers/header_unifier_test.go
+++ b/internal/rules/mechanisms/unifiers/header_unifier_test.go
@@ -111,6 +111,8 @@ headers:
 				val, err = unifier.headers["bar"].Render(nil, &subject.Subject{ID: "baz"})
 				require.NoError(t, err)
 				assert.Equal(t, "baz", val)
+
+				assert.False(t, unifier.ContinueOnError())
 			},
 		},
 	} {
@@ -187,10 +189,14 @@ headers:
 				require.NotNil(t, configured)
 				assert.NotEmpty(t, configured.headers)
 				assert.Equal(t, "hun3", configured.HandlerID())
+				assert.Equal(t, prototype.HandlerID(), configured.HandlerID())
 
 				val, err := configured.headers["bar"].Render(nil, nil)
 				require.NoError(t, err)
 				assert.Equal(t, "foo", val)
+
+				assert.False(t, prototype.ContinueOnError())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 	} {

--- a/internal/rules/mechanisms/unifiers/jwt_unifier.go
+++ b/internal/rules/mechanisms/unifiers/jwt_unifier.go
@@ -167,9 +167,9 @@ func (m *jwtUnifier) WithConfig(rawConfig map[string]any) (Unifier, error) {
 	}, nil
 }
 
-func (m *jwtUnifier) HandlerID() string {
-	return m.id
-}
+func (m *jwtUnifier) HandlerID() string { return m.id }
+
+func (m *jwtUnifier) ContinueOnError() bool { return false }
 
 func (m *jwtUnifier) generateToken(ctx heimdall.Context, sub *subject.Subject) (string, error) {
 	iss := ctx.Signer()

--- a/internal/rules/mechanisms/unifiers/jwt_unifier_test.go
+++ b/internal/rules/mechanisms/unifiers/jwt_unifier_test.go
@@ -120,6 +120,7 @@ claims:
 				require.NoError(t, err)
 				assert.Equal(t, `{ "sub": "bar" }`, val)
 				assert.Equal(t, "jun", unifier.HandlerID())
+				assert.False(t, unifier.ContinueOnError())
 			},
 		},
 		{
@@ -142,6 +143,7 @@ claims:
 				require.NoError(t, err)
 				assert.Equal(t, `{ "sub": "bar" }`, val)
 				assert.Equal(t, "jun", unifier.HandlerID())
+				assert.False(t, unifier.ContinueOnError())
 			},
 		},
 		{
@@ -194,6 +196,7 @@ func TestCreateJWTUnifierFromPrototype(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, prototype, configured)
 				assert.Equal(t, "jun1", configured.HandlerID())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 		{
@@ -206,6 +209,7 @@ func TestCreateJWTUnifierFromPrototype(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, prototype, configured)
 				assert.Equal(t, "jun2", configured.HandlerID())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 		{
@@ -221,6 +225,8 @@ func TestCreateJWTUnifierFromPrototype(t *testing.T) {
 				assert.NotEqual(t, prototype.ttl, configured.ttl)
 				assert.Equal(t, expectedTTL, configured.ttl)
 				assert.Equal(t, "jun3", configured.HandlerID())
+				assert.False(t, prototype.ContinueOnError())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 		{
@@ -253,6 +259,8 @@ claims:
 				require.NoError(t, err)
 				assert.Equal(t, `{ "sub": "bar" }`, val)
 				assert.Equal(t, "jun4", configured.HandlerID())
+				assert.False(t, prototype.ContinueOnError())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 		{
@@ -276,6 +284,8 @@ claims:
 				require.NoError(t, err)
 				assert.Equal(t, `{ "sub": "bar" }`, val)
 				assert.Equal(t, "jun5", configured.HandlerID())
+				assert.False(t, prototype.ContinueOnError())
+				assert.False(t, configured.ContinueOnError())
 			},
 		},
 		{

--- a/internal/rules/mechanisms/unifiers/noop_unifier.go
+++ b/internal/rules/mechanisms/unifiers/noop_unifier.go
@@ -27,18 +27,20 @@ import (
 // nolint
 func init() {
 	registerUnifierTypeFactory(
-		func(_ string, typ string, conf map[string]any) (bool, Unifier, error) {
+		func(id string, typ string, conf map[string]any) (bool, Unifier, error) {
 			if typ != UnifierNoop {
 				return false, nil, nil
 			}
 
-			return true, newNoopUnifier(), nil
+			return true, newNoopUnifier(id), nil
 		})
 }
 
-func newNoopUnifier() *noopUnifier { return &noopUnifier{} }
+func newNoopUnifier(id string) *noopUnifier { return &noopUnifier{id: id} }
 
-type noopUnifier struct{}
+type noopUnifier struct {
+	id string
+}
 
 func (m *noopUnifier) Execute(ctx heimdall.Context, sub *subject.Subject) error {
 	logger := zerolog.Ctx(ctx.AppContext())
@@ -48,3 +50,7 @@ func (m *noopUnifier) Execute(ctx heimdall.Context, sub *subject.Subject) error 
 }
 
 func (m *noopUnifier) WithConfig(map[string]any) (Unifier, error) { return m, nil }
+
+func (m *noopUnifier) HandlerID() string { return m.id }
+
+func (m *noopUnifier) ContinueOnError() bool { return false }

--- a/internal/rules/mechanisms/unifiers/noop_unifier.go
+++ b/internal/rules/mechanisms/unifiers/noop_unifier.go
@@ -42,7 +42,7 @@ type noopUnifier struct {
 	id string
 }
 
-func (m *noopUnifier) Execute(ctx heimdall.Context, sub *subject.Subject) error {
+func (m *noopUnifier) Execute(ctx heimdall.Context, _ *subject.Subject) error {
 	logger := zerolog.Ctx(ctx.AppContext())
 	logger.Debug().Msg("Unifying using noop unifier")
 

--- a/internal/rules/mechanisms/unifiers/noop_unifier_test.go
+++ b/internal/rules/mechanisms/unifiers/noop_unifier_test.go
@@ -40,6 +40,8 @@ func TestNoopUnifierExecution(t *testing.T) {
 
 	// THEN
 	require.NoError(t, err)
+	assert.Equal(t, "foo", unifier.HandlerID())
+	assert.False(t, unifier.ContinueOnError())
 }
 
 func TestCreateNoopUnifierFromPrototype(t *testing.T) {

--- a/internal/rules/mechanisms/unifiers/noop_unifier_test.go
+++ b/internal/rules/mechanisms/unifiers/noop_unifier_test.go
@@ -33,7 +33,7 @@ func TestNoopUnifierExecution(t *testing.T) {
 	ctx := &mocks.MockContext{}
 	ctx.On("AppContext").Return(context.Background())
 
-	unifier := newNoopUnifier()
+	unifier := newNoopUnifier("foo")
 
 	// WHEN
 	err := unifier.Execute(ctx, nil)
@@ -46,7 +46,7 @@ func TestCreateNoopUnifierFromPrototype(t *testing.T) {
 	t.Parallel()
 
 	// GIVEN
-	prototype := newNoopUnifier()
+	prototype := newNoopUnifier("baz")
 
 	// WHEN
 	un1, err1 := prototype.WithConfig(nil)

--- a/internal/rules/mechanisms/unifiers/unifier.go
+++ b/internal/rules/mechanisms/unifiers/unifier.go
@@ -24,4 +24,5 @@ import (
 type Unifier interface {
 	Execute(ctx heimdall.Context, sub *subject.Subject) error
 	WithConfig(config map[string]any) (Unifier, error)
+	ContinueOnError() bool
 }

--- a/internal/rules/mocks/subject_handler.go
+++ b/internal/rules/mocks/subject_handler.go
@@ -27,6 +27,10 @@ type MockSubjectHandler struct {
 	mock.Mock
 }
 
-func (a *MockSubjectHandler) Execute(ctx heimdall.Context, sub *subject.Subject) error {
-	return a.Called(ctx, sub).Error(0)
+func (m *MockSubjectHandler) Execute(ctx heimdall.Context, sub *subject.Subject) error {
+	return m.Called(ctx, sub).Error(0)
+}
+
+func (m *MockSubjectHandler) ContinueOnError() bool {
+	return m.Called().Bool(0)
 }

--- a/internal/rules/rule_impl_test.go
+++ b/internal/rules/rule_impl_test.go
@@ -203,6 +203,7 @@ func TestRuleExecute(t *testing.T) {
 
 				authenticator.On("Execute", ctx).Return(sub, nil)
 				authorizer.On("Execute", ctx, sub).Return(testsupport.ErrTestPurpose)
+				authorizer.On("ContinueOnError").Return(false)
 				errHandler.On("Execute", ctx, testsupport.ErrTestPurpose).
 					Return(true, nil)
 			},
@@ -214,7 +215,7 @@ func TestRuleExecute(t *testing.T) {
 			},
 		},
 		{
-			uc:          "authenticator succeeds, authorizer fails, but error handler fails",
+			uc:          "authenticator succeeds, authorizer fails and error handler fails",
 			upstreamURL: &url.URL{Scheme: "http", Host: "test.local", Path: "foo"},
 			configureMocks: func(t *testing.T, ctx *heimdallmocks.MockContext, authenticator *mocks.MockSubjectCreator,
 				authorizer *mocks.MockSubjectHandler, unifier *mocks.MockSubjectHandler,
@@ -226,6 +227,7 @@ func TestRuleExecute(t *testing.T) {
 
 				authenticator.On("Execute", ctx).Return(sub, nil)
 				authorizer.On("Execute", ctx, sub).Return(testsupport.ErrTestPurpose)
+				authorizer.On("ContinueOnError").Return(false)
 				errHandler.On("Execute", ctx, testsupport.ErrTestPurpose).
 					Return(true, testsupport.ErrTestPurpose2)
 			},
@@ -251,6 +253,7 @@ func TestRuleExecute(t *testing.T) {
 				authenticator.On("Execute", ctx).Return(sub, nil)
 				authorizer.On("Execute", ctx, sub).Return(nil)
 				unifier.On("Execute", ctx, sub).Return(testsupport.ErrTestPurpose)
+				unifier.On("ContinueOnError").Return(false)
 				errHandler.On("Execute", ctx, testsupport.ErrTestPurpose).
 					Return(true, nil)
 			},
@@ -262,7 +265,7 @@ func TestRuleExecute(t *testing.T) {
 			},
 		},
 		{
-			uc:          "authenticator succeeds, authorizer succeeds, unifier fails, but error handler fails",
+			uc:          "authenticator succeeds, authorizer succeeds, unifier fails and error handler fails",
 			upstreamURL: &url.URL{Scheme: "http", Host: "test.local", Path: "foo"},
 			configureMocks: func(t *testing.T, ctx *heimdallmocks.MockContext, authenticator *mocks.MockSubjectCreator,
 				authorizer *mocks.MockSubjectHandler, unifier *mocks.MockSubjectHandler,
@@ -275,6 +278,7 @@ func TestRuleExecute(t *testing.T) {
 				authenticator.On("Execute", ctx).Return(sub, nil)
 				authorizer.On("Execute", ctx, sub).Return(nil)
 				unifier.On("Execute", ctx, sub).Return(testsupport.ErrTestPurpose)
+				unifier.On("ContinueOnError").Return(false)
 				errHandler.On("Execute", ctx, testsupport.ErrTestPurpose).
 					Return(true, testsupport.ErrTestPurpose2)
 			},

--- a/internal/rules/subject_handler.go
+++ b/internal/rules/subject_handler.go
@@ -23,4 +23,5 @@ import (
 
 type subjectHandler interface {
 	Execute(heimdall.Context, *subject.Subject) error
+	ContinueOnError() bool
 }

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -1177,6 +1177,11 @@
                 "1m",
                 "30s"
               ]
+            },
+            "continue_on_error": {
+              "type": "boolean",
+              "description": "Continue the pipeline execution even if this contextualizer fails",
+              "default": false
             }
           }
         }

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -1178,7 +1178,7 @@
                 "30s"
               ]
             },
-            "continue_on_error": {
+            "continue_pipeline_on_error": {
               "type": "boolean",
               "description": "Continue the pipeline execution even if this contextualizer fails",
               "default": false


### PR DESCRIPTION
## Related issue(s)

relates to #521 

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description
This PR introduces a new `continue_pipeline_on_error` configuration property for contextualizers defaulting to `false` if not set (the old behavior). If this property is set to `true` on a contextualizer, the execution of the regular pipeline will still continue even if the contexualizer run into an error condition (e.g. communication with the remote endpoint failed due to a timeout or if the HTTP response code was not a 2xx one). This way the rule pipeline becomes more resilient for network outages and other issues. That means however the upstream service will have to deal with missing contextual information.

Here a usage example in a rule pipeline:

```.yaml
id: some_rule
match:
  url: http://127.0.0.1:9090/some/endpoint/<**>
methods:
  - GET
  - POST
execute:
  - authenticator: cookie_session
  - authenticator: anonymous
  - contextualizer: subscription_plan  # <-- if this one fails, the pipeline will still continue
    config:
      continue_pipeline_on_error: true
  - contextualizer: user_article_stats # <-- if this one fails, the pipeline will be canceled and the error pipe line will start
  - authorizer: allow_all
  - unifier: jwt
on_error:
  - error_handler: redirect_to_login
```
