### PR TITLE
feat: Command for validation of rules

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -41,5 +41,5 @@ func init() {
 		"Prefix for the environment variables to consider for\nloading configuration from")
 
 	validateCmd.AddCommand(validate.NewValidateConfigCommand())
-	validateCmd.AddCommand(validate.NewValidateRuleSetCommand())
+	validateCmd.AddCommand(validate.NewValidateRulesCommand())
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -36,8 +36,7 @@ func init() {
 	RootCmd.AddCommand(validateCmd)
 
 	validateCmd.PersistentFlags().StringP("config", "c", "",
-		"Path to heimdall's configuration file.\n"+
-			"If not provided, the lookup sequence is:\n  1. $PWD\n  2. $HOME/.config\n  3. /etc/heimdall/")
+		"Path to heimdall's configuration file.")
 	validateCmd.PersistentFlags().String("env-config-prefix", "HEIMDALLCFG_",
 		"Prefix for the environment variables to consider for\nloading configuration from")
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -36,6 +36,11 @@ func init() {
 	RootCmd.AddCommand(validateCmd)
 
 	validateCmd.PersistentFlags().StringP("config", "c", "",
-		"Path to heimdall's configuration file")
+		"Path to heimdall's configuration file.\n"+
+			"If not provided, the lookup sequence is:\n  1. $PWD\n  2. $HOME/.config\n  3. /etc/heimdall/")
+	validateCmd.PersistentFlags().String("env-config-prefix", "HEIMDALLCFG_",
+		"Prefix for the environment variables to consider for\nloading configuration from")
+
 	validateCmd.AddCommand(validate.NewValidateConfigCommand())
+	validateCmd.AddCommand(validate.NewValidateRuleSetCommand())
 }

--- a/cmd/validate/config_test.go
+++ b/cmd/validate/config_test.go
@@ -47,7 +47,7 @@ func TestValidateConfig(t *testing.T) {
 	}
 }
 
