### PR TITLE
fix: Leading slash is not added to the URL path anymore during URL path extraction

### DIFF
--- a/internal/fiber/middleware/xfmphu/handler_test.go
+++ b/internal/fiber/middleware/xfmphu/handler_test.go
@@ -154,6 +154,26 @@ func TestMiddlewareApplicationWithoutConfiguredTrustedProxy(t *testing.T) {
 			},
 		},
 		{
+			uc:  "Empty path",
+			URL: "http://heimdall.test.local",
+			configureRequest: func(t *testing.T, req *http.Request) {
+				t.Helper()
+
+				req.Header.Set(xSentFrom, nginxIngressAgent)
+				req.URL.RawQuery = url.Values{"foo": []string{"bar"}}.Encode()
+			},
+			assert: func(t *testing.T) {
+				t.Helper()
+
+				require.True(t, testAppCalled)
+				assert.Equal(t, "GET", extractedMethod)
+				assert.Equal(t, "http", extractedURL.Scheme)
+				assert.Equal(t, "heimdall.test.local", extractedURL.Host)
+				assert.Empty(t, extractedURL.Path)
+				assert.Equal(t, url.Values{"foo": []string{"bar"}}, extractedURL.Query())
+			},
+		},
+		{
 			uc:  "NGINX workaround test 1",
 			URL: "http://heimdall.test.local//test",
 			configureRequest: func(t *testing.T, req *http.Request) {

--- a/internal/fiber/middleware/xfmphu/request_url.go
+++ b/internal/fiber/middleware/xfmphu/request_url.go
@@ -51,7 +51,10 @@ func requestURL(c *fiber.Ctx) *url.URL {
 	}
 
 	if len(path) == 0 {
-		path = fmt.Sprintf("/%s", c.Params("*"))
+		path = c.Params("*")
+		if len(path) != 0 {
+			path = fmt.Sprintf("/%s", path)
+		}
 
 		// there is a bug in the implementation of the nginx controller
 		// see: https://github.com/kubernetes/ingress-nginx/issues/10114


### PR DESCRIPTION
## Related issue(s)

closes #693 

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

Fix for the bug
