### PR TITLE
chore: Access to Request object disabled for the JWT finalizer

### DIFF
--- a/internal/rules/mechanisms/finalizers/jwt_finalizer.go
+++ b/internal/rules/mechanisms/finalizers/jwt_finalizer.go
@@ -181,7 +181,6 @@ func (u *jwtFinalizer) generateToken(ctx heimdall.Context, sub *subject.Subject)
 	claims := map[string]any{}
 	if u.claims != nil {
 		vals, err := u.claims.Render(map[string]any{
-			"Request": ctx.Request(),
 			"Subject": sub,
 		})
 		if err != nil {

--- a/internal/rules/mechanisms/finalizers/jwt_finalizer_test.go
+++ b/internal/rules/mechanisms/finalizers/jwt_finalizer_test.go
@@ -541,7 +541,6 @@ claims: '{
 
 				ctx.EXPECT().Signer().Return(signer)
 				ctx.EXPECT().AddHeaderForUpstream("X-Token", "Bar barfoo")
-				ctx.EXPECT().Request().Return(&heimdall.Request{})
 
 				cch.EXPECT().Get(mock.Anything).Return(nil)
 				cch.EXPECT().Set(mock.Anything, "barfoo", defaultJWTTTL-defaultCacheLeeway)
@@ -565,7 +564,6 @@ claims: '{
 				signer.EXPECT().Hash().Return([]byte("foobar"))
 
 				ctx.EXPECT().Signer().Return(signer)
-				ctx.EXPECT().Request().Return(&heimdall.Request{})
 
 				cch.EXPECT().Get(mock.Anything).Return(nil)
 			},
@@ -594,7 +592,6 @@ claims: '{
 				signer.EXPECT().Hash().Return([]byte("foobar"))
 
 				ctx.EXPECT().Signer().Return(signer)
-				ctx.EXPECT().Request().Return(&heimdall.Request{})
 
 				cch.EXPECT().Get(mock.Anything).Return(nil)
 			},


### PR DESCRIPTION
... it has been added by accident but never documented. The Request object should also not be used from a JWT finalizer.