### PR TITLE
feat: Support for automatically Helm roll deployments

### DIFF
--- a/charts/heimdall/templates/demo/deployment.yaml
+++ b/charts/heimdall/templates/demo/deployment.yaml
@@ -22,6 +22,8 @@ metadata:
   namespace: heimdall-demo
   labels:
     {{- include "heimdall.demo.labels" . | nindent 4 }}
+  annotations:
+    checksum/config: {{ include (print $.Template.BasePath "/demo/configmap.yaml") . | sha256sum }}
 spec:
   selector:
     matchLabels:

--- a/charts/heimdall/templates/heimdall/deployment.yaml
+++ b/charts/heimdall/templates/heimdall/deployment.yaml
@@ -27,7 +27,10 @@ metadata:
   labels:
     {{- include "heimdall.labels" $data | nindent 4 }}
   annotations:
+    checksum/config: {{ include (print $.Template.BasePath "/heimdall/configmap.yaml") . | sha256sum }}
+    {{- with .Values.deployment.annotations }}
     {{- toYaml .Values.deployment.annotations | nindent 4 }}
+    {{- end }}
 spec:
   {{- if not .Values.deployment.autoscaling.enabled }}
   replicas: {{ .Values.deployment.replicaCount }}


### PR DESCRIPTION
## Related issue(s)

closes #701

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.

## Description

Adds an annotation as described in https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments

This should automatically ensure a zero-downtime restart of the heimdall pods should the values and by extension the ConfigMap be updated via `helm upgrade`.
