### PR TITLE
perf: converting byte slice to a string and vice versa without memory allocation

### DIFF
--- a/cmd/health.go
+++ b/cmd/health.go
@@ -27,6 +27,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/dadrus/heimdall/internal/handler/management"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 // nolint: gochecknoglobals
@@ -65,14 +66,14 @@ var healthCmd = &cobra.Command{
 
 		switch outputFormat {
 		case "json":
-			cmd.Println(string(rawResp))
+			cmd.Println(stringx.ToString(rawResp))
 		case "yaml":
 			rawYaml, err := yaml.Marshal(structuredResponse)
 			if err != nil {
 				cmd.PrintErrf("Failed to convert response to yaml: %v", err)
 				os.Exit(-1)
 			}
-			cmd.Println(string(rawYaml))
+			cmd.Println(stringx.ToString(rawYaml))
 		default:
 			cmd.Println(structuredResponse["status"])
 		}

--- a/internal/config/parser/env.go
+++ b/internal/config/parser/env.go
@@ -30,14 +30,15 @@ import (
 
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 var isNumRegex = regexp.MustCompile(`^\d+$`)
 
 func messageDigest(val, hash string) string {
 	mds := sha256.New()
-	mds.Write([]byte(val))
-	mds.Write([]byte(hash))
+	mds.Write(stringx.ToBytes(val))
+	mds.Write(stringx.ToBytes(hash))
 
 	return hex.EncodeToString(mds.Sum(nil))
 }
@@ -47,7 +48,7 @@ func toRealType(val string) any {
 
 	// here we're using the ability of the yaml parser to "guess" the type and convert the given string to it.
 	// this is not the fastest way, but ok for now.
-	yaml.Unmarshal([]byte(fmt.Sprintf("val: %s", val)), &parsed) // nolint: errcheck
+	yaml.Unmarshal(stringx.ToBytes(fmt.Sprintf("val: %s", val)), &parsed) // nolint: errcheck
 
 	return parsed["val"]
 }

--- a/internal/config/parser/yaml.go
+++ b/internal/config/parser/yaml.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 func koanfFromYaml(configFile string) (*koanf.Koanf, error) {
@@ -37,13 +38,13 @@ func koanfFromYaml(configFile string) (*koanf.Koanf, error) {
 			"failed to read yaml config from %s", configFile).CausedBy(err)
 	}
 
-	content, err := envsubst.EvalEnv(string(raw))
+	content, err := envsubst.EvalEnv(stringx.ToString(raw))
 	if err != nil {
 		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
 			"failed to parse yaml config from %s", configFile).CausedBy(err)
 	}
 
-	if err = parser.Load(rawbytes.Provider([]byte(content)), yaml.Parser()); err != nil {
+	if err = parser.Load(rawbytes.Provider(stringx.ToBytes(content)), yaml.Parser()); err != nil {
 		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
 			"failed to load yaml config from %s", configFile).CausedBy(err)
 	}

--- a/internal/config/validator.go
+++ b/internal/config/validator.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 	"github.com/dadrus/heimdall/schema"
 )
 
@@ -47,7 +48,7 @@ func ValidateConfig(configPath string) error {
 			"failed to parse config file").CausedBy(err)
 	}
 
