### PR TITLE
feat: Configuration for read and write buffer sizes

### DIFF
--- a/docs/content/docs/configuration/reference/reference.adoc
+++ b/docs/content/docs/configuration/reference/reference.adoc
@@ -30,6 +30,9 @@ serve:
       read: 2s
       write: 5s
       idle: 2m
+    buffer_limit:
+      read: 10KB
+      write: 10KB
     tls:
       key_store:
         path: /path/to/key/store.pem

--- a/docs/content/docs/configuration/reference/types.adoc
+++ b/docs/content/docs/configuration/reference/types.adoc
@@ -417,6 +417,33 @@ message: No groups ending with @acme.co present
 ----
 ====
 
+== Buffer Limit
+
+Following configuration properties are supported to limit:
+
+* *`read`*: _link:{{< relref "#_bytesize" >}}[ByteSize]_ (optional)
++
+The maximum size for the read buffer allowed to read the full request including body. Defaults to 4KB.
+
+* *`write`*: _link:{{< relref "#_bytesize" >}}[ByteSize]_ (optional)
++
+The maximum size for the write buffer of the response. Defaults to 4KB.
+
+.Setting the read buffer size limit to 1MB and the write buffer size limit to 2KB.
+====
+[source, yaml]
+----
+read: 1MB
+write: 2KB
+----
+====
+
+== ByteSize
+
+ByteSize is actually a string type, which adheres to the following pattern: `^[0-9]+(B|KB|MB)$`
+
+So with `10B` you can define the byte size of 10 bytes and with `2MB` you can say 2 megabytes.
+
 == CORS
 
 https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[CORS] (Cross-Origin Resource Sharing) headers can be added and configured by making use of this type. This functionality allows for advanced security features to quickly be set. If CORS headers are set, then heimdall does not pass preflight requests to its decision pipeline, instead the response will be generated and sent back to the client directly. Following properties are supported:

--- a/docs/content/docs/configuration/services/decision.adoc
+++ b/docs/content/docs/configuration/services/decision.adoc
@@ -61,6 +61,21 @@ decision:
 ----
 ====
 
+* *`buffer_limit`*: _link:{{< relref "/docs/configuration/reference/types.adoc#_buffer_limit" >}}[BufferLimit]_ (optional)
++
+Read and write buffer limits for incoming requests and responses created by heimdall default to 4KB. You can however override this by making use of this property and specifying the limits you need.
++
+.Setting the read buffer size limit to 1MB and the write buffer size limit to 2KB.
+====
+[source, yaml]
+----
+decision:
+  buffer_limit:
+    read: 1MB
+    write: 2KB
+----
+====
+
 * *`tls`*: _link:{{< relref "/docs/configuration/reference/types.adoc#_tls" >}}[TLS]_ (optional)
 +
 By default, the Decision service accepts HTTP requests. Depending on your deployment scenario, you could require Heimdall to accept HTTPs requests only (which is highly recommended). You can do so by making use of this option.

--- a/docs/content/docs/configuration/services/decision.adoc
+++ b/docs/content/docs/configuration/services/decision.adoc
@@ -63,7 +63,7 @@ decision:
 
 * *`buffer_limit`*: _link:{{< relref "/docs/configuration/reference/types.adoc#_buffer_limit" >}}[BufferLimit]_ (optional)
 +
-Read and write buffer limits for incoming requests and responses created by heimdall default to 4KB. You can however override this by making use of this property and specifying the limits you need.
+Read and write buffer limits (defaults to 4KB) for incoming requests and responses created by heimdall. You can however override this by making use of this property and specifying the limits you need.
 +
 .Setting the read buffer size limit to 1MB and the write buffer size limit to 2KB.
 ====

--- a/docs/content/docs/configuration/services/management.adoc
+++ b/docs/content/docs/configuration/services/management.adoc
@@ -61,7 +61,7 @@ management:
 
 * *`buffer_limit`*: _link:{{< relref "/docs/configuration/reference/types.adoc#_buffer_limit" >}}[BufferLimit]_ (optional)
 +
-Read and write buffer limits for incoming requests and responses created by heimdall default to 4KB. You can however override this by making use of this property and specifying the limits you need.
+Read and write buffer limits (default to 4KB) for incoming requests and responses created by heimdall. You can however override this by making use of this property and specifying the limits you need.
 +
 .Setting the read buffer size limit to 1MB and the write buffer size limit to 2KB.
 ====

