### PR TITLE
fix: Matcher expressions do not have to cope with url encoded path fragments any more if such are present

### DIFF
--- a/internal/rules/repository_impl_test.go
+++ b/internal/rules/repository_impl_test.go
@@ -71,7 +71,7 @@ func TestRepositoryFindRule(t *testing.T) {
 	}{
 		{
 			uc:         "no matching rule without default rule",
-			requestURL: &url.URL{Scheme: "http", Host: "foo.bar", Path: "baz"},
+			requestURL: &url.URL{Scheme: "http", Host: "foo.bar", Path: "/baz"},
 			configureFactory: func(t *testing.T, factory *mocks.FactoryMock) {
 				t.Helper()
 
@@ -86,7 +86,7 @@ func TestRepositoryFindRule(t *testing.T) {
 		},
 		{
 			uc:         "no matching rule with default rule",
-			requestURL: &url.URL{Scheme: "http", Host: "foo.bar", Path: "baz"},
+			requestURL: &url.URL{Scheme: "http", Host: "foo.bar", Path: "/baz"},
 			configureFactory: func(t *testing.T, factory *mocks.FactoryMock) {
 				t.Helper()
 
@@ -102,7 +102,7 @@ func TestRepositoryFindRule(t *testing.T) {
 		},
 		{
 			uc:         "matching rule",
-			requestURL: &url.URL{Scheme: "http", Host: "foo.bar", Path: "baz"},
+			requestURL: &url.URL{Scheme: "http", Host: "foo.bar", Path: "/baz"},
 			configureFactory: func(t *testing.T, factory *mocks.FactoryMock) {
 				t.Helper()
 

--- a/internal/rules/rule_impl.go
+++ b/internal/rules/rule_impl.go
@@ -17,6 +17,7 @@
 package rules
 
 import (
+	"fmt"
 	"net/url"
 
 	"github.com/rs/zerolog"
@@ -75,8 +76,10 @@ func (r *ruleImpl) Execute(ctx heimdall.Context) (*url.URL, error) {
 }
 
 func (r *ruleImpl) MatchesURL(requestURL *url.URL) bool {
-	toBeMatched := *requestURL
-	toBeMatched.RawQuery = ""
+	toBeMatched := url.URL{
+		Scheme: requestURL.Scheme,
+		Opaque: fmt.Sprintf("//%s%s", requestURL.Host, requestURL.Path),
+	}
 
 	return r.urlMatcher.Match(toBeMatched.String())
 }

--- a/internal/rules/rule_impl_test.go
+++ b/internal/rules/rule_impl_test.go
@@ -80,7 +80,7 @@ func TestRuleMatchURL(t *testing.T) {
 	for _, tc := range []struct {
 		uc          string
 		matcher     func(t *testing.T) patternmatcher.PatternMatcher
-		toBeMatched *url.URL
+		toBeMatched string
 		assert      func(t *testing.T, matched bool)
 	}{
 		{
@@ -93,7 +93,24 @@ func TestRuleMatchURL(t *testing.T) {
 
 				return matcher
 			},
-			toBeMatched: &url.URL{Scheme: "http", Host: "foo.bar", Path: "baz"},
+			toBeMatched: "http://foo.bar/baz",
+			assert: func(t *testing.T, matched bool) {
+				t.Helper()
+
+				assert.True(t, matched)
+			},
+		},
+		{
+			uc: "matches with urlencoded path fragments",
+			matcher: func(t *testing.T) patternmatcher.PatternMatcher {
+				t.Helper()
+
+				matcher, err := patternmatcher.NewPatternMatcher("glob", "http://foo.bar/[id]/baz")
+				require.NoError(t, err)
+
+				return matcher
+			},
+			toBeMatched: "http://foo.bar/%5Bid%5D/baz",
 			assert: func(t *testing.T, matched bool) {
 				t.Helper()
 
@@ -110,7 +127,24 @@ func TestRuleMatchURL(t *testing.T) {
 
 				return matcher
 			},
-			toBeMatched: &url.URL{Scheme: "https", Host: "foo.bar", Path: "baz"},
+			toBeMatched: "https://foo.bar/baz",
+			assert: func(t *testing.T, matched bool) {
+				t.Helper()
+
+				assert.False(t, matched)
+			},
+		},
+		{
+			uc: "query params are ignored while matching",
+			matcher: func(t *testing.T) patternmatcher.PatternMatcher {
+				t.Helper()
+
+				matcher, err := patternmatcher.NewPatternMatcher("glob", "http://foo.bar/baz")
+				require.NoError(t, err)
+
+				return matcher
+			},
+			toBeMatched: "https://foo.bar/baz?foo=bar",
 			assert: func(t *testing.T, matched bool) {
 				t.Helper()
 
@@ -122,8 +156,11 @@ func TestRuleMatchURL(t *testing.T) {
 			// GIVEN
 			rul := &ruleImpl{urlMatcher: tc.matcher(t)}
 
+			tbmu, err := url.Parse(tc.toBeMatched)
+			require.NoError(t, err)
+
 			// WHEN
-			matched := rul.MatchesURL(tc.toBeMatched)
+			matched := rul.MatchesURL(tbmu)
 
 			// THEN
 			tc.assert(t, matched)


### PR DESCRIPTION
## Related issue(s)

closes #720

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.


## Description

See title
