### PR TITLE
ci: Cosign configured to sign released binaries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ env:
   KUBECONFORM_VERSION: "0.6.2"
   KUBERNETES_API_VERSION: "1.27.0"
   NODE_VERSION: "18.16"
+  COSIGN_VERSION: "v2.1.1"
   DOCUMENTATION_URL: "https://dadrus.github.io/heimdall/"
 
 jobs:
@@ -235,6 +236,9 @@ jobs:
     needs:
       - prepare-release
     if: needs.prepare-release.outputs.release_created
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -242,6 +246,10 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v4
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.1.1
+        with:
+          cosign-release: "${{ env.COSIGN_VERSION }}"
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,3 +42,16 @@ archives:
 
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Tag }}_checksums.txt"
+
+signs:
+  - cmd: cosign
+    signature: "${artifact}-keyless.sig"
+    certificate: "${artifact}-keyless.pem"
+    args:
+      - "sign-blob"
+      - "--oidc-issuer=https://token.actions.githubusercontent.com"
+      - "--output-signature=${artifact}-keyless.sig"
+      - "--output-certificate=${artifact}-keyless.pem"
+      - "${artifact}"
+      - "--yes"
+    artifacts: all


### PR DESCRIPTION
## Related issue(s)

closes #758

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.

## Description

This PR updates the CI release pipeline to sign every artifact published in a release using a so called "keyless signing" supported by cosign (See [here](https://docs.sigstore.dev/cosign/signing_with_blobs/#keyless-signing-of-blobs-and-files) for more details).

Verification of the released binaries can happen using [cosign](https://github.com/sigstore/cosign) as follows:

```bash
cosign verify-blob <path to the artifact> \
  --certificate <path to the certificate> \
  --signature <path to the signature file> \
  --certificate-identity=https://github.com/dadrus/heimdall/.github/workflows/ci.yaml@refs/heads/main \
  --certificate-oidc-issuer=https://token.actions.githubusercontent.com
```
