### PR TITLE
feat: `api_key` endpoint authentication strategy can now add api keys to query parameters

### DIFF
--- a/docs/content/docs/configuration/reference/reference.adoc
+++ b/docs/content/docs/configuration/reference/reference.adoc
@@ -229,6 +229,12 @@ rules:
             foo-bar: "{{ .Subject.ID }}"
           values:
             some-key: some-value
+          auth:
+            type: api_key
+            config:
+              in: header
+              name: X-API-Key
+              value: super duper secret
         payload: "https://bla.bar"
         expressions:
           - expression: |
@@ -250,6 +256,12 @@ rules:
           method: GET
           headers:
             bla: bla
+          auth:
+            type: api_key
+            config:
+              in: query
+              name: key
+              value: super duper secret
         payload: http://foo
     - id: profile_data_contextualizer
       type: generic
@@ -321,9 +333,9 @@ rules:
           auth:
             type: api_key
             config:
-              name: X-Api-Key
+              name: api_key
               value: super-secret
-              in: header
+              in: cookie
           header:
             X-Customer-Header: Some Value
 

--- a/docs/content/docs/configuration/reference/types.adoc
+++ b/docs/content/docs/configuration/reference/types.adoc
@@ -162,13 +162,15 @@ Available strategies are described in the following sections.
 
 === API Key Strategy
 
-This strategy can be used if your endpoint expects a specific api key be send in a header or a cookie.
+This strategy can be used if your endpoint expects a specific api key be sent in a header, a cookie or query.
 
 `type` must be set to `api_key`. `config` supports the following properties:
 
 * *`in`*: _string_ (mandatory)
 +
-Where to put the api key. Can be either `header`, or `cookie`.
+Where to put the api key. Can be either `header`, `cookie`, or `query`.
++
+WARNING: Using `query` strategy will expose the api key to access logs and tracing.
 
 * *`name`*: _string_ (mandatory)
 +

--- a/go.sum
+++ b/go.sum
@@ -822,8 +822,6 @@ github.com/dgryski/go-sip13 v0.0.0-20200911182023-62edffca9245/go.mod h1:vAd38F8
 github.com/digitalocean/godo v1.78.0/go.mod h1:GBmu8MkjZmNARE7IXRPmkbbnocNN8+uBm0xbEVw2LCs=
 github.com/digitalocean/godo v1.95.0/go.mod h1:NRpFznZFvhHjBoqZAaOD3khVzsJ3EibzKqFL4R60dmA=
 github.com/dlclark/regexp2 v1.2.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
-github.com/dlclark/regexp2 v1.9.0 h1:pTK/l/3qYIKaRXuHnEnIf7Y5NxfRPfpb7dis6/gdlVI=
-github.com/dlclark/regexp2 v1.9.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
 github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -275,6 +275,12 @@ rules:
               foo: bar
             values:
               some-key: some-value
+            auth:
+              type: api_key
+              config:
+                in: query
+                name: key
+                value: super duper secret
     unifiers:
       - id: jwt
         type: jwt

--- a/internal/endpoint/api_key_strategy.go
+++ b/internal/endpoint/api_key_strategy.go
@@ -37,6 +37,10 @@ func (c *APIKeyStrategy) Apply(_ context.Context, req *http.Request) error {
 		req.AddCookie(&http.Cookie{Name: c.Name, Value: c.Value})
 	case "header":
 		req.Header.Set(c.Name, c.Value)
+	case "query":
+		query := req.URL.Query()
+		query.Set(c.Name, c.Value)
+		req.URL.RawQuery = query.Encode()
 	default:
 		return errorchain.NewWithMessagef(heimdall.ErrConfiguration,
 			"unsupported in value (%s) in api key auth strategy", c.In)

--- a/internal/endpoint/mapstructure_decoder.go
+++ b/internal/endpoint/mapstructure_decoder.go
@@ -144,9 +144,9 @@ func decodeAPIKeyStrategy(config any) (AuthenticationStrategy, error) {
 			"api-key strategy requires 'in' property to be set")
 	}
 
-	if strategy.In != "header" && strategy.In != "cookie" {
+	if strategy.In != "header" && strategy.In != "cookie" && strategy.In != "query" {
 		return nil, errorchain.NewWithMessage(heimdall.ErrConfiguration,
-			"api-key strategy requires 'in' property to be set to either 'header' or 'cookie'")
+			"api-key strategy requires 'in' property to be set to either 'header', 'cookie', or 'query'")
 	}
 
 	return &strategy, nil

--- a/internal/endpoint/mapstructure_decoder_test.go
+++ b/internal/endpoint/mapstructure_decoder_test.go
@@ -183,6 +183,27 @@ auth:
 			},
 		},
 		{
+			uc: "api key with all required properties, with in=query",
+			config: []byte(`
+auth:
+  type: api_key
+  config:
+    name: foo
+    value: bar
+    in: query
+`),
+			assert: func(t *testing.T, err error, as AuthenticationStrategy) {
+				t.Helper()
+
+				assert.NoError(t, err)
+				assert.IsType(t, &APIKeyStrategy{}, as)
+				aks := as.(*APIKeyStrategy)
+				assert.Equal(t, "foo", aks.Name)
+				assert.Equal(t, "bar", aks.Value)
+				assert.Equal(t, "query", aks.In)
+			},
+		},
+		{
 			uc: "api key with all required properties, with in=foobar",
 			config: []byte(`
 auth:
@@ -196,7 +217,7 @@ auth:
 				t.Helper()
 
 				assert.Error(t, err)
-				assert.ErrorContains(t, err, "to either 'header' or 'cookie'")
+				assert.ErrorContains(t, err, "to either 'header', 'cookie', or 'query'")
 			},
 		},
 		{

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -560,7 +560,8 @@
               "type": "string",
               "enum": [
                 "header",
-                "cookie"
+                "cookie",
+                "query"
               ]
             }
           },


### PR DESCRIPTION
## Related issue(s)

closes #617 

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

With this PR the `api_key` strategy supports a new `query` option for its `in` parameter. So if you are using APIs such as google fireboase, which expect api keys in queries, e.g. `https://identitytoolkit.googleapis.com/v1/accounts:lookup?key=[API_KEY]`, you can configure such endpoints in heimdall as follows:

```yaml
method: GET
url: https://identitytoolkit.googleapis.com/v1/accounts:lookup
auth:
  type: api_key
  config:
    in: query
    name: key
    value: ${apikey_env_var}
```

This is actually kind of syntactic sugar for

```yaml
method: GET
url: https://identitytoolkit.googleapis.com/v1/accounts:lookup?key={{ ${apikey_env_var} | urlenc }}
```

**NOTE**: Such APIs lead to api key exposure in logs, metrics and tracing. So use with caution.
