### PR TITLE
fix: Refresh of cached items disabled to avoid retrieval of stale items

### DIFF
--- a/internal/cache/memory/cache.go
+++ b/internal/cache/memory/cache.go
@@ -28,7 +28,7 @@ type InMemoryCache struct {
 }
 
 func New() *InMemoryCache {
-	return &InMemoryCache{c: ttlcache.New[string, any]()}
+	return &InMemoryCache{c: ttlcache.New[string, any](ttlcache.WithDisableTouchOnHit[string, any]())}
 }
 
 func (c *InMemoryCache) Start(_ context.Context) error {

--- a/internal/cache/memory/cache_test.go
+++ b/internal/cache/memory/cache_test.go
@@ -104,3 +104,23 @@ func TestCacheUsage(t *testing.T) {
 		})
 	}
 }
+
+func TestCacheExpiration(t *testing.T) {
+	t.Parallel()
+
+	cache := New()
+	cache.Set("baz", "bar", 1*time.Second)
+
+	hits := 0
+
+	for i := 0; i < 8; i++ {
+		time.Sleep(250 * time.Millisecond)
+
+		item := cache.Get("baz")
+		if item != nil {
+			hits++
+		}
+	}
+
+	assert.LessOrEqual(t, hits, 4)
+}


### PR DESCRIPTION
## Related issue(s)

See discussion in discord: https://discord.com/channels/1100447190796742698/1100447191358787646/1121328565879836732

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have added tests that prove the correctness of my implementation.

## Description

The library used by heimdall extends the ttl of cached object if not explicitly disabled. That was not done in heimdall leading to extending the ttl of e.g. cached JWTs resulting in expired JWTs being returned to the calling proxy, respectively forwarded to the upstream service.