--- a/docs/content/docs/configuration/services/management.adoc
+++ b/docs/content/docs/configuration/services/management.adoc
@@ -59,6 +59,21 @@ management:
 ----
 ====
 
+* *`buffer_limit`*: _link:{{< relref "/docs/configuration/reference/types.adoc#_buffer_limit" >}}[BufferLimit]_ (optional)
++
+Read and write buffer limits for incoming requests and responses created by heimdall default to 4KB. You can however override this by making use of this property and specifying the limits you need.
++
+.Setting the read buffer size limit to 1MB and the write buffer size limit to 2KB.
+====
+[source, yaml]
+----
+management:
+  buffer_limit:
+    read: 1MB
+    write: 2KB
+----
+====
+
 * *`cors`*: _link:{{< relref "/docs/configuration/reference/types.adoc#_cors" >}}[CORS]_ (optional)
 +
 https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[CORS] (Cross-Origin Resource Sharing) headers can be added and configured by making use of this option. This functionality allows for advanced security features to quickly be set.

--- a/docs/content/docs/configuration/services/proxy.adoc
+++ b/docs/content/docs/configuration/services/proxy.adoc
@@ -61,6 +61,21 @@ proxy:
 ----
 ====
 
+* *`buffer_limit`*: _link:{{< relref "/docs/configuration/reference/types.adoc#_buffer_limit" >}}[BufferLimit]_ (optional)
++
+Read and write buffer limits for incoming requests and responses created by heimdall default to 4KB. You can however override this by making use of this property and specifying the limits you need.
++
+.Setting the read buffer size limit to 1MB and the write buffer size limit to 2KB.
+====
+[source, yaml]
+----
+management:
+  buffer_limit:
+    read: 1MB
+    write: 2KB
+----
+====
+
 * *`cors`*: _link:{{< relref "/docs/configuration/reference/types.adoc#_cors" >}}[CORS]_ (optional)
 +
 https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[CORS] (Cross-Origin Resource Sharing) headers can be added and configured by making use of this option. This functionality allows for advanced security features to quickly be set. If CORS headers are set, then the Heimdall does not pass preflight requests neither to its pipeline, nor to the upstream service. Instead, the response will be generated and sent back to the client directly.

--- a/docs/content/docs/configuration/services/proxy.adoc
+++ b/docs/content/docs/configuration/services/proxy.adoc
@@ -63,7 +63,7 @@ proxy:
 
 * *`buffer_limit`*: _link:{{< relref "/docs/configuration/reference/types.adoc#_buffer_limit" >}}[BufferLimit]_ (optional)
 +
-Read and write buffer limits for incoming requests and responses created by heimdall default to 4KB. You can however override this by making use of this property and specifying the limits you need.
+Read and write buffer limits (default to 4KB) for incoming requests and responses created by heimdall. You can however override this by making use of this property and specifying the limits you need.
 +
 .Setting the read buffer size limit to 1MB and the write buffer size limit to 2KB.
 ====

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/iancoleman/strcase v0.2.0
+	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf
 	github.com/instana/go-otel-exporter v1.0.0
 	github.com/jellydator/ttlcache/v3 v3.0.1
 	github.com/johannesboyne/gofakes3 v0.0.0-20230506070712-04da935ef877

--- a/go.sum
+++ b/go.sum
@@ -1160,8 +1160,6 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=
-github.com/go-co-op/gocron v1.28.3 h1:swTsge6u/1Ei51b9VLMz/YTzEzWpbsk5SiR7m5fklTI=
-github.com/go-co-op/gocron v1.28.3/go.mod h1:39f6KNSGVOU1LO/ZOoZfcSxwlsJDQOKSu8erN0SH48Y=
 github.com/go-co-op/gocron v1.29.0 h1:HHKBSnCqurMw8eENEcBIDGwoU1TY7wkH1CKzf1Rm/3M=
 github.com/go-co-op/gocron v1.29.0/go.mod h1:39f6KNSGVOU1LO/ZOoZfcSxwlsJDQOKSu8erN0SH48Y=
 github.com/go-fonts/dejavu v0.1.0/go.mod h1:4Wt4I4OU2Nq9asgDCteaAaWZOV24E+0/Pwo0gppep4g=