-	schema, err := jsonschema.CompileString("config.schema.json", string(schema.ConfigSchema))
+	schema, err := jsonschema.CompileString("config.schema.json", stringx.ToString(schema.ConfigSchema))
 	if err != nil {
 		return errorchain.NewWithMessage(heimdall.ErrConfiguration,
 			"failed to compile JSON schema").CausedBy(err)

--- a/internal/endpoint/api_key_strategy.go
+++ b/internal/endpoint/api_key_strategy.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 type APIKeyStrategy struct {
@@ -52,9 +53,9 @@ func (c *APIKeyStrategy) Apply(_ context.Context, req *http.Request) error {
 func (c *APIKeyStrategy) Hash() []byte {
 	hash := sha256.New()
 
-	hash.Write([]byte(c.In))
-	hash.Write([]byte(c.Name))
-	hash.Write([]byte(c.Value))
+	hash.Write(stringx.ToBytes(c.In))
+	hash.Write(stringx.ToBytes(c.Name))
+	hash.Write(stringx.ToBytes(c.Value))
 
 	return hash.Sum(nil)
 }

--- a/internal/endpoint/basic_auth_strategy.go
+++ b/internal/endpoint/basic_auth_strategy.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"net/http"
+
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 type BasicAuthStrategy struct {
@@ -36,8 +38,8 @@ func (c *BasicAuthStrategy) Apply(_ context.Context, req *http.Request) error {
 func (c *BasicAuthStrategy) Hash() []byte {
 	hash := sha256.New()
 
-	hash.Write([]byte(c.User))
-	hash.Write([]byte(c.Password))
+	hash.Write(stringx.ToBytes(c.User))
+	hash.Write(stringx.ToBytes(c.Password))
 
 	return hash.Sum(nil)
 }

--- a/internal/endpoint/client_credentials_strategy.go
+++ b/internal/endpoint/client_credentials_strategy.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dadrus/heimdall/internal/cache"
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 const defaultCacheLeeway = 15
@@ -78,10 +79,10 @@ func (c *ClientCredentialsStrategy) Apply(ctx context.Context, req *http.Request
 
 func (c *ClientCredentialsStrategy) calculateCacheKey() string {
 	digest := sha256.New()
-	digest.Write([]byte(c.ClientID))
-	digest.Write([]byte(c.ClientSecret))
-	digest.Write([]byte(c.TokenURL))
-	digest.Write([]byte(strings.Join(c.Scopes, "")))
+	digest.Write(stringx.ToBytes(c.ClientID))
+	digest.Write(stringx.ToBytes(c.ClientSecret))
+	digest.Write(stringx.ToBytes(c.TokenURL))
+	digest.Write(stringx.ToBytes(strings.Join(c.Scopes, "")))
 
 	return hex.EncodeToString(digest.Sum(nil))
 }
@@ -123,8 +124,8 @@ func (c *ClientCredentialsStrategy) getAccessToken(ctx context.Context) (*tokenE
 func (c *ClientCredentialsStrategy) Hash() []byte {
 	hash := sha256.New()
 
-	hash.Write([]byte(c.ClientID))
-	hash.Write([]byte(c.ClientSecret))
+	hash.Write(stringx.ToBytes(c.ClientID))
+	hash.Write(stringx.ToBytes(c.ClientSecret))
 
 	return hash.Sum(nil)
 }

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -36,6 +36,7 @@ import (
 	"github.com/dadrus/heimdall/internal/httpcache"
 	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 type Endpoint struct {
@@ -181,8 +182,8 @@ func (e Endpoint) Hash() []byte {
 
 	hash := sha256.New()
 
-	hash.Write([]byte(e.URL))
-	hash.Write([]byte(e.Method))
+	hash.Write(stringx.ToBytes(e.URL))
+	hash.Write(stringx.ToBytes(e.Method))
 
 	if e.Retry != nil {
 		maxDelayBytes := make([]byte, int64BytesCount)
@@ -197,8 +198,8 @@ func (e Endpoint) Hash() []byte {
 
 	buf := bytes.NewBufferString("")
 	for k, v := range e.Headers {
-		buf.Write([]byte(k))
-		buf.Write([]byte(v))
+		buf.Write(stringx.ToBytes(k))
+		buf.Write(stringx.ToBytes(v))
 	}
 
 	hash.Write(buf.Bytes())

--- a/internal/fiber/middleware/accesslog/accesslog_handler.go
+++ b/internal/fiber/middleware/accesslog/accesslog_handler.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/dadrus/heimdall/internal/accesscontext"
 	"github.com/dadrus/heimdall/internal/x/opentelemetry/tracecontext"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 func New(logger zerolog.Logger) fiber.Handler {
@@ -39,8 +40,8 @@ func New(logger zerolog.Logger) fiber.Handler {
 			Str("_http_method", c.Method()).
 			Str("_http_path", c.Path()).
 			Str("_http_user_agent", c.Get("User-Agent")).
-			Str("_http_host", string(c.Request().URI().Host())).
-			Str("_http_scheme", string(c.Request().URI().Scheme()))
+			Str("_http_host", stringx.ToString(c.Request().URI().Host())).
+			Str("_http_scheme", stringx.ToString(c.Request().URI().Scheme()))
 		logCtx = logTraceData(c.UserContext(), logCtx)
 
 		if c.IsProxyTrusted() {

--- a/internal/fiber/middleware/proxyheader/proxy_header.go
+++ b/internal/fiber/middleware/proxyheader/proxy_header.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/dadrus/heimdall/internal/x"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 const (
@@ -49,7 +50,7 @@ func New() fiber.Handler {
 		}
 
 		clientIP := c.IP()
-		proto := string(c.Request().URI().Scheme())
+		proto := stringx.ToString(c.Request().URI().Scheme())
 
 		// Set the X-Forwarded-For
 		c.Request().Header.Set(headerXForwardedFor,

--- a/internal/fiber/middleware/xfmphu/request_url.go
+++ b/internal/fiber/middleware/xfmphu/request_url.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/dadrus/heimdall/internal/x"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 func requestURL(c *fiber.Ctx) *url.URL {
@@ -54,7 +55,7 @@ func requestURL(c *fiber.Ctx) *url.URL {
 
 	if len(query) == 0 {
 		origReqURL := *c.Request().URI()
-		query = string(origReqURL.QueryString())
+		query = stringx.ToString(origReqURL.QueryString())
 	}
 
 	return &url.URL{

--- a/internal/handler/envoyextauth/grpcv3/middleware/errorhandler/error_response.go
+++ b/internal/handler/envoyextauth/grpcv3/middleware/errorhandler/error_response.go
@@ -27,6 +27,8 @@ import (
 	"github.com/goccy/go-json"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
+
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 func responseWith(
@@ -79,11 +81,11 @@ func format(mimeType string, body any) (string, error) {
 	case "application/json":
 		res, err := json.Marshal(body)
 
-		return string(res), err
+		return stringx.ToString(res), err
 	case "application/xml":
 		res, err := xml.Marshal(body)
 
-		return string(res), err
+		return stringx.ToString(res), err
 	case "test/plain":
 		fallthrough
 	default:

--- a/internal/httpcache/round_tripper.go
+++ b/internal/httpcache/round_tripper.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pquerna/cachecontrol"
 
 	"github.com/dadrus/heimdall/internal/cache"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 var (
@@ -93,13 +94,13 @@ func (rt *RoundTripper) cacheResponse(req *http.Request, resp *http.Response) {
 func cacheKey(req *http.Request) string {
 	hash := sha256.New()
 
-	hash.Write([]byte("RFC 7234"))
-	hash.Write([]byte(req.URL.String()))
-	hash.Write([]byte(req.Method))
+	hash.Write(stringx.ToBytes("RFC 7234"))
+	hash.Write(stringx.ToBytes(req.URL.String()))
+	hash.Write(stringx.ToBytes(req.Method))
 
 	value := req.Header.Get("Authorization")
 	if len(value) != 0 {
-		hash.Write([]byte(strings.TrimSpace(value)))
+		hash.Write(stringx.ToBytes(strings.TrimSpace(value)))
 	}
 
 	return hex.EncodeToString(hash.Sum(nil))

--- a/internal/keystore/key_store.go
+++ b/internal/keystore/key_store.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
 	"github.com/dadrus/heimdall/internal/x/pkix"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 const (
@@ -116,7 +117,7 @@ func createKeyStore(blocks []*pem.Block, password string) (keyStore, error) {
 		switch block.Type {
 		case pemBlockTypeEncryptedPrivateKey:
 			// PKCS#8 (PKCS#5 (v2.0) algorithms)
-			key, err = pkcs8.ParsePKCS8PrivateKey(block.Bytes, []byte(password))
+			key, err = pkcs8.ParsePKCS8PrivateKey(block.Bytes, stringx.ToBytes(password))
 		case pemBlockTypePrivateKey:
 			// PKCS#8 - unencrypted
 			key, err = x509.ParsePKCS8PrivateKey(block.Bytes)

--- a/internal/rules/config/matcher.go
+++ b/internal/rules/config/matcher.go
@@ -18,6 +18,8 @@ package config
 
 import (
 	"github.com/goccy/go-json"
+
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 type Matcher struct {
@@ -28,7 +30,7 @@ type Matcher struct {
 func (m *Matcher) UnmarshalJSON(data []byte) error {
 	if data[0] == '"' {
 		// data contains just the url matching value
-		m.URL = string(data[1 : len(data)-1])
+		m.URL = stringx.ToString(data[1 : len(data)-1])
 		m.Strategy = "glob"
 
 		return nil

--- a/internal/rules/mechanisms/authenticators/basic_auth_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/basic_auth_authenticator.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/subject"
 	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 const (
@@ -90,11 +91,11 @@ func newBasicAuthAuthenticator(id string, rawConfig map[string]any) (*basicAuthA
 	// rewrite user id and password as hashes to mitigate potential side-channel attacks
 	// during credentials check
 	md := sha256.New()
-	md.Write([]byte(conf.UserID))
+	md.Write(stringx.ToBytes(conf.UserID))
 	auth.userID = hex.EncodeToString(md.Sum(nil))
 
 	md.Reset()
-	md.Write([]byte(conf.Password))
+	md.Write(stringx.ToBytes(conf.Password))
 	auth.password = hex.EncodeToString(md.Sum(nil))
 
 	return &auth, nil
@@ -129,11 +130,11 @@ func (a *basicAuthAuthenticator) Execute(ctx heimdall.Context) (*subject.Subject
 	}
 
 	md := sha256.New()
-	md.Write([]byte(userIDAndPassword[0]))
+	md.Write(stringx.ToBytes(userIDAndPassword[0]))
 	userID := hex.EncodeToString(md.Sum(nil))
 
 	md.Reset()
-	md.Write([]byte(userIDAndPassword[1]))
+	md.Write(stringx.ToBytes(userIDAndPassword[1]))
 	password := hex.EncodeToString(md.Sum(nil))
 
 	userIDOK := userID == a.userID
@@ -173,7 +174,7 @@ func (a *basicAuthAuthenticator) WithConfig(rawConfig map[string]any) (Authentic
 		userID: x.IfThenElseExec(len(conf.UserID) != 0,
 			func() string {
 				md := sha256.New()
-				md.Write([]byte(conf.UserID))
+				md.Write(stringx.ToBytes(conf.UserID))
 
 				return hex.EncodeToString(md.Sum(nil))
 			}, func() string {
@@ -182,7 +183,7 @@ func (a *basicAuthAuthenticator) WithConfig(rawConfig map[string]any) (Authentic
 		password: x.IfThenElseExec(len(conf.Password) != 0,
 			func() string {
 				md := sha256.New()
-				md.Write([]byte(conf.Password))
+				md.Write(stringx.ToBytes(conf.Password))
 
 				return hex.EncodeToString(md.Sum(nil))
 			}, func() string {

--- a/internal/rules/mechanisms/authenticators/generic_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/generic_authenticator.go
@@ -36,6 +36,7 @@ import (
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/template"
 	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 // by intention. Used only during application bootstrap
@@ -225,7 +226,7 @@ func (a *genericAuthenticator) getSubjectInformation(ctx heimdall.Context, authD
 		return nil, err
 	}
 
-	logger.Debug().Str("_payload", string(payload)).Msg("Raw subject information")
+	logger.Debug().Str("_payload", stringx.ToString(payload)).Msg("Raw subject information")
 
 	if a.sessionLifespanConf != nil {
 		session, err = a.sessionLifespanConf.CreateSessionLifespan(payload)
@@ -380,7 +381,7 @@ func (a *genericAuthenticator) getCacheTTL(sessionLifespan *SessionLifespan) tim
 func (a *genericAuthenticator) calculateCacheKey(reference string) string {
 	digest := sha256.New()
 	digest.Write(a.e.Hash())
-	digest.Write([]byte(reference))
+	digest.Write(stringx.ToBytes(reference))
 
 	return hex.EncodeToString(digest.Sum(nil))
 }

--- a/internal/rules/mechanisms/authenticators/jwt_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator.go
@@ -41,6 +41,7 @@ import (
 	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
 	"github.com/dadrus/heimdall/internal/x/pkix"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 const defaultJWTAuthenticatorTTL = 10 * time.Minute
@@ -502,7 +503,7 @@ func (a *jwtAuthenticator) verifyTokenWithKey(token *jwt.JSONWebToken, key *jose
 func (a *jwtAuthenticator) calculateCacheKey(reference string) string {
 	digest := sha256.New()
 	digest.Write(a.e.Hash())
-	digest.Write([]byte(reference))
+	digest.Write(stringx.ToBytes(reference))
 
 	return hex.EncodeToString(digest.Sum(nil))
 }

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
@@ -37,6 +37,7 @@ import (
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/subject"
 	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 // by intention. Used only during application bootstrap
@@ -375,7 +376,7 @@ func (a *oauth2IntrospectionAuthenticator) getCacheTTL(introspectResp *oauth2.In
 func (a *oauth2IntrospectionAuthenticator) calculateCacheKey(reference string) string {
 	digest := sha256.New()
 	digest.Write(a.e.Hash())
-	digest.Write([]byte(reference))
+	digest.Write(stringx.ToBytes(reference))
 
 	return hex.EncodeToString(digest.Sum(nil))
 }

--- a/internal/rules/mechanisms/authorizers/remote_authorizer.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer.go
@@ -40,6 +40,7 @@ import (
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/template"
 	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 // by intention. Used only during application bootstrap
@@ -357,7 +358,7 @@ func (a *remoteAuthorizer) readResponse(ctx heimdall.Context, resp *http.Respons
 		logger.Warn().Str("_content_type", contentType).
 			Msg("Content type is not supported. Treating it as string")
 
-		return string(rawData), nil // nolint: nilerr
+		return stringx.ToString(rawData), nil // nolint: nilerr
 	}
 
 	result, err := decoder.Decode(rawData)
@@ -379,11 +380,11 @@ func (a *remoteAuthorizer) calculateCacheKey(sub *subject.Subject) string {
 
 	hash := sha256.New()
 	hash.Write(a.e.Hash())
-	hash.Write([]byte(a.id))
-	hash.Write([]byte(strings.Join(a.headersForUpstream, ",")))
+	hash.Write(stringx.ToBytes(a.id))
+	hash.Write(stringx.ToBytes(strings.Join(a.headersForUpstream, ",")))
 	hash.Write(x.IfThenElseExec(a.payload != nil,
 		func() []byte { return a.payload.Hash() },
-		func() []byte { return []byte("nil") }))
+		func() []byte { return stringx.ToBytes("nil") }))
 	hash.Write(ttlBytes)
 	hash.Write(sub.Hash())
 

--- a/internal/rules/mechanisms/contenttype/www_form_urlencoded_decoder.go
+++ b/internal/rules/mechanisms/contenttype/www_form_urlencoded_decoder.go
@@ -18,12 +18,14 @@ package contenttype
 
 import (
 	"net/url"
+
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 type WWWFormUrlencodedDecoder struct{}
 
 func (WWWFormUrlencodedDecoder) Decode(rawData []byte) (map[string]any, error) {
-	values, err := url.ParseQuery(string(rawData))
+	values, err := url.ParseQuery(stringx.ToString(rawData))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
@@ -37,6 +37,7 @@ import (
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/template"
 	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 const (
@@ -336,7 +337,7 @@ func (h *genericContextualizer) readResponse(ctx heimdall.Context, resp *http.Re
 		logger.Warn().Str("_content_type", contentType).
 			Msg("Content type is not supported. Treating it as string")
 
-		return string(rawData), nil // nolint: nilerr
+		return stringx.ToString(rawData), nil // nolint: nilerr
 	}
 
 	result, err := decoder.Decode(rawData)
@@ -356,12 +357,12 @@ func (h *genericContextualizer) calculateCacheKey(sub *subject.Subject) string {
 	binary.LittleEndian.PutUint64(ttlBytes, uint64(h.ttl))
 
 	hash := sha256.New()
-	hash.Write([]byte(h.id))
-	hash.Write([]byte(strings.Join(h.fwdHeaders, ",")))
-	hash.Write([]byte(strings.Join(h.fwdCookies, ",")))
+	hash.Write(stringx.ToBytes(h.id))
+	hash.Write(stringx.ToBytes(strings.Join(h.fwdHeaders, ",")))
+	hash.Write(stringx.ToBytes(strings.Join(h.fwdCookies, ",")))
 	hash.Write(x.IfThenElseExec(h.payload != nil,
 		func() []byte { return h.payload.Hash() },
-		func() []byte { return []byte("nil") }))
+		func() []byte { return stringx.ToBytes("nil") }))
 	hash.Write(h.e.Hash())
 	hash.Write(ttlBytes)
 	hash.Write(sub.Hash())

--- a/internal/rules/mechanisms/oauth2/numeric_date.go
+++ b/internal/rules/mechanisms/oauth2/numeric_date.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 // NumericDate represents date and time as the number of seconds since the
@@ -33,7 +34,7 @@ type NumericDate int64
 func (n *NumericDate) UnmarshalJSON(b []byte) error {
 	const floatPrecision = 64
 
-	f, err := strconv.ParseFloat(string(b), floatPrecision)
+	f, err := strconv.ParseFloat(stringx.ToString(b), floatPrecision)
 	if err != nil {
 		return errorchain.NewWithMessage(ErrConfiguration, "failed to parse date").CausedBy(err)
 	}

--- a/internal/rules/mechanisms/template/template.go
+++ b/internal/rules/mechanisms/template/template.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 var ErrTemplateRender = errors.New("template error")
@@ -57,7 +58,7 @@ func New(val string) (Template, error) {
 	}
 
 	hash := sha256.New()
-	hash.Write([]byte(val))
+	hash.Write(stringx.ToBytes(val))
 
 	return &templateImpl{t: tmpl, hash: hash.Sum(nil)}, nil
 }

--- a/internal/rules/mechanisms/unifiers/jwt_unifier.go
+++ b/internal/rules/mechanisms/unifiers/jwt_unifier.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/template"
 	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 const (
@@ -187,7 +188,7 @@ func (u *jwtUnifier) generateToken(ctx heimdall.Context, sub *subject.Subject) (
 				CausedBy(err)
 		}
 
-		if err = json.Unmarshal([]byte(vals), &claims); err != nil {
+		if err = json.Unmarshal(stringx.ToBytes(vals), &claims); err != nil {
 			return "", errorchain.
 				NewWithMessage(heimdall.ErrInternal, "failed to unmarshal claims rendered by template").
 				WithErrorContext(u).
@@ -216,7 +217,7 @@ func (u *jwtUnifier) calculateCacheKey(sub *subject.Subject, iss heimdall.JWTSig
 	hash.Write(iss.Hash())
 	hash.Write(x.IfThenElseExec(u.claims != nil,
 		func() []byte { return u.claims.Hash() },
-		func() []byte { return []byte("nil") }))
+		func() []byte { return stringx.ToBytes("nil") }))
 	hash.Write(ttlBytes)
 	hash.Write(sub.Hash())
 

--- a/internal/signer/jwt_signer.go
+++ b/internal/signer/jwt_signer.go
@@ -36,6 +36,7 @@ import (
 	"github.com/dadrus/heimdall/internal/keystore"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
 	"github.com/dadrus/heimdall/internal/x/pkix"
+	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 func NewJWTSigner(conf *config.Configuration, logger zerolog.Logger) (heimdall.JWTSigner, error) {
@@ -117,9 +118,9 @@ type jwtSigner struct {
 
 func (s *jwtSigner) Hash() []byte {
 	hash := sha256.New()
-	hash.Write([]byte(s.jwk.KeyID))
-	hash.Write([]byte(s.jwk.Algorithm))
-	hash.Write([]byte(s.iss))
+	hash.Write(stringx.ToBytes(s.jwk.KeyID))
+	hash.Write(stringx.ToBytes(s.jwk.Algorithm))
+	hash.Write(stringx.ToBytes(s.iss))
 
 	return hash.Sum(nil)
 }

--- a/internal/x/stringx/stringx.go
+++ b/internal/x/stringx/stringx.go
@@ -1,0 +1,11 @@
+package stringx
+
+import "unsafe"
+
+func ToString(b []byte) string {
+	return unsafe.String(unsafe.SliceData(b), len(b))
+}
+
+func ToBytes(str string) []byte {
+	return unsafe.Slice(unsafe.StringData(str), len(str))
+}


### PR DESCRIPTION
uses the new Go 1.20 unsafe functionality