### PR TITLE
refactor!: Endpoint specific `client_credentials` auth strategy renamed to `oauth2_client_credentials`

### DIFF
--- a/docs/content/docs/configuration/reference/reference.adoc
+++ b/docs/content/docs/configuration/reference/reference.adoc
@@ -273,7 +273,7 @@ rules:
           headers:
             bla: bla
           auth:
-            type: client_credentials
+            type: oauth2_client_credentials
             config:
               auth_method: request_body
               token_url: http://bar.foo

--- a/docs/content/docs/configuration/reference/types.adoc
+++ b/docs/content/docs/configuration/reference/types.adoc
@@ -343,7 +343,7 @@ config:
 
 This strategy implements the https://datatracker.ietf.org/doc/html/rfc6749#section-4.4[OAuth2 Client Credentials Grant Flow] to obtain an access token expected by the endpoint. Heimdall caches the received access token.
 
-`type` must be set to `client_credentials`. `config` supports the following properties:
+`type` must be set to `oauth2_client_credentials`. `config` supports the following properties:
 
 
 * *`token_url`*: _string_ (mandatory)
@@ -386,7 +386,7 @@ Defines the `name` and `scheme` to be used for the header. Defaults to `Authoriz
 
 [source, yaml]
 ----
-type: client_credentials
+type: oauth2_client_credentials
 config:
   header:
     name: X-My-Token

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -316,7 +316,7 @@ rules:
           endpoint:
             url: http://foo.bar
             auth:
-              type: client_credentials
+              type: oauth2_client_credentials
               config:
                 auth_method: request_body
                 token_url: http://foo.bar

--- a/internal/rules/endpoint/authstrategy/client_credentials_strategy.go
+++ b/internal/rules/endpoint/authstrategy/client_credentials_strategy.go
@@ -38,7 +38,7 @@ type ClientCredentialsStrategy struct {
 
 func (c *ClientCredentialsStrategy) Apply(ctx context.Context, req *http.Request) error {
 	logger := zerolog.Ctx(ctx)
-	logger.Debug().Msg("Applying client-credentials strategy to authenticate request")
+	logger.Debug().Msg("Applying oauth2_client_credentials strategy to authenticate request")
 
 	token, err := c.Token(ctx)
 	if err != nil {

--- a/internal/rules/endpoint/authstrategy/mapstructure_decoder.go
+++ b/internal/rules/endpoint/authstrategy/mapstructure_decoder.go
@@ -59,8 +59,8 @@ func DecodeAuthenticationStrategyHookFunc() mapstructure.DecodeHookFunc {
 			return decodeStrategy("basic_auth", &BasicAuthStrategy{}, typed["config"])
 		case "api_key":
 			return decodeStrategy("api_key", &APIKeyStrategy{}, typed["config"])
-		case "client_credentials":
-			return decodeStrategy("client_credentials", &ClientCredentialsStrategy{}, typed["config"])
+		case "oauth2_client_credentials":
+			return decodeStrategy("oauth2_client_credentials", &ClientCredentialsStrategy{}, typed["config"])
 		default:
 			return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
 				"unsupported authentication type: '%s'", typed["type"])

--- a/internal/rules/endpoint/authstrategy/mapstructure_decoder_test.go
+++ b/internal/rules/endpoint/authstrategy/mapstructure_decoder_test.go
@@ -322,7 +322,7 @@ func TestDecodeAuthenticationStrategyHookFuncForClientCredentialsStrategy(t *tes
 			uc: "client credentials with all required properties",
 			config: []byte(`
 auth:
-  type: client_credentials
+  type: oauth2_client_credentials
   config:
     client_id: foo
     client_secret: bar
@@ -343,7 +343,7 @@ auth:
 			uc: "client credentials with all possible properties",
 			config: []byte(`
 auth:
-  type: client_credentials
+  type: oauth2_client_credentials
   config:
     client_id: foo
     client_secret: bar
@@ -368,7 +368,7 @@ auth:
 			uc: "client credentials without client_id property",
 			config: []byte(`
 auth:
-  type: client_credentials
+  type: oauth2_client_credentials
   config:
     client_secret: bar
     token_url: http://foobar.foo
@@ -384,7 +384,7 @@ auth:
 			uc: "client credentials without client_secret property",
 			config: []byte(`
 auth:
-  type: client_credentials
+  type: oauth2_client_credentials
   config:
     client_id: foo
     token_url: http://foobar.foo
@@ -400,7 +400,7 @@ auth:
 			uc: "client credentials without token_url property",
 			config: []byte(`
 auth:
-  type: client_credentials
+  type: oauth2_client_credentials
   config:
     client_id: foo
     client_secret: bar
@@ -416,7 +416,7 @@ auth:
 			uc: "client credentials without config property",
 			config: []byte(`
 auth:
-  type: client_credentials
+  type: oauth2_client_credentials
 `),
 			assert: func(t *testing.T, err error, as endpoint.AuthenticationStrategy) {
 				t.Helper()

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -515,7 +515,7 @@
               "$ref": "#/definitions/endpointAuthBasicAuthProperties"
             },
             {
-              "$ref": "#/definitions/endpointAuthClientCredentialsProperties"
+              "$ref": "#/definitions/endpointAuth2ClientCredentialsProperties"
             }
           ]
         },
@@ -600,7 +600,7 @@
                   "$ref": "#/definitions/endpointAuthBasicAuthProperties"
                 },
                 {
-                  "$ref": "#/definitions/endpointAuthClientCredentialsProperties"
+                  "$ref": "#/definitions/endpointAuth2ClientCredentialsProperties"
                 }
               ]
             },
@@ -691,7 +691,7 @@
         "config"
       ]
     },
-    "endpointAuthClientCredentialsProperties": {
+    "endpointAuth2ClientCredentialsProperties": {
       "additionalProperties": false,
       "required": [
         "type",
@@ -699,7 +699,7 @@
       ],
       "properties": {
         "type": {
-          "const": "client_credentials"
+          "const": "oauth2_client_credentials"
         },
         "config": {
           "$ref": "#/definitions/oauth2ClientCredentialsFlowConfig"


### PR DESCRIPTION
## Related issue(s)

none

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

This PR unifies the names for the OAuth Client Credentials Grant flow implementation used for finalizers and endpoint auth strategy. Latter has been renamed from `client_credentials` to `oauth2_client_credentials` (which is also used for a finalizer).

The following examples highlights the changes

```yaml
endpoint:
  url: http://foo.bar
  method: GET
  headers:
    bla: bla
  auth:
    type: oauth2_client_credentials # was client_credentials before
    config:
      auth_method: request_body
      token_url: http://bar.foo
      client_id: foo
      client_secret: bar
      cache_ttl: 20s
      header:
        name: X-Foo
        scheme: Bar
```
