### PR TITLE
ci: fix for the SBOM generation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -247,6 +247,8 @@ jobs:
           fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v4
+        with:
+          go-version: "${{ env.GO_VERSION }}"
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.1.1
         with:
@@ -287,6 +289,10 @@ jobs:
         uses: sigstore/cosign-installer@v3.1.1
         with:
           cosign-release: "${{ env.COSIGN_VERSION }}"
+      - name: Set up Go # required as the sbom generator is compiled using go < 1.21
+        uses: actions/setup-go@v4
+        with:
+          go-version: "${{ env.GO_VERSION }}"
       - name: Generate SBOM
         if: github.ref == 'refs/heads/main'
         uses: CycloneDX/gh-gomod-generate-sbom@v2
@@ -366,6 +372,10 @@ jobs:
         uses: sigstore/cosign-installer@v3.1.1
         with:
           cosign-release: "${{ env.COSIGN_VERSION }}"
+      - name: Set up Go # required as the sbom generator is compiled using go < 1.21
+        uses: actions/setup-go@v4
+        with:
+          go-version: "${{ env.GO_VERSION }}"
       - name: Generate SBOM
         uses: CycloneDX/gh-gomod-generate-sbom@v2
         with:


### PR DESCRIPTION
As the CycloneDX/gh-gomod-generate-sbom, repectively cyclonedx-gomod, which is used to generate the SBOM is compiled using go version < 1.21 and heimdall makes use of the new std lib features, there is a need to have the proper go version  (1.21) installed locally. Otherwise `go list` will fail as some of the used packages are unknown.