### PR TITLE
ci: Renovate is using `deps` for its PRs to have autorelease create PRs for updates only

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,3 +1,3 @@
 enabled: true
 titleOnly: true
-types: [ feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert, wip ]
+types: [ feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert, wip, deps ]

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "extends": [
     "config:base",
     ":semanticCommits",
-    ":semanticCommitTypeAll(chore)"
+    ":semanticCommitTypeAll(deps)",
+    ":semanticCommitScopeDisabled"
   ],
   "assigneesFromCodeOwners": true,
   "addLabels": ["dependency"],


### PR DESCRIPTION
## Related issue(s)

closes #786 

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.

## Description

This PR configures the semantic plugin to allow `deps` as a commit tag and configures renovate to use it for its PRs.

