### PR TITLE
ci: CI pipeline updated to publish container images built after merging PRs into main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -199,8 +199,8 @@ jobs:
           md5sum: false
           extra_files: CHANGELOG.md LICENSE
 
-  # this job is here only for the verification purpose of the docker images build
-  build-docker-images:
+  # this job builds container images for PRs, as well as publishes these on merges to main
+  build-dev-container-images:
     runs-on: ubuntu-22.04
     needs:
       - test
@@ -213,7 +213,22 @@ jobs:
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Build and push
+      - name: Login to container registry
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Collect container meta-info
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ github.repository }}
+          labels: |
+            org.opencontainers.image.version=${{ github.sha }}
+            org.opencontainers.image.documentation=${{ env.DOCUMENTATION_URL }}
+      - name: Build images
+        if: ${{ github.ref != 'refs/heads/main' }}
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -221,9 +236,21 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm
           push: false
           build-args: VERSION=${{ github.sha }}
-          tags: ${{ github.repository }}:latest
+          tags: ${{ github.repository }}:local
+      - name: Build and push dev images to container registry
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./docker/Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm
+          push: true
+          build-args: VERSION=${{ github.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ github.repository }}:dev-${{ github.sha }},${{ github.repository }}:dev
 
-  release-docker-images:
+  # this job releases container images
+  release-container-images:
     if: needs.prepare-release.outputs.release_created
     runs-on: ubuntu-22.04
     needs:
@@ -276,7 +303,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs:
       - prepare-release
-      - release-docker-images
+      - release-container-images
     if: needs.prepare-release.outputs.release_created
     steps:
       - name: Prepare image version

--- a/DockerHub-README.md
+++ b/DockerHub-README.md
@@ -231,7 +231,11 @@ As of today heimdall is built as a multi-platform image for the following platfo
 
 If you need support for other platforms, don't hesitate to file an issue at GitHub. Contributions are very welcome as well!
 
-All images adhere to the `dadrus/heimdall:<version>` pattern, with `dadrus/heimdall:latest` referencing the latest version as well.
+All images adhere to the following patterns:
+
+* For stable, respectively released versions, image tags have the suffix of the corresponding version and have the `dadrus/heimdall:<version>` form. E.g. an image tagged with `dadrus/heimdall:v0.10.1-alpha` is the image for the released `v0.10.1-alpha` version of heimdall. In addition, there is a `dadrus/heimdall:latest` tag referencing the latest released version as well.
+
+* Development images are created from the main branch by heimdall's continuous integration and are tagged with the `dev` and with the `dev-<SHA>` suffix, where the SHA is the commit in heimdall main from which it was created. For example, after a build at commit `730b2206`, an image will be created for `dadrus/heimdall:dev-730b2206fdfc688ca42bcdf0e344d8fa6bfba232` and the image `dadrus/heimdall:dev` will be tagged to it until the next build.
 
 ## License
 


### PR DESCRIPTION
## Related issue(s)

closes #782 

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have updated the documentation.

## Description

Makes the images built after merges into main available in the container registry. These images are tagged with just the `dev` suffix and with the `dev-<SHA>` suffix, where the SHA is the commit in heimdall main from which it was created.

For example, after a build at commit `730b2206`, an image will be created for `dadrus/heimdall:dev-730b2206fdfc688ca42bcdf0e344d8fa6bfba232` and the image `dadrus/heimdall:dev` will be tagged to it until the next build.
