### PR TITLE
feat: Helm chart enhanced to allow passing optional arguments to heimdall

### DIFF
--- a/charts/heimdall/README.adoc
+++ b/charts/heimdall/README.adoc
@@ -403,4 +403,17 @@ env:
 ```
 
 a| `{}` (empty map)
+
+a| `extraArgs`
+
+Optional extra arguments to pass to heimdall when starting.
+
+E.g. to start heimdall in decision mode for integration with envoy v3 ext_auth, set it to:
+
+```.yaml
+extraArgs:
+  - --envoy-grpc
+```
+
+a| `[]` (empty array)
 |===

--- a/charts/heimdall/templates/heimdall/deployment.yaml
+++ b/charts/heimdall/templates/heimdall/deployment.yaml
@@ -70,11 +70,12 @@ spec:
             {{- toYaml .Values.deployment.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if eq $opMode "decision" }}
-          args: [ "serve", "decision" ]
-          {{- else }}
-          args: [ "serve", "proxy" ]
-          {{- end }}
+          args:
+            - serve
+            - {{- if eq $opMode "decision" }} decision{{- else }} proxy{{- end }}
+            {{- with .Values.extraArgs }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             {{- if eq $opMode "decision" }}
             - name: http-decision

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -123,6 +123,9 @@ service:
 # Configures arbitrary environment variables for the deployment
 env: { }
 
+# Optional flags for heimdall to use
+extraArgs: []
+
 # heimdall config defaults
 # DO NOT OVERRIDE the values here. Use heimdall config yaml file instead!
 serve:


### PR DESCRIPTION
## Related issue(s)

closes #822

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have updated the documentation.

## Description

Implements the option described in the referenced ticket. This allows starting heimdall for integration with envoy v3 ext_auth, when installing via helm chart and enables usage of further flags, which might come in the future.
