### PR TITLE
feat: Values object can be used in payload of generic contextualizer and remote authorizer

### DIFF
--- a/docs/content/docs/configuration/rules/pipeline_mechanisms/authorizers.adoc
+++ b/docs/content/docs/configuration/rules/pipeline_mechanisms/authorizers.adoc
@@ -134,7 +134,7 @@ Allows caching of the authorization endpoint responses. Defaults to 0s, which me
 
 * *`values`* _map of strings_ (optional, overridable)
 +
-A key value map, which is made accessible to the template rendering engine as link:{{< relref "overview.adoc#_values" >}}[`Values`] object, e.g. to render parts of the URL.
+A key value map, which is made accessible to the template rendering engine as link:{{< relref "overview.adoc#_values" >}}[`Values`] object, to render parts of the URL or the payload.
 
 .Configuration of Remote authorizer to communicate with https://www.openpolicyagent.org/[Open Policy Agent] (OPA)
 ====
@@ -156,7 +156,7 @@ config:
         user: ${OPA_USER}
         password: ${OPA_PASSWORD}
   payload: |
-    { "input": { "user": {{ quote .Subject.ID }} } }
+    { "input": { "user": {{ quote .Subject.ID }} }, "some_data": {{ quote .Values.whatever }} }
   values:
     namespace: myapi/policy
     policy: allow_write
@@ -187,6 +187,7 @@ A specific rule could then use this authorizer in the following ways:
     config: # overriding with rule specifics
       values:
         policy: allow_read
+        whatever: foo
   - # other mechanisms
 ----
 

--- a/docs/content/docs/configuration/rules/pipeline_mechanisms/contextualizers.adoc
+++ b/docs/content/docs/configuration/rules/pipeline_mechanisms/contextualizers.adoc
@@ -49,9 +49,9 @@ If set to `true`, allows the pipeline to continue with the execution of the next
 
 * *`values`* _map of strings_ (optional, overridable)
 +
-A key value map, which is made accessible to the template rendering engine as link:{{< relref "overview.adoc#_values" >}}[`Values`] object, e.g. to render parts of the URL.
+A key value map, which is made accessible to the template rendering engine as link:{{< relref "overview.adoc#_values" >}}[`Values`] object to render parts of the URL or the payload.
 
-.Contextualizer configuration
+.Contextualizer configuration without payload
 ====
 
 In this example the contextualizer is configured to call an endpoint using the HTTP `GET` method with the subject id being part of the url path. As the endpoint requires the `X-My-Session-Cookie` cookie for subject authentication purposes, `forward_cookies` is used to achieve this.
@@ -66,5 +66,25 @@ config:
     method: GET
   forward_cookies:
     - X-My-Session-Cookie
+----
+====
+
+.Contextualizer configuration with payload
+====
+
+In this example the contextualizer is configured to call an endpoint using the HTTP `POST` and send some data. Since the `values` property is not defined, but used in the payload, it must be specified in a rule making use of this contextualzer.
+
+[source, yaml]
+----
+id: foo
+type: generic
+config:
+  endpoint:
+    url: https://some-other.service/users
+    method: POST
+  payload: |
+    {
+      "user_id": {{ quote .Values.user_id }}
+    }
 ----
 ====

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -290,8 +290,8 @@ rules:
             method: POST
             headers:
               foo-bar: "{{ .Subject.ID }}"
-            values:
-              key: value
+          values:
+            key: value
           payload: https://bla.bar
           forward_response_headers_to_upstream:
             - bla-bar
@@ -320,14 +320,14 @@ rules:
             url: http://profile/{{ .Subject.ID }}
             headers:
               foo: bar
-            values:
-              some-key: some-value
             auth:
               type: api_key
               config:
                 in: query
                 name: key
                 value: super duper secret
+          values:
+            some-key: some-value
     unifiers:
       - id: jwt
         type: jwt

