### PR TITLE
ci: Not using deprecated set-output in pipeline jobs anymore

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -260,7 +260,7 @@ jobs:
         id: image-version
         run: |
           export version=$(echo ${{ needs.prepare-release.outputs.tag_name }} |  sed 's/v//g')
-          echo ::set-output name=result::$version
+          echo "result=$version" >> $GITHUB_OUTPUT
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Set up QEMU
@@ -310,7 +310,7 @@ jobs:
         id: image-version
         run: |
           export version=$(echo ${{ needs.prepare-release.outputs.tag_name }} |  sed 's/v//g')
-          echo ::set-output name=result::$version
+          echo "result=$version" >> $GITHUB_OUTPUT
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Publish Helm Chart


### PR DESCRIPTION
## Related issue(s)

closes #785

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.

## Description

Usage of `run: echo "::set-output name={name}::{value}"` replaced with `run: echo "{name}={value}" >> $GITHUB_OUTPUT`
