### PR TITLE
fix: Validation of a self-signed certificate does not require its presence in the system wide trust store any more

### DIFF
--- a/docs/content/docs/configuration/rules/pipeline_mechanisms/authenticators.adoc
+++ b/docs/content/docs/configuration/rules/pipeline_mechanisms/authenticators.adoc
@@ -332,7 +332,7 @@ If set to `true`, allows the pipeline to fall back to the next authenticator in 
 
 * *`validate_jwk`*: _boolean_ (optional, not overridable)
 +
-Enables or disables the verification of the JWK certificate used for JWT signature verification purposes. Effective only if the JWK contains a certificate. The verification happens according to https://www.rfc-editor.org/rfc/rfc5280#section-6.1[RFC 5280, section 6.1] and also includes the check, that the certificate is allowed to be used for signature verification purposes. Revokation check is not supported. Defaults to `true`.
+Enables or disables the verification of the JWK certificate used for JWT signature verification purposes. Effective only if the JWK contains a certificate. The verification happens according to https://www.rfc-editor.org/rfc/rfc5280#section-6.1[RFC 5280, section 6.1] and also includes the check, that the certificate is allowed to be used for signature verification purposes. Revocation check is not supported. Defaults to `true`.
 
 * *`trust_store`*: _string_ (optional, not overridable)
 +

--- a/internal/signer/jwt_signer.go
+++ b/internal/signer/jwt_signer.go
@@ -92,6 +92,7 @@ func NewJWTSigner(conf *config.Configuration, logger zerolog.Logger) (heimdall.J
 	if len(kse.CertChain) != 0 {
 		if err = pkix.ValidateCertificate(kse.CertChain[0],
 			pkix.WithKeyUsage(x509.KeyUsageDigitalSignature),
+			pkix.WithRootCACertificates([]*x509.Certificate{kse.CertChain[len(kse.CertChain)-1]}),
 			pkix.WithCurrentTime(time.Now()),
 		); err != nil {
 			logger.Error().Err(err).Msg("Failed validating certificate")

--- a/internal/signer/jwt_signer.go
+++ b/internal/signer/jwt_signer.go
@@ -94,6 +94,8 @@ func NewJWTSigner(conf *config.Configuration, logger zerolog.Logger) (heimdall.J
 			pkix.WithKeyUsage(x509.KeyUsageDigitalSignature),
 			pkix.WithCurrentTime(time.Now()),
 		); err != nil {
+			logger.Error().Err(err).Msg("Failed validating certificate")
+
 			return nil, errorchain.NewWithMessage(heimdall.ErrConfiguration,
 				"configured certificate cannot be used for JWT signing purposes").CausedBy(err)
 		}


### PR DESCRIPTION
## Related issue(s)

Not really, but many complains and people wondering, why it is the case

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have added tests that prove the correctness of my implementation.


## Description

With that update, you can use self-signed certificates (highly discouraged for production), respectively the corresponding keys to e.g. sign the JWTs issued by heimdall without the need to make the self-signed certificate present in the system-wide trust store.

Before the change introduced with this PR, heimdall would log `x509: certificate signed by unknown authority` and refuse starting.