@@ -1597,6 +1595,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
+github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf h1:FtEj8sfIcaaBfAKrE1Cwb61YDtYq9JxChK1c7AKce7s=
+github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf/go.mod h1:yrqSXGoD/4EKfF26AOGzscPOgTTJcyAwM2rpixWT+t4=
 github.com/instana/go-otel-exporter v1.0.0 h1:s7PPvvB8xcSRNaXpgjYpBQWnFZRAqGGJZPkQ/j6RNjU=
 github.com/instana/go-otel-exporter v1.0.0/go.mod h1:chO0kaNOIV+bhh+eYRBiSShhuOHMV6HHQYgVo/7xxAs=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=
@@ -3299,7 +3299,6 @@ google.golang.org/grpc v1.52.3/go.mod h1:pu6fVzoFb+NBYNAvQL08ic+lvB2IojljRYuun5v
 google.golang.org/grpc v1.53.0/go.mod h1:OnIrk0ipVdj4N5d9IUoFUx72/VlD7+jUsHwZgwSMQpw=
 google.golang.org/grpc v1.54.0/go.mod h1:PUSEXI6iWghWaB6lXM4knEgpJNu2qUcKfDtNci3EC2g=
 google.golang.org/grpc v1.55.0/go.mod h1:iYEXKGkEBhg1PjZQvoYEVPTDkHo1/bjTnfwTeGONTY8=
-google.golang.org/grpc v1.56.0 h1:+y7Bs8rtMd07LeXmL3NxcTLn7mUkbKZqEpPhMNkwJEE=
 google.golang.org/grpc v1.56.0/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
 google.golang.org/grpc v1.56.1 h1:z0dNfjIl0VpaZ9iSVjA6daGatAYwPGstTjt5vkRMFkQ=
 google.golang.org/grpc v1.56.1/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -43,6 +43,7 @@ func NewConfiguration(envPrefix EnvVarPrefix, configFile ConfigurationPath) (*Co
 	opts := []parser.Option{
 		parser.WithDecodeHookFunc(mapstructure.StringToTimeDurationHookFunc()),
 		parser.WithDecodeHookFunc(mapstructure.StringToSliceHookFunc(",")),
+		parser.WithDecodeHookFunc(stringToByteSizeHookFunc()),
 		parser.WithDecodeHookFunc(logLevelDecodeHookFunc),
 		parser.WithDecodeHookFunc(logFormatDecodeHookFunc),
 		parser.WithDecodeHookFunc(decodeTLSCipherSuiteHookFunc),

--- a/internal/config/default_configuration.go
+++ b/internal/config/default_configuration.go
@@ -19,6 +19,7 @@ package config
 import (
 	"time"
 
+	"github.com/inhies/go-bytesize"
 	"github.com/rs/zerolog"
 )
 
@@ -33,6 +34,8 @@ const (
 	defaultMetricsServicePort    = 10250
 	defaultProfilingServicePort  = 10251
 
+	defaultBufferSize = 4 * bytesize.KB
+
 	loopbackIP = "127.0.0.1"
 )
 
@@ -46,6 +49,10 @@ func defaultConfig() Configuration {
 					Write: defaultWriteTimeout,
 					Idle:  defaultIdleTimeout,
 				},
+				BufferLimit: BufferLimit{
+					Read:  defaultBufferSize,
+					Write: defaultBufferSize,
+				},
 			},
 			Decision: ServiceConfig{
 				Port: defaultDecisionServicePort,
@@ -54,6 +61,10 @@ func defaultConfig() Configuration {
 					Write: defaultWriteTimeout,
 					Idle:  defaultIdleTimeout,
 				},
+				BufferLimit: BufferLimit{
+					Read:  defaultBufferSize,
+					Write: defaultBufferSize,
+				},
 			},
 			Management: ServiceConfig{
 				Port: defaultManagementServicePort,
@@ -61,6 +72,10 @@ func defaultConfig() Configuration {
 					Read:  defaultReadTimeout,
 					Write: defaultWriteTimeout,
 					Idle:  defaultIdleTimeout,
+				},
+				BufferLimit: BufferLimit{
+					Read:  defaultBufferSize,
+					Write: defaultBufferSize,
 				},
 			},
 		},