--- a/internal/rules/mechanisms/authorizers/remote_authorizer.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer.go
@@ -289,6 +289,7 @@ func (a *remoteAuthorizer) createRequest(ctx heimdall.Context, sub *subject.Subj
 		bodyContents, err := a.payload.Render(map[string]any{
 			"Request": ctx.Request(),
 			"Subject": sub,
+			"Values":  a.v,
 		})
 		if err != nil {
 			return nil, errorchain.

--- a/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
@@ -517,8 +517,9 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 					URL:     srv.URL,
 					Headers: map[string]string{"Foo-Bar": "{{ .Subject.Attributes.bar }}"},
 				},
+				v: values.Values{"foo": "bar"},
 				payload: func() template.Template {
-					tpl, _ := template.New("{{ .Subject.ID }}")
+					tpl, _ := template.New("{{ .Subject.ID }}-{{ .Values.foo }}")
 
 					return tpl
 				}(),
@@ -543,7 +544,7 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 					data, err := io.ReadAll(req.Body)
 					assert.NoError(t, err)
 
-					assert.Equal(t, "my-id", string(data))
+					assert.Equal(t, "my-id-bar", string(data))
 				}
 			},
 			configureContext: func(t *testing.T, ctx *heimdallmocks.ContextMock) {

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
@@ -251,6 +251,7 @@ func (h *genericContextualizer) createRequest(ctx heimdall.Context, sub *subject
 		value, err := h.payload.Render(map[string]any{
 			"Request": ctx.Request(),
 			"Subject": sub,
+			"Values":  h.v,
 		})
 		if err != nil {
 			return nil, errorchain.NewWithMessage(heimdall.ErrInternal,

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer_test.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer_test.go
@@ -782,8 +782,14 @@ func TestGenericContextualizerExecute(t *testing.T) {
 						"X-Bar":        "{{ .Subject.Attributes.bar }}",
 					},
 				},
+				v: values.Values{"foo": "bar"},
 				payload: func() template.Template {
-					tpl, _ := template.New(`{ "user_id": {{ quote .Subject.ID }}}`)
+					tpl, _ := template.New(`
+{
+	"user_id": {{ quote .Subject.ID }},
+	"value": {{ quote .Values.foo }}
+}
+`)
 
 					return tpl
 				}(),
@@ -809,7 +815,7 @@ func TestGenericContextualizerExecute(t *testing.T) {
 					content, err := io.ReadAll(req.Body)
 					require.NoError(t, err)
 
-					assert.JSONEq(t, `{"user_id": "Foo"}`, string(content))
+					assert.JSONEq(t, `{"user_id": "Foo", "value": "bar"}`, string(content))
 				}
 
 				responseContentType = "application/json"

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -517,13 +517,6 @@
               "description": "Enables or disables http cache usage according to RFC 7234",
               "type": "boolean",
               "default": false
-            },
-            "values": {
-              "description": "Key-Value map with entries required for templating of e.g. the URL",
-              "type": "object",
-              "minLength": 0,
-              "uniqueItems": true,
-              "default": []
             }
           }
         },
@@ -1170,6 +1163,13 @@
                 "1m",
                 "30s"
               ]
+            },
+            "values": {
+              "description": "Key-Value map with entries required for templating of e.g. the endpoint URL",
+              "type": "object",
+              "minLength": 0,
+              "uniqueItems": true,
+              "default": []
             }
           }
         }
@@ -1238,6 +1238,13 @@
               "type": "boolean",
               "description": "Continue the pipeline execution even if this contextualizer fails",
               "default": false
+            },
+            "values": {
+              "description": "Key-Value map with entries required for templating of e.g. the endpoint URL",
+              "type": "object",
+              "minLength": 0,
+              "uniqueItems": true,
+              "default": []
             }
           }
         }


### PR DESCRIPTION
## Related issue(s)

closes #686

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

Makes following possible:

```yaml
- id: openfga
  config:
    endpoint: # etc.
    payload: |
      {
        "user": "user:{{ .Subject.ID }}",
        "relation": {{ quote .Values.relation }},
        "resource": {{ quote .Values.resource }}
      }
```

and then used in a pipeline like

```yaml
- authorizer: openfga
  config:
    values:
      relation: read
      resource: "endpoint:foo"
```

which will result in the following json payload sent to the defined endpoint for the `.Subject.ID` being `1`:

```json
{
    "user": "user:1",
    "relation": "read",
    "resource": "endpoint:foo"
}
```

If the `values` property is defined in the configuration of the particular mechanism, the corresponding entries act as defaults for the rule pipeline making use of that mechanism.
