### PR TITLE
Feat/helm volumes and volume mounts

### DIFF
--- a/charts/heimdall/README.adoc
+++ b/charts/heimdall/README.adoc
@@ -352,6 +352,16 @@ a| `deployment.affinity`
 Affinity settings for the deploment
 a| `{}` (empty map)
 
+a| `deployment.volumes`
+
+Optional volumes to use
+a| `[]` (empty array)
+
+a| `deployment.volumeMounts`
+
+Optional volumeMounts to use
+a| `[]` (empty array)
+
 a| `service.labels`
 
 Enables you to set additional labels for the created services

--- a/charts/heimdall/templates/heimdall/deployment.yaml
+++ b/charts/heimdall/templates/heimdall/deployment.yaml
@@ -64,6 +64,9 @@ spec:
         - name: {{ include "heimdall.name" $data }}-config-volume
           configMap:
             name: {{ include "heimdall.fullname" $data }}-config
+        {{- with .Values.deployment.volumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -103,6 +106,9 @@ spec:
             - name: {{ include "heimdall.name" . }}-config-volume
               mountPath: /etc/heimdall
               readOnly: true
+          {{- with .Values.deployment.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.env }}
           env:
             {{- range $key, $val := .Values.env }}

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -18,7 +18,7 @@
 # Defaults to "decision" as operating in proxy mode makes most probably only sense
 # if heimdall is installed as a side card either in the Ingress Controller itself,
 # or in each pod before the actual business service.
-operationMode: "decision" # decision or proxy
+operationMode: decision # decision or proxy
 
 # If set to true, a demo deployment with exemplary rules, as these can be found in the documentation,
 # will be done
@@ -94,6 +94,12 @@ deployment:
   tolerations: [ ]
 
   affinity: { }
+
+  # Optional volumes to be used
+  volumes: [ ]
+
+  # Optional volume mounts to be used
+  volumeMounts: [ ]
 
 # Configures k8s services (decision, proxy, management)
 service:


### PR DESCRIPTION
## Related issue(s)

closes #823

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have updated the documentation.

## Description

Makes usage of custom volumes and volume mounts possible, e.g. to configure secrets for TLS and JWK purpose usage.

**Example:**

Given a project specific `heimdall-config.yaml` and the following `values.yaml` file

```yaml
deployment:
  volumes:
  - name: tls-cert-volume
    secret:
      secretName: heimdall-tls
  - name: jwt-cert-volume
    secret:
      secretName: heimdall-jwt
  volumeMounts:
  - name: tls-cert-volume
    readOnly: true
    mountPath: "/etc/heimdall/certs/ssl"
  - name: jwt-cert-volume
    readOnly: true
    mountPath: "/etc/heimdall/certs/jwt"
```

An installation via

```bash
$ helm install heimdall -f heimdall-config.yaml -f values.yaml -n heimdall dadrus/heimdall
```

will deploy a `Deployment` with the following `spec` contents:

```yaml
imagePullSecrets: [ ]
automountServiceAccountToken: true
serviceAccountName: heimdall
securityContext:
  fsGroup: 10001
  runAsGroup: 10001
  runAsNonRoot: true
  runAsUser: 10001
volumes:
  - name: heimdall-config-volume
    configMap:
      name: heimdall-config
  # the next two entries are created based on the corresponding values.yaml entries
  - name: tls-cert-volume
    secret:
      secretName: heimdall-tls
  - name: jwt-cert-volume
    secret:
      secretName: heimdall-jwt
containers:
  - name: heimdall
    securityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
          - ALL
      readOnlyRootFilesystem: true
    image: "dadrus/heimdall:latest"
    imagePullPolicy: IfNotPresent
    args:
      - serve
      - decision
    ports:
      - name: http-decision
        containerPort: 4456
        protocol: TCP
      - name: http-management
        protocol: TCP
        containerPort: 4457
      - name: http-metrics
        protocol: TCP
        containerPort: 10250
    volumeMounts:
      - name: heimdall-config-volume
        mountPath: /etc/heimdall
        readOnly: true
      # the next two entries are created based on the corresponding values.yaml entries
      - mountPath: /etc/heimdall/certs/ssl
        name: tls-cert-volume
        readOnly: true
      - mountPath: /etc/heimdall/certs/jwt
        name: jwt-cert-volume
        readOnly: true
    livenessProbe:
      httpGet:
        path: /.well-known/health
        port: http-management
    readinessProbe:
      httpGet:
        path: /.well-known/health
        port: http-management
    resources: { }
nodeSelector: { }
affinity: { }
tolerations: [ ]
```

