### PR TITLE
fix: Proper usage of system trust store for certificate validation purposes

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -921,8 +921,6 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=
-github.com/go-co-op/gocron v1.28.2 h1:H9oHUGH+9HZ5mAorbnzRjzXLf4poP+ctZdbtaKRYagc=
-github.com/go-co-op/gocron v1.28.2/go.mod h1:39f6KNSGVOU1LO/ZOoZfcSxwlsJDQOKSu8erN0SH48Y=
 github.com/go-co-op/gocron v1.28.3 h1:swTsge6u/1Ei51b9VLMz/YTzEzWpbsk5SiR7m5fklTI=
 github.com/go-co-op/gocron v1.28.3/go.mod h1:39f6KNSGVOU1LO/ZOoZfcSxwlsJDQOKSu8erN0SH48Y=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/internal/x/pkix/validate_certificate.go
+++ b/internal/x/pkix/validate_certificate.go
@@ -137,7 +137,7 @@ func ValidateCertificate(cert *x509.Certificate, opts ...ValidationOption) error
 		validationOpts.verifyOpts.KeyUsages = []x509.ExtKeyUsage{x509.ExtKeyUsageAny}
 	}
 
-	if validationOpts.verifyOpts.Roots == nil {
+	if len(validationOpts.rootCAs) != 0 && validationOpts.verifyOpts.Roots == nil {
 		validationOpts.verifyOpts.Roots = x509.NewCertPool()
 	}
 


### PR DESCRIPTION
## Related issue(s)

closes #670 

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.

## Description

This fix updates the certificate validation implementation to not create a new cert pool if there are no root certificates configured. That way the system trust store will be used in such cases. Without that fix, the system trust store will never be used, leading to the issue described in #670