-func TestRunValidateCommand(t *testing.T) {
+func TestRunValidateConfigCommand(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {

--- a/cmd/validate/config_test.go
+++ b/cmd/validate/config_test.go
@@ -21,7 +21,7 @@ func TestValidateConfig(t *testing.T) {
 	}{
 		{uc: "no config provided", expError: ErrNoConfigFile},
 		{uc: "invalid config", confFile: "doesnotexist.yaml", expError: os.ErrNotExist},
-		{uc: "valid config", confFile: "../../internal/config/test_data/test_config.yaml"},
+		{uc: "valid config", confFile: "test_data/config.yaml"},
 	} {
 		t.Run(tc.uc, func(t *testing.T) {
 			// GIVEN
@@ -56,7 +56,7 @@ func TestRunValidateCommand(t *testing.T) {
 		expError string
 	}{
 		{uc: "invalid config", confFile: "doesnotexist.yaml", expError: "no such file or dir"},
-		{uc: "valid config", confFile: "../../internal/config/test_data/test_config.yaml"},
+		{uc: "valid config", confFile: "test_data/config.yaml"},
 	} {
 		t.Run(tc.uc, func(t *testing.T) {
 			// GIVEN

--- a/cmd/validate/config_test.go
+++ b/cmd/validate/config_test.go
@@ -48,8 +48,6 @@ func TestValidateConfig(t *testing.T) {
 }
 
 func TestRunValidateConfigCommand(t *testing.T) {
-	t.Parallel()
-
 	for _, tc := range []struct {
 		uc       string
 		confFile string

--- a/cmd/validate/ruleset.go
+++ b/cmd/validate/ruleset.go
@@ -15,8 +15,8 @@ import (
 	"github.com/dadrus/heimdall/internal/rules/provider/filesystem"
 )
 
-// NewValidateRuleSetCommand represents the "validate rules" command.
-func NewValidateRuleSetCommand() *cobra.Command {
+// NewValidateRulesCommand represents the "validate rules" command.
+func NewValidateRulesCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:     "rules [path to ruleset]",
 		Short:   "Validates heimdall's ruleset",

--- a/cmd/validate/ruleset.go
+++ b/cmd/validate/ruleset.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/dadrus/heimdall/internal/config"
-	"github.com/dadrus/heimdall/internal/logging"
 	"github.com/dadrus/heimdall/internal/rules"
 	"github.com/dadrus/heimdall/internal/rules/event"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms"
@@ -52,11 +51,9 @@ func validateRuleSet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	conf.Log.Format = config.LogTextFormat
-	conf.Log.Level = zerolog.ErrorLevel
 	conf.Rules.Providers.FileSystem = map[string]any{"src": args[0]}
 
-	logger := logging.NewLogger(conf.Log)
+	logger := zerolog.Nop()
 
 	mFactory, err := mechanisms.NewFactory(conf, logger)
 	if err != nil {

--- a/cmd/validate/ruleset.go
+++ b/cmd/validate/ruleset.go
@@ -1,0 +1,83 @@
+package validate
+
+import (
+	"context"
+	"os"
+
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+
+	"github.com/dadrus/heimdall/internal/config"
+	"github.com/dadrus/heimdall/internal/logging"
+	"github.com/dadrus/heimdall/internal/rules"
+	"github.com/dadrus/heimdall/internal/rules/event"
+	"github.com/dadrus/heimdall/internal/rules/mechanisms"
+	"github.com/dadrus/heimdall/internal/rules/provider/filesystem"
+)
+
+// NewValidateRuleSetCommand represents the "validate rules" command.
+func NewValidateRuleSetCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:     "rules [path to ruleset]",
+		Short:   "Validates heimdall's ruleset",
+		Args:    cobra.ExactArgs(1),
+		Example: "heimdall validate rules -c myconfig.yaml myruleset.yaml",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := validateRuleSet(cmd, args); err != nil {
+				cmd.PrintErrf("%v\n", err)
+
+				os.Exit(1)
+			}
+
+			cmd.Println("Rule set is valid")
+		},
+	}
+}
+
+func validateRuleSet(cmd *cobra.Command, args []string) error {
+	const queueSize = 50
+
+	configPath, _ := cmd.Flags().GetString("config")
+	if len(configPath) == 0 {
+		return ErrNoConfigFile
+	}
+
+	envPrefix, _ := cmd.Flags().GetString("env-config-prefix")
+
+	conf, err := config.NewConfiguration(
+		config.EnvVarPrefix(envPrefix),
+		config.ConfigurationPath(configPath),
+	)
+	if err != nil {
+		return err
+	}
+
+	conf.Log.Format = config.LogTextFormat
+	conf.Log.Level = zerolog.ErrorLevel
+	conf.Rules.Providers.FileSystem = map[string]any{"src": args[0]}
+	conf.Signer.KeyStore.Path = ""
+	conf.Signer.KeyStore.Password = ""
+
+	logger := logging.NewLogger(conf.Log)
+
+	mFactory, err := mechanisms.NewFactory(conf, logger)
+	if err != nil {
+		return err
+	}
+
+	rFactory, err := rules.NewRuleFactory(mFactory, conf, logger)
+	if err != nil {
+		return err
+	}
+
+	queue := make(event.RuleSetChangedEventQueue, queueSize)
+
+	defer close(queue)
+
+	provider, err := filesystem.NewProvider(conf, rules.NewRuleSetProcessor(queue, rFactory, logger), logger)
+	if err != nil {
+		return err
+	}
+
+	return provider.Start(context.Background())
+}

--- a/cmd/validate/ruleset.go
+++ b/cmd/validate/ruleset.go
@@ -36,12 +36,13 @@ func NewValidateRulesCommand() *cobra.Command {
 func validateRuleSet(cmd *cobra.Command, args []string) error {
 	const queueSize = 50
 
+	envPrefix, _ := cmd.Flags().GetString("env-config-prefix")
+	logger := zerolog.Nop()
+
 	configPath, _ := cmd.Flags().GetString("config")
 	if len(configPath) == 0 {
 		return ErrNoConfigFile
 	}
-
-	envPrefix, _ := cmd.Flags().GetString("env-config-prefix")
 
 	conf, err := config.NewConfiguration(
 		config.EnvVarPrefix(envPrefix),
@@ -52,8 +53,6 @@ func validateRuleSet(cmd *cobra.Command, args []string) error {
 	}
 
 	conf.Rules.Providers.FileSystem = map[string]any{"src": args[0]}
-
-	logger := zerolog.Nop()
 
 	mFactory, err := mechanisms.NewFactory(conf, logger)
 	if err != nil {

--- a/cmd/validate/ruleset.go
+++ b/cmd/validate/ruleset.go
@@ -55,8 +55,6 @@ func validateRuleSet(cmd *cobra.Command, args []string) error {
 	conf.Log.Format = config.LogTextFormat
 	conf.Log.Level = zerolog.ErrorLevel
 	conf.Rules.Providers.FileSystem = map[string]any{"src": args[0]}
-	conf.Signer.KeyStore.Path = ""
-	conf.Signer.KeyStore.Password = ""
 
 	logger := logging.NewLogger(conf.Log)
 

--- a/cmd/validate/ruleset_test.go
+++ b/cmd/validate/ruleset_test.go
@@ -1,0 +1,58 @@
+package validate
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateRuleset(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		uc        string
+		confFile  string
+		rulesFile string
+		expError  error
+	}{
+		{
+			uc:       "no config provided",
+			expError: ErrNoConfigFile,
+		},
+		{
+			uc:       "invalid configconfig file",
+			confFile: "doesnotexist.yaml",
+			expError: os.ErrNotExist,
+		},
+		{
+			uc:        "invalid rule set file",
+			confFile:  "test_data/config.yaml",
+			rulesFile: "doesnotexist.yaml",
+			expError:  os.ErrNotExist,
+		},
+	} {
+		t.Run(tc.uc, func(t *testing.T) {
+			// GIVEN
+			cmd := NewValidateRuleSetCommand()
+			cmd.Flags().StringP("config", "c", "", "Path to heimdall's configuration file.")
+
+			if len(tc.confFile) != 0 {
+				err := cmd.ParseFlags([]string{"--config", tc.confFile})
+				require.NoError(t, err)
+			}
+
+			// WHEN
+			err := validateRuleSet(cmd, []string{tc.rulesFile})
+
+			// THEN
+			if tc.expError != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tc.expError)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/validate/ruleset_test.go
+++ b/cmd/validate/ruleset_test.go
@@ -66,8 +66,6 @@ func TestValidateRuleset(t *testing.T) {
 }
 
 func TestRunValidateRulesCommand(t *testing.T) {
-	t.Parallel()
-
 	for _, tc := range []struct {
 		uc        string
 		confFile  string

--- a/cmd/validate/ruleset_test.go
+++ b/cmd/validate/ruleset_test.go
@@ -1,11 +1,14 @@
 package validate
 
 import (
+	"bytes"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dadrus/heimdall/internal/x/testsupport"
 )
 
 func TestValidateRuleset(t *testing.T) {
@@ -32,10 +35,15 @@ func TestValidateRuleset(t *testing.T) {
 			rulesFile: "doesnotexist.yaml",
 			expError:  os.ErrNotExist,
 		},
+		{
+			uc:        "everything is valid",
+			confFile:  "test_data/config.yaml",
+			rulesFile: "test_data/ruleset.yaml",
+		},
 	} {
 		t.Run(tc.uc, func(t *testing.T) {
 			// GIVEN
-			cmd := NewValidateRuleSetCommand()
+			cmd := NewValidateRulesCommand()
 			cmd.Flags().StringP("config", "c", "", "Path to heimdall's configuration file.")
 
 			if len(tc.confFile) != 0 {
@@ -52,6 +60,58 @@ func TestValidateRuleset(t *testing.T) {
 				assert.ErrorIs(t, err, tc.expError)
 			} else {
 				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRunValidateRulesCommand(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		uc        string
+		confFile  string
+		rulesFile string
+		expError  string
+	}{
+		{
+			uc:       "validation fails",
+			expError: "no config file",
+		},
+		{
+			uc:        "everything is valid",
+			confFile:  "test_data/config.yaml",
+			rulesFile: "test_data/ruleset.yaml",
+		},
+	} {
+		t.Run(tc.uc, func(t *testing.T) {
+			// GIVEN
+			exit, err := testsupport.PatchOSExit(t, func(int) {})
+			require.NoError(t, err)
+
+			cmd := NewValidateRulesCommand()
+
+			buf := bytes.NewBuffer([]byte{})
+			cmd.SetOut(buf)
+			cmd.SetErr(buf)
+
+			cmd.Flags().StringP("config", "c", "", "Path to heimdall's configuration file.")
+
+			if len(tc.confFile) != 0 {
+				err := cmd.ParseFlags([]string{"--config", tc.confFile})
+				require.NoError(t, err)
+			}
+
+			// WHEN
+			cmd.Run(cmd, []string{tc.rulesFile})
+
+			log := buf.String()
+			if len(tc.expError) != 0 {
+				assert.Contains(t, log, tc.expError)
+				assert.True(t, exit.Called)
+				assert.Equal(t, 1, exit.Code)
+			} else {
+				assert.Contains(t, log, "Rule set is valid")
 			}
 		})
 	}

--- a/cmd/validate/test_data/config.yaml
+++ b/cmd/validate/test_data/config.yaml
@@ -1,0 +1,225 @@
+rules:
+  mechanisms:
+    authenticators:
+      - id: noop_authenticator
+        type: noop
+      - id: anonymous_authenticator
+        type: anonymous
+      - id: unauthorized_authenticator
+        type: unauthorized
+      - id: kratos_session_authenticator
+        type: generic
+        config:
+          identity_info_endpoint:
+            url: http://127.0.0.1:4433/sessions/whoami
+            retry:
+              max_delay: 300ms
+              give_up_after: 2s
+          authentication_data_source:
+            - cookie: ory_kratos_session
+          subject:
+            attributes: "@this"
+            id: "identity.id"
+          allow_fallback_on_error: true
+          cache_ttl: 10m
+          session_lifespan:
+            active: active
+            issued_at: issued_at
+            not_before: authenticated_at
+            not_after: expires_at
+            time_format: "2006-01-02T15:04:05.999999Z07"
+            validity_leeway: 10s
+      - id: hydra_authenticator
+        type: oauth2_introspection
+        config:
+          introspection_endpoint:
+            url: http://hydra:4445/oauth2/introspect
+            retry:
+              max_delay: 300ms
+              give_up_after: 2s
+            auth:
+              type: basic_auth
+              config:
+                user: foo
+                password: bar
+          token_source:
+            - header: Authorization
+              schema: Bearer
+          assertions:
+            issuers:
+              - http://127.0.0.1:4444/
+            scopes:
+              - foo
+              - bar
+            audience:
+              - bla
+          subject:
+            attributes: "@this"
+            id: sub
+          allow_fallback_on_error: true
+      - id: jwt_authenticator1
+        type: jwt
+        config:
+          jwks_endpoint:
+            url: http://foo/token
+            method: GET
+            enable_http_cache: true
+          jwt_source:
+            - header: Authorization
+              schema: Bearer
+          assertions:
+            audience:
+              - bla
+            scopes:
+              - foo
+            allowed_algorithms:
+              - RSA
+            issuers:
+              - bla
+          subject:
+            attributes: "@this"
+            id: "identity.id"
+          cache_ttl: 5m
+          allow_fallback_on_error: true
+      - id: jwt_authenticator2
+        type: jwt
+        config:
+          jwks_endpoint: http://bar/token
+          assertions:
+             audience:
+               - bla
+             scopes:
+               - foo
+             allowed_algorithms:
+               - RSA
+             issuers:
+               - bla
+          allow_fallback_on_error: true
+          validate_jwk: true
+      - id: basic_auth_authenticator
+        type: basic_auth
+        config:
+          user_id: foo
+          password: bar
+          allow_fallback_on_error: false
+    authorizers:
+      - id: allow_all_authorizer
+        type: allow
+      - id: deny_all_authorizer
+        type: deny
+      - id: keto_authorizer
+        type: remote
+        config:
+          endpoint:
+            url: http://keto
+            method: POST
+            headers:
+              foo-bar: "{{ .Subject.ID }}"
+          payload: https://bla.bar
+          forward_response_headers_to_upstream:
+            - bla-bar
+          expressions:
+            - expression: "Payload.foo == 'bar'"
+      - id: attributes_based_authorizer_2
+        type: cel
+        config:
+          expressions:
+            - expression: "'admin' in Subject.Attributes.groups"
+    contextualizers:
+      - id: subscription_contextualizer
+        type: generic
+        config:
+          endpoint:
+            url: http://foo.bar
+            method: GET
+            headers:
+              bla: bla
+          payload: http://foo
+          continue_pipeline_on_error: true
+      - id: profile_data_contextualizer
+        type: generic
+        config:
+          endpoint:
+            url: http://profile
+            headers:
+              foo: bar
+    unifiers:
+      - id: jwt
+        type: jwt
+        config:
+          ttl: 5m
+          claims: |
+            {"user": {{ quote .Subject.ID }} }
+      - id: bla
+        type: header
+        config:
+          headers:
+            foo-bar: bla
+      - id: blabla
+        type: cookie
+        config:
+          cookies:
+            foo-bar: '{{ .Subject.ID }}'
+    error_handlers:
+      - id: default
+        type: default
+      - id: authenticate_with_kratos
+        type: redirect
+        config:
+          to: http://127.0.0.1:4433/self-service/login/browser?return_to={{ .Request.URL | urlenc }}
+          when:
+            - error:
+                - type: authentication_error
+                  raised_by: kratos_session_authenticator
+                - type: authorization_error
+              request_headers:
+                Accept:
+                  - '*/*'
+
+  default:
+    methods:
+      - GET
+      - POST
+    execute:
+      - authenticator: anonymous_authenticator
+      - unifier: jwt
+    on_error:
+      - error_handler: authenticate_with_kratos
+
+  providers:
+    file_system:
+      src: test_rules.yaml
+      watch: true
+
+    http_endpoint:
+      watch_interval: 5m
+      endpoints:
+        - url: http://foo.bar/rules.yaml
+          rule_path_match_prefix: /foo
+          enable_http_cache: true
+        - url: http://bar.foo/rules.yaml
+          headers:
+            bla: bla
+          retry:
+            give_up_after: 5s
+            max_delay: 250ms
+          auth:
+            type: api_key
+            config:
+              name: foo
+              value: bar
+              in: header
+
+    cloud_blob:
+      watch_interval: 2m
+      buckets:
+        - url: gs://my-bucket
+          prefix: service1
+          rule_path_match_prefix: /service1
+        - url: gs://my-bucket
+          prefix: service2
+          rule_path_match_prefix: /service2
+        - url: s3://my-bucket/my-rule-set
+
+    kubernetes:
+      auth_class: foo

--- a/cmd/validate/test_data/ruleset.yaml
+++ b/cmd/validate/test_data/ruleset.yaml
@@ -1,0 +1,35 @@
+version: 1
+name: test-rule-set
+rules:
+- id: rule:foo
+  match:
+    url: http://foo.bar/<**>
+    strategy: glob
+  upstream: http://bar.foo
+#  methods: # reuses default
+#    - GET
+#    - POST
+  execute:
+    - authenticator: unauthorized_authenticator
+    - authenticator: jwt_authenticator
+      config:
+        assertions:
+          allowed_algorithms:
+            - RS256
+          issuers:
+            - http://127.0.0.1:4444/
+          scopes:
+            - profile
+    - authenticator: hydra_authenticator
+    - contextualizer: subscription_contextualizer
+    - authorizer: allow_all_authorizer
+    - unifier: jwt
+      config:
+        claims: |
+          {"foo": "bar"}
+    - unifier: bla
+      config:
+        headers:
+          foo-bar: bla
+    - unifier: blabla
+# no on_error (reuses default)

--- a/cmd/validate/test_data/ruleset.yaml
+++ b/cmd/validate/test_data/ruleset.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: "1"
 name: test-rule-set
 rules:
 - id: rule:foo
@@ -11,7 +11,7 @@ rules:
 #    - POST
   execute:
     - authenticator: unauthorized_authenticator
-    - authenticator: jwt_authenticator
+    - authenticator: jwt_authenticator1
       config:
         assertions:
           allowed_algorithms:

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -25,7 +25,7 @@ import (
 	"github.com/dadrus/heimdall/internal/config/parser"
 )
 
-type Configuration struct {
+type Configuration struct { //nolint:musttag
 	Serve     ServeConfig     `koanf:"serve"`
 	Log       LoggingConfig   `koanf:"log"`
 	Tracing   TracingConfig   `koanf:"tracing"`

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -38,7 +38,7 @@ type Configuration struct {
 
 func NewConfiguration(envPrefix EnvVarPrefix, configFile ConfigurationPath) (*Configuration, error) {
 	// copy defaults
-	result := defaultConfig
+	result := defaultConfig()
 
 	opts := []parser.Option{
 		parser.WithDecodeHookFunc(mapstructure.StringToTimeDurationHookFunc()),

--- a/internal/config/configuration_test.go
+++ b/internal/config/configuration_test.go
@@ -21,17 +21,26 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestNewConfigurationFromStructWithDefaultsOnly(t *testing.T) {
 	t.Parallel()
+
+	// GIVEN
+	rawExp, err := yaml.Marshal(defaultConfig())
+	require.NoError(t, err)
 
 	// WHEN
 	config, err := NewConfiguration("HEIMDALLCFG_", "")
 
 	// THEN
 	require.NoError(t, err)
-	require.Equal(t, defaultConfig, *config)
+
+	rawConf, err := yaml.Marshal(config)
+	require.NoError(t, err)
+
+	require.Equal(t, string(rawExp), string(rawConf))
 }
 
 func TestNewConfigurationWithConfigFile(t *testing.T) {
@@ -42,5 +51,5 @@ func TestNewConfigurationWithConfigFile(t *testing.T) {
 
 	// THEN
 	require.NoError(t, err)
-	assert.NotEqual(t, defaultConfig, config)
+	assert.NotEqual(t, defaultConfig(), *config)
 }

--- a/internal/config/configuration_test.go
+++ b/internal/config/configuration_test.go
@@ -19,7 +19,6 @@ package config
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -46,10 +45,18 @@ func TestNewConfigurationFromStructWithDefaultsOnly(t *testing.T) {
 func TestNewConfigurationWithConfigFile(t *testing.T) {
 	t.Parallel()
 
+	// GIVEN
+	rawExp, err := yaml.Marshal(defaultConfig())
+	require.NoError(t, err)
+
 	// WHEN
 	config, err := NewConfiguration("HEIMDALLCFG_", "./test_data/test_config.yaml")
 
 	// THEN
 	require.NoError(t, err)
-	assert.NotEqual(t, defaultConfig(), *config)
+
+	rawConf, err := yaml.Marshal(config)
+	require.NoError(t, err)
+
+	require.NotEqual(t, string(rawExp), string(rawConf))
 }

--- a/internal/config/default_configuration.go
+++ b/internal/config/default_configuration.go
@@ -36,57 +36,58 @@ const (
 	loopbackIP = "127.0.0.1"
 )
 
-// nolint: gochecknoglobals
-var defaultConfig = Configuration{
-	Serve: ServeConfig{
-		Proxy: ServiceConfig{
-			Port: defaultProxyServicePort,
-			Timeout: Timeout{
-				Read:  defaultReadTimeout,
-				Write: defaultWriteTimeout,
-				Idle:  defaultIdleTimeout,
+func defaultConfig() Configuration {
+	return Configuration{
+		Serve: ServeConfig{
+			Proxy: ServiceConfig{
+				Port: defaultProxyServicePort,
+				Timeout: Timeout{
+					Read:  defaultReadTimeout,
+					Write: defaultWriteTimeout,
+					Idle:  defaultIdleTimeout,
+				},
+			},
+			Decision: ServiceConfig{
+				Port: defaultDecisionServicePort,
+				Timeout: Timeout{
+					Read:  defaultReadTimeout,
+					Write: defaultWriteTimeout,
+					Idle:  defaultIdleTimeout,
+				},
+			},
+			Management: ServiceConfig{
+				Port: defaultManagementServicePort,
+				Timeout: Timeout{
+					Read:  defaultReadTimeout,
+					Write: defaultWriteTimeout,
+					Idle:  defaultIdleTimeout,
+				},
 			},
 		},
-		Decision: ServiceConfig{
-			Port: defaultDecisionServicePort,
-			Timeout: Timeout{
-				Read:  defaultReadTimeout,
-				Write: defaultWriteTimeout,
-				Idle:  defaultIdleTimeout,
-			},
+		Log: LoggingConfig{
+			Level:  zerolog.ErrorLevel,
+			Format: LogTextFormat,
 		},
-		Management: ServiceConfig{
-			Port: defaultManagementServicePort,
-			Timeout: Timeout{
-				Read:  defaultReadTimeout,
-				Write: defaultWriteTimeout,
-				Idle:  defaultIdleTimeout,
-			},
+		Tracing: TracingConfig{
+			Enabled:           true,
+			SpanProcessorType: SpanProcessorBatch,
 		},
-	},
-	Log: LoggingConfig{
-		Level:  zerolog.ErrorLevel,
-		Format: LogTextFormat,
-	},
-	Tracing: TracingConfig{
-		Enabled:           true,
-		SpanProcessorType: SpanProcessorBatch,
-	},
-	Metrics: MetricsConfig{
-		Enabled:     true,
-		Port:        defaultMetricsServicePort,
-		Host:        loopbackIP,
-		MetricsPath: "/metrics",
-	},
-	Profiling: ProfilingConfig{
-		Enabled: false,
-		Port:    defaultProfilingServicePort,
-		Host:    loopbackIP,
-	},
-	Signer: SignerConfig{
-		Name: "heimdall",
-	},
-	Rules: Rules{
-		Prototypes: &MechanismPrototypes{},
-	},
+		Metrics: MetricsConfig{
+			Enabled:     true,
+			Port:        defaultMetricsServicePort,
+			Host:        loopbackIP,
+			MetricsPath: "/metrics",
+		},
+		Profiling: ProfilingConfig{
+			Enabled: false,
+			Port:    defaultProfilingServicePort,
+			Host:    loopbackIP,
+		},
+		Signer: SignerConfig{
+			Name: "heimdall",
+		},
+		Rules: Rules{
+			Prototypes: &MechanismPrototypes{},
+		},
+	}
 }


### PR DESCRIPTION
## Related issue(s)

closes #7 

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

This PR implements a command to validate rule sets as it already possible to validate configuration.

Example:

```
heimdall validate rules -c <path to config yaml> <path to rules file>
```

unlike config validation, which just performs schema validation, rules validation loads the configuration and instantiates rules, respectively the corresponding objects, exactly as heimdall would do this when started.