--- a/internal/config/mapstructure_decoder.go
+++ b/internal/config/mapstructure_decoder.go
@@ -20,6 +20,8 @@ import (
 	"crypto/tls"
 	"reflect"
 
+	"github.com/inhies/go-bytesize"
+	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog"
 
 	"github.com/dadrus/heimdall/internal/heimdall"
@@ -123,5 +125,21 @@ func decodeTLSMinVersionHookFunc(from reflect.Type, to reflect.Type, data any) (
 		return tls.VersionTLS13, nil
 	default:
 		return data, errorchain.NewWithMessagef(heimdall.ErrConfiguration, "TLS version %s is unsupported", data)
+	}
+}
+
+func stringToByteSizeHookFunc() mapstructure.DecodeHookFunc {
+	return func(f reflect.Type, t reflect.Type, data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.String {
+			return data, nil
+		}
+
+		if t != reflect.TypeOf(bytesize.ByteSize(0)) {
+			return data, nil
+		}
+
+		// Convert it by parsing
+		// nolint: forcetypeassert
+		return bytesize.Parse(data.(string))
 	}
 }

--- a/internal/config/parser/merge.go
+++ b/internal/config/parser/merge.go
@@ -29,16 +29,20 @@ func merge(dest, src any) any {
 	vDst := reflect.ValueOf(dest)
 	vSrc := reflect.ValueOf(src)
 
-	if vSrc.Type() != vDst.Type() {
-		panic(fmt.Sprintf("Cannot merge %s and %s. Types are different: %s - %s", dest, src, vDst.Type(), vSrc.Type()))
-	}
-
 	// nolint: exhaustive
 	switch vDst.Kind() {
 	case reflect.Map:
+		if vSrc.Type() != vDst.Type() {
+			panic(fmt.Sprintf("Cannot merge %s and %s. Types are different: %s - %s", dest, src, vDst.Type(), vSrc.Type()))
+		}
+
 		// nolint: forcetypeassert
 		return mergeMaps(dest.(map[string]any), src.(map[string]any))
 	case reflect.Slice:
+		if vSrc.Type() != vDst.Type() {
+			panic(fmt.Sprintf("Cannot merge %s and %s. Types are different: %s - %s", dest, src, vDst.Type(), vSrc.Type()))
+		}
+
 		// nolint: forcetypeassert
 		return mergeSlices(dest.([]any), src.([]any))
 	default:

--- a/internal/config/serve.go
+++ b/internal/config/serve.go
@@ -20,7 +20,14 @@ import (
 	"crypto/tls"
 	"fmt"
 	"time"
+
+	"github.com/inhies/go-bytesize"
 )
+
+type BufferLimit struct {
+	Read  bytesize.ByteSize `koanf:"read"`
+	Write bytesize.ByteSize `koanf:"write"`
+}
 
 type Timeout struct {
 	Read  time.Duration `koanf:"read,string"`
@@ -75,6 +82,7 @@ type ServiceConfig struct {
 	Host           string        `koanf:"host"`
 	Port           int           `koanf:"port"`
 	Timeout        Timeout       `koanf:"timeout"`
+	BufferLimit    BufferLimit   `koanf:"buffer_limit"`
 	CORS           *CORS         `koanf:"cors,omitempty"`
 	TLS            *TLS          `koanf:"tls,omitempty"`
 	TrustedProxies *[]string     `koanf:"trusted_proxies,omitempty"`

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -6,6 +6,9 @@ serve:
       read: 2s
       write: 5s
       idle: 2m
+    buffer_limit:
+      read: 4KB
+      write: 4KB
     tls:
       key_store:
         path: /path/to/keystore/file.pem
@@ -41,6 +44,9 @@ serve:
       read: 2s
       write: 5s
       idle: 2m
+    buffer_limit:
+      read: 4KB
+      write: 4KB
     cors:
       allowed_origins:
         - example.org
@@ -82,6 +88,9 @@ serve:
       read: 2s
       write: 5s
       idle: 2m
+    buffer_limit:
+      read: 4KB
+      write: 4KB
     cors:
       allowed_origins:
         - example.org

--- a/internal/handler/decision/app.go
+++ b/internal/handler/decision/app.go
@@ -53,6 +53,8 @@ func newApp(args appArgs) *fiber.App {
 		ReadTimeout:             service.Timeout.Read,
 		WriteTimeout:            service.Timeout.Write,
 		IdleTimeout:             service.Timeout.Idle,
+		ReadBufferSize:          int(service.BufferLimit.Read),
+		WriteBufferSize:         int(service.BufferLimit.Write),
 		DisableStartupMessage:   true,
 		EnableTrustedProxyCheck: true,
 		TrustedProxies: x.IfThenElseExec(service.TrustedProxies != nil,

--- a/internal/handler/envoyextauth/grpcv3/service.go
+++ b/internal/handler/envoyextauth/grpcv3/service.go
@@ -95,6 +95,8 @@ func newService(
 
 	srv := grpc.NewServer(
 		grpc.KeepaliveParams(keepalive.ServerParameters{Timeout: service.Timeout.Idle}),
+		grpc.ReadBufferSize(int(service.BufferLimit.Read)),
+		grpc.WriteBufferSize(int(service.BufferLimit.Write)),
 		grpc.UnknownServiceHandler(func(srv interface{}, stream grpc.ServerStream) error {
 			return status.Error(codes.Unknown, "unknown service or method")
 		}),

--- a/internal/handler/management/app.go
+++ b/internal/handler/management/app.go
@@ -53,6 +53,8 @@ func newApp(args appArgs) *fiber.App {
 		ReadTimeout:             service.Timeout.Read,
 		WriteTimeout:            service.Timeout.Write,
 		IdleTimeout:             service.Timeout.Idle,
+		ReadBufferSize:          int(service.BufferLimit.Read),
+		WriteBufferSize:         int(service.BufferLimit.Write),
 		DisableStartupMessage:   true,
 		EnableTrustedProxyCheck: true,
 		JSONDecoder:             json.Unmarshal,

--- a/internal/handler/proxy/app.go
+++ b/internal/handler/proxy/app.go
@@ -57,6 +57,8 @@ func newApp(args appArgs) *fiber.App {
 		ReadTimeout:             service.Timeout.Read,
 		WriteTimeout:            service.Timeout.Write,
 		IdleTimeout:             service.Timeout.Idle,
+		ReadBufferSize:          int(service.BufferLimit.Read),
+		WriteBufferSize:         int(service.BufferLimit.Write),
 		DisableStartupMessage:   true,
 		EnableTrustedProxyCheck: true,
 		TrustedProxies: x.IfThenElseExec(service.TrustedProxies != nil,

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -205,7 +205,35 @@
         }
       }
     },
-
+    "bufferLimitConfig": {
+      "type": "object",
+      "description": "Overrides the default request and response buffer sizes",
+      "additionalProperties": false,
+      "properties": {
+        "read": {
+          "description": "The maximum buffer size for reading the entire request, including the body. Increase this parameter to prevent unexpected closing a client connection if the client request exceeds the default 4KB.",
+          "type": "string",
+          "default": "4KB",
+          "pattern": "^[0-9]+(B|KB|MB)$",
+          "examples": [
+            "5KB",
+            "1MB",
+            "1.6MB"
+          ]
+        },
+        "write": {
+          "description": "The maximum buffer size for writing the response. Increase this parameter to prevent unexpected closing a client connection if a response create by heimdall exceeds the default 4KB.",
+          "type": "string",
+          "default": "4KB",
+          "pattern": "^[0-9]+(B|KB|MB)$",
+          "examples": [
+            "5KB",
+            "1MB",
+            "1.6MB"
+          ]
+        }
+      }
+    },
     "responseOverride": {
       "type": "object",
       "description": "Overrides the defaults for responses",
@@ -1788,6 +1816,9 @@
             "timeout": {
               "$ref": "#/definitions/timeoutConfig"
             },
+            "buffer_limit": {
+              "$ref": "#/definitions/bufferLimitConfig"
+            },
             "tls": {
               "$ref": "#/definitions/tlsConfig"
             },
@@ -1823,6 +1854,9 @@
             },
             "timeout": {
               "$ref": "#/definitions/timeoutConfig"
+            },
+            "buffer_limit": {
+              "$ref": "#/definitions/bufferLimitConfig"
             },
             "cors": {
               "$ref": "#/definitions/corsConfig"
@@ -1862,6 +1896,9 @@
             },
             "timeout": {
               "$ref": "#/definitions/timeoutConfig"
+            },
+            "buffer_limit": {
+              "$ref": "#/definitions/bufferLimitConfig"
             },
             "cors": {
               "$ref": "#/definitions/corsConfig"


### PR DESCRIPTION
## Related issue(s)

closes #704

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

Introduces a new property to define the read and write buffer sizes for the incoming request and the outgoing responses. The following property is supported for all services exposed by heimdall, so the decision, the proxy and the management service:

```yaml
buffer_limit:
  read: 1MB
  write: 10KB
```


