### PR TITLE
ci: New template to file documentation issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/DOCS-ISSUE-REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/DOCS-ISSUE-REPORT.yaml
@@ -1,0 +1,44 @@
+name: Bug Report
+description: File a documentation issue report
+labels: [bug, documentation]
+body:
+  - id: thanks
+    type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this report!
+
+  - id: checklist
+    type: checkboxes
+    attributes:
+      label: Preflight checklist
+      options:
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/dadrus/heimdall/blob/main/CODE_OF_CONDUCT.md).
+          required: true
+        - label: I have read and am following this repository's [Contribution Guidelines](https://github.com/dadrus/heimdall/blob/main/CONTRIBUTING.md)."
+          required: true
+
+  - id: what-happened
+    type: textarea
+    attributes:
+      label: Describe the issue
+      description: A clear and concise description of what is missing or wrong. Also tell us, what did you expect to see in the documentation.
+      placeholder: Tell us your observation!
+    validations:
+      required: true
+
+  - id: version
+    type: input
+    attributes:
+      label: Version
+      description: | 
+        What version of heimdall are you running? Please provide the output from `heimdall --version`.
+    validations:
+      required: true
+
+  - id: additional
+    type: textarea
+    attributes:
+      label: Additional Context
+      description: Add any other context information about the issue here.
+


### PR DESCRIPTION
## Related issue(s)

closes #682 

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.

## Description

New template, which makes it easier to file issues related to documentation.
