### PR TITLE
fix: URL encoding fixed while forwarding the request to the upstream in proxy mode

### DIFF
--- a/internal/fiber/middleware/xfmphu/request_url.go
+++ b/internal/fiber/middleware/xfmphu/request_url.go
@@ -68,6 +68,8 @@ func requestURL(c *fiber.Ctx) *url.URL {
 		query = stringx.ToString(origReqURL.QueryString())
 	}
 
+	unescapedPath, _ := url.PathUnescape(path)
+
 	return &url.URL{
 		Scheme: x.IfThenElseExec(len(proto) != 0,
 			func() string { return proto },
@@ -75,7 +77,8 @@ func requestURL(c *fiber.Ctx) *url.URL {
 		Host: x.IfThenElseExec(len(host) != 0,
 			func() string { return host },
 			func() string { return c.Hostname() }),
-		Path:     path,
+		Path:     unescapedPath,
+		RawPath:  path,
 		RawQuery: query,
 	}
 }

--- a/internal/handler/proxy/handler_test.go
+++ b/internal/handler/proxy/handler_test.go
@@ -399,8 +399,7 @@ func TestHandleProxyEndpointRequest(t *testing.T) {
 				})).Return(upstreamURL, nil)
 
 				repository.EXPECT().FindRule(mock.MatchedBy(func(reqURL *url.URL) bool {
-					res := reqURL.String()
-					return res == "http://heimdall.test.local/%5Bbarfoo%5D"
+					return reqURL.String() == "http://heimdall.test.local/%5Bbarfoo%5D"
 				})).Return(rule, nil)
 			},
 			instructUpstream: func(t *testing.T) {

--- a/internal/handler/proxy/handler_test.go
+++ b/internal/handler/proxy/handler_test.go
@@ -383,7 +383,7 @@ func TestHandleProxyEndpointRequest(t *testing.T) {
 					strings.NewReader("hello"))
 
 				req.Header.Set("Content-Type", "text/html")
-				req.Header.Set("X-Forwarded-Path", "/barfoo")
+				req.Header.Set("X-Forwarded-Path", "/%5Bbarfoo%5D")
 
 				return req
 			},
@@ -399,7 +399,8 @@ func TestHandleProxyEndpointRequest(t *testing.T) {
 				})).Return(upstreamURL, nil)
 
 				repository.EXPECT().FindRule(mock.MatchedBy(func(reqURL *url.URL) bool {
-					return reqURL.String() == "http://heimdall.test.local/barfoo"
+					res := reqURL.String()
+					return res == "http://heimdall.test.local/%5Bbarfoo%5D"
 				})).Return(rule, nil)
 			},
 			instructUpstream: func(t *testing.T) {
@@ -407,7 +408,7 @@ func TestHandleProxyEndpointRequest(t *testing.T) {
 
 				upstreamCheckRequest = func(req *http.Request) {
 					assert.Equal(t, http.MethodPost, req.Method)
-					assert.Equal(t, "/barfoo", req.URL.Path)
+					assert.Equal(t, "/[barfoo]", req.URL.Path)
 
 					assert.Equal(t, "baz", req.Header.Get("X-Foo-Bar"))
 					cookie, err := req.Cookie("X-Bar-Foo")

--- a/internal/handler/proxy/handler_test.go
+++ b/internal/handler/proxy/handler_test.go
@@ -306,7 +306,7 @@ func TestHandleProxyEndpointRequest(t *testing.T) {
 
 				req := httptest.NewRequest(
 					http.MethodPost,
-					"http://heimdall.test.local/foobar",
+					"http://heimdall.test.local/%5Bid%5D/foobar",
 					strings.NewReader("hello"))
 
 				req.Header.Set("Content-Type", "text/html")
@@ -326,7 +326,7 @@ func TestHandleProxyEndpointRequest(t *testing.T) {
 				})).Return(upstreamURL, nil)
 
 				repository.EXPECT().FindRule(mock.MatchedBy(func(reqURL *url.URL) bool {
-					return reqURL.String() == "http://heimdall.test.local/foobar"
+					return reqURL.String() == "http://heimdall.test.local/%5Bid%5D/foobar"
 				})).Return(rule, nil)
 			},
 			instructUpstream: func(t *testing.T) {
@@ -334,7 +334,7 @@ func TestHandleProxyEndpointRequest(t *testing.T) {
 
 				upstreamCheckRequest = func(req *http.Request) {
 					assert.Equal(t, http.MethodGet, req.Method)
-					assert.Equal(t, "/foobar", req.URL.Path)
+					assert.Equal(t, "/[id]/foobar", req.URL.Path)
 
 					assert.Equal(t, "baz", req.Header.Get("X-Foo-Bar"))
 					cookie, err := req.Cookie("X-Bar-Foo")

--- a/internal/handler/requestcontext/request_context.go
+++ b/internal/handler/requestcontext/request_context.go
@@ -120,12 +120,9 @@ func (s *RequestContext) FinalizeAndForward(upstreamURL *url.URL, timeout time.D
 		s.c.Request().Header.Del(name)
 	}
 
-	URL := &url.URL{
-		Scheme:   upstreamURL.Scheme,
-		Host:     upstreamURL.Host,
-		Path:     s.reqURL.Path,
-		RawQuery: s.reqURL.RawQuery,
-	}
+	URL := *s.reqURL
+	URL.Scheme = upstreamURL.Scheme
+	URL.Host = upstreamURL.Host
 
 	s.c.Request().Header.SetMethod(s.reqMethod)
 	s.c.Request().SetRequestURI(URL.String())


### PR DESCRIPTION
## Related issue(s)

closes #715 

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

Fixes the duplicate url encoding

