### PR TITLE
fix: HTTP method expansion in k8s RuleSet resources

### DIFF
--- a/charts/heimdall/crds/ruleset.yaml
+++ b/charts/heimdall/crds/ruleset.yaml
@@ -124,15 +124,25 @@ spec:
                           type: string
                           maxLength: 16
                           enum:
-                            - CONNECT
-                            - DELETE
-                            - GET
-                            - HEAD
-                            - OPTIONS
-                            - PATCH
-                            - POST
-                            - PUT
-                            - TRACE
+                            - "CONNECT"
+                            - "!CONNECT"
+                            - "DELETE"
+                            - "!DELETE"
+                            - "GET"
+                            - "!GET"
+                            - "HEAD"
+                            - "!HEAD"
+                            - "OPTIONS"
+                            - "!OPTIONS"
+                            - "PATCH"
+                            - "!PATCH"
+                            - "POST"
+                            - "!POST"
+                            - "PUT"
+                            - "!PUT"
+                            - "TRACE"
+                            - "!TRACE"
+                            - "ALL"
                       execute:
                         description: The pipeline mechanisms to execute
                         type: array


### PR DESCRIPTION
## Related issue(s)

closes #991

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.

## Description

Makes usage of HTTP method expansion possible, as this is also the case in regular rulesets
