### PR TITLE
feat: `jwt` unifier supports definition of a custom header and scheme

### DIFF
--- a/docs/content/docs/configuration/reference/reference.adoc
+++ b/docs/content/docs/configuration/reference/reference.adoc
@@ -279,6 +279,9 @@ rules:
       type: jwt
       config:
         ttl: 5m
+        header:
+          name: Foo
+          scheme: Bar
         claims: "{'user': {{ quote .Subject.ID }} }"
     - id: bla
       type: header

--- a/docs/content/docs/configuration/rules/pipeline_mechanisms/unifiers.adoc
+++ b/docs/content/docs/configuration/rules/pipeline_mechanisms/unifiers.adoc
@@ -82,7 +82,7 @@ config:
 
 === JWT
 
-This unifier enables transformation of a link:{{< relref "overview.adoc#_subject" >}}[`Subject`] object into a bearer token in a https://www.rfc-editor.org/rfc/rfc7519[JWT] format, which is made available to your upstream service in the HTTP `Authorization` header. In addition to setting the JWT specific claims, it allows setting custom claims as well. Your upstream service can then verify the signature of the JWT by making use of heimdall's JWKS endpoint to retrieve the required public keys/certificates from.
+This unifier enables transformation of a link:{{< relref "overview.adoc#_subject" >}}[`Subject`] object into a token in a https://www.rfc-editor.org/rfc/rfc7519[JWT] format, which is made available to your upstream service in either the HTTP `Authorization` header with `Bearer` scheme set, or in a custom header. In addition to setting the JWT specific claims, it allows setting custom claims as well. Your upstream service can then verify the signature of the JWT by making use of heimdall's JWKS endpoint to retrieve the required public keys/certificates from.
 
 To enable the usage of this unifier, you have to set the `type` property to `jwt`. The usage of this unifier type requires a configured link:{{< relref "/docs/configuration/cryptographic_material.adoc" >}}[Signer] as well. At least it is a must in production environments.
 
@@ -96,6 +96,10 @@ Your template with custom claims, you would like to add to the JWT (See also lin
 +
 Defines how long the JWT should be valid. Defaults to 5 minutes. Heimdall sets the `iat` and the `nbf` claims to the current system time. The value of the `exp` claim is then influenced by the `ttl` property.
 
+* *`header`*: _object_ (optional, not overridable)
++
+Defines the `name` and `scheme` to be used for the header. Defaults to `Authorization` with scheme `Bearer`. If defined, the `name` property must be set. If `scheme` is not defined, no scheme will be prepended to the resulting JWT.
+
 The generated JWT is always cached until 5 seconds before its expiration. The cache key is calculated from the entire configuration of the unifier instance and the available information about the current subject.
 
 .JWT unifier configuration
@@ -106,6 +110,8 @@ id: jwt_unifier
 type: jwt
 config:
   ttl: 5m
+  header:
+    name: X-Token
   claims: |
     {
       {{ $user_name := .Subject.Attributes.identity.user_name -}}

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -326,6 +326,15 @@ rules:
           ttl: 5m
           claims: |
             {"user": {{ quote .Subject.ID }} }
+      - id: jwt_with_custom_header
+        type: jwt
+        config:
+          ttl: 5m
+          header:
+            name: Foo
+            scheme: Bar
+          claims: |
+            {"user": {{ quote .Subject.ID }} }
       - id: bla
         type: header
         config:

--- a/internal/rules/mechanisms/unifiers/jwt_unifier.go
+++ b/internal/rules/mechanisms/unifiers/jwt_unifier.go
@@ -88,16 +88,21 @@ func newJWTUnifier(id string, rawConfig map[string]any) (*jwtUnifier, error) {
 			NewWithMessage(heimdall.ErrConfiguration, "configured JWT ttl is less than one second")
 	}
 
+	if conf.Header != nil && len(strings.TrimSpace(conf.Header.Name)) == 0 {
+		return nil, errorchain.
+			NewWithMessage(heimdall.ErrConfiguration, "configured JWT header name is an empty string")
+	}
+
 	return &jwtUnifier{
 		id:     id,
 		claims: conf.Claims,
 		ttl: x.IfThenElseExec(conf.TTL != nil,
 			func() time.Duration { return *conf.TTL },
 			func() time.Duration { return defaultJWTTTL }),
-		headerName: x.IfThenElseExec(conf.Header != nil && len(strings.TrimSpace(conf.Header.Name)) != 0,
+		headerName: x.IfThenElseExec(conf.Header != nil,
 			func() string { return conf.Header.Name },
 			func() string { return "Authorization" }),
-		headerScheme: x.IfThenElseExec(conf.Header != nil && len(strings.TrimSpace(conf.Header.Scheme)) != 0,
+		headerScheme: x.IfThenElseExec(conf.Header != nil,
 			func() string { return conf.Header.Scheme },
 			func() string { return "Bearer" }),
 	}, nil

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -1252,6 +1252,22 @@
                 "1m",
                 "30s"
               ]
+            },
+            "header": {
+              "description": "Header configuration",
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "scheme": {
+                  "type": "string"
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## Related issue(s)

closes #663 

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

Implements the idea described in #663.
