### PR TITLE
feat: Release archive contains an SBOM in CycloneDX (json) format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -250,6 +250,10 @@ jobs:
         uses: sigstore/cosign-installer@v3.1.1
         with:
           cosign-release: "${{ env.COSIGN_VERSION }}"
+      - name: Install CycloneDX gomod
+        run: go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@v1.4.1
+      - name: Generate SBOM
+        run: cyclonedx-gomod app -licenses -assert-licenses -json -std -output CycloneDX-SBOM.json -main .
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 cover.out
 coverage.*
 
+# Ingnore generated SBOM
+CycloneDX-SBOM.json
+
 # Documentation
 
 # ignore asciidoctor generated files

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -39,6 +39,7 @@ archives:
     files:
       - LICENSE
       - CHANGELOG.md
+      - CycloneDX-SBOM.json
 
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Tag }}_checksums.txt"
@@ -53,4 +54,4 @@ signs:
       - "--output-certificate=${artifact}-keyless.pem"
       - "${artifact}"
       - "--yes"
-    artifacts: all
+    artifacts: checksum


### PR DESCRIPTION
## Related issue(s)

closes #833 

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.

## Description

Starting with the release built based on the CI changes introduced in this PR, every archive build during the release process and containing the heimdall binary, will also contain an SBOM in CycloneDX (json) format, which will allow organizations making use of heimdall to achieve their security and compliance goals easier then before.
