### PR TITLE
feat: Container images are published to GHCR in addition to DockerHub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -272,6 +272,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
+      packages: write
       id-token: write
     needs:
       - test
@@ -321,12 +322,19 @@ jobs:
           push: false
           build-args: VERSION=${{ github.sha }}
           tags: ${{ github.repository }}:local
-      - name: Login to container registry
+      - name: Login to DockerHub
         if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub
+        if: github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push dev images to container registry
         if: github.ref == 'refs/heads/main'
         id: publish-image
@@ -338,17 +346,37 @@ jobs:
           push: true
           build-args: VERSION=${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
-          tags: ${{ github.repository }}:dev-${{ github.sha }},${{ github.repository }}:dev
-      - name: Sign the published Docker image
+          tags: |
+            ${{ github.repository }}:dev
+            ${{ github.repository }}:dev-${{ github.sha }}
+            ghcr.io/${{ github.repository }}:dev
+            ghcr.io/${{ github.repository }}:dev-${{ github.sha }}
+      # DockerHub
+      - name: Sign the image published in DockerHub
         if: steps.publish-image.conclusion == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_REPOSITORY: ${{ github.repository }}-signatures
         run: cosign sign --yes ${{ github.repository }}@${{ steps.publish-image.outputs.digest }}
-      - name: Attest and attach SBOM
+      - name: Attest and attach SBOM to the image published in DockerHub
         if: steps.publish-image.conclusion == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_REPOSITORY: ${{ github.repository }}-sbom
         run: cosign attest --yes --predicate CycloneDX-SBOM.json --type cyclonedx ${{ github.repository }}@${{ steps.publish-image.outputs.digest }}
+      # GHCR
+      - name: Sign the image published in GitHub
+        if: steps.publish-image.conclusion == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_REPOSITORY: ghcr.io/${{ github.repository }}-signatures
+        run: cosign sign --yes ghcr.io/${{ github.repository }}@${{ steps.publish-image.outputs.digest }}
+      - name: Attest and attach SBOM to the image published in GitHub
+        if: steps.publish-image.conclusion == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_REPOSITORY: ghcr.io/${{ github.repository }}-sbom
+        run: cosign attest --yes --predicate CycloneDX-SBOM.json --type cyclonedx ghcr.io/${{ github.repository }}@${{ steps.publish-image.outputs.digest }}
 
 
   # this job releases container images
@@ -357,6 +385,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
+      packages: write
       id-token: write
     needs:
       - prepare-release
@@ -390,6 +419,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Collect Docker meta-info
         id: meta
         uses: docker/metadata-action@v5
@@ -408,16 +443,23 @@ jobs:
           push: true
           build-args: VERSION=${{ needs.prepare-release.outputs.tag_name }}
           labels: ${{ steps.meta.outputs.labels }}
-          tags: ${{ github.repository }}:${{ steps.image-version.outputs.result }},${{ github.repository }}:latest
-      - name: Sign the published container image
+          tags: |
+            ${{ github.repository }}:latest
+            ${{ github.repository }}:${{ steps.image-version.outputs.result }}
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ steps.image-version.outputs.result }}
+      # DockerHub
+      - name: Sign the image published in DockerHub
         if: steps.publish-image.conclusion == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_REPOSITORY: ${{ github.repository }}-signatures
         run: cosign sign --yes ${{ github.repository }}@${{ steps.publish-image.outputs.digest }}
-      - name: Attest and attach SBOM
+      - name: Attest and attach SBOM to the image published in DockerHub
         if: steps.publish-image.conclusion == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_REPOSITORY: ${{ github.repository }}-sbom
         run: cosign attest --yes --predicate CycloneDX-SBOM.json --type cyclonedx ${{ github.repository }}@${{ steps.publish-image.outputs.digest }}
       - name: Update DockerHub repository description & readme
         uses: peter-evans/dockerhub-description@v3
@@ -427,6 +469,19 @@ jobs:
           repository: ${{ github.repository }}
           short-description: ${{ github.event.repository.description }}
           readme-filepath: ./DockerHub-README.md
+      # GHCR
+      - name: Sign the image published in GitHub
+        if: steps.publish-image.conclusion == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_REPOSITORY: ghcr.io/${{ github.repository }}-signatures
+        run: cosign sign --yes ghcr.io/${{ github.repository }}@${{ steps.publish-image.outputs.digest }}
+      - name: Attest and attach SBOM to the image published in GitHub
+        if: steps.publish-image.conclusion == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COSIGN_REPOSITORY: ghcr.io/${{ github.repository }}-sbom
+        run: cosign attest --yes --predicate CycloneDX-SBOM.json --type cyclonedx ghcr.io/${{ github.repository }}@${{ steps.publish-image.outputs.digest }}
 
   release-helm-chart:
     runs-on: ubuntu-22.04

--- a/docs/content/docs/configuration/rules/providers.adoc
+++ b/docs/content/docs/configuration/rules/providers.adoc
@@ -15,7 +15,7 @@ Supported providers, including the corresponding configuration options are descr
 
 == Filesystem
 
-The filesystem provider allows loading of rule sets in a format defined in link:{{< relref "configuration.adoc#_rule_set" >}}[Rule Sets] from a file system. The configuration of this provider goes into the `file_system` property. This provider is handy for e.g. starting playing around with heimdall, e.g. locally, or using Docker, as well as if your deployment strategy considers deploying a heimdall instance as a Side-Car for each of your services.
+The filesystem provider allows loading of rule sets in a format defined in link:{{< relref "configuration.adoc#_rule_set" >}}[Rule Sets] from a file system. The configuration of this provider goes into the `file_system` property. This provider is handy for e.g. starting playing around with heimdall, e.g. locally, or using a container runtime, as well as if your deployment strategy considers deploying a heimdall instance as a Side-Car for each of your services.
 
 Following configuration options are supported:
 

--- a/docs/content/docs/getting_started/decision_service_quickstart.adoc
+++ b/docs/content/docs/getting_started/decision_service_quickstart.adoc
@@ -17,7 +17,7 @@ This document describes a very simple use case in which you'll see heimdall's De
 == Prerequisites
 
 * link:{{< relref "/docs/operations/install.adoc" >}}[Download Heimdall] in your flavor.
-* https://docs.docker.com/install/[Docker] (optionally) and
+* https://docs.docker.com/install/[Docker], https://podman.io/[Podman], or other container runtime of your choice (examples are however using docker) (optionally) and
 * https://docs.docker.com/compose/install/[docker-compose] (optionally)
 
 == Configure
@@ -101,7 +101,7 @@ $ ./heimdall serve decision -c config.yaml
 
 The above command will start heimdall in a link:{{< relref "concepts.adoc#_decision_api_mode" >}}[decision] operation mode. By default, the service will be served on port `4456`.
 
-Otherwise, if you've built a Docker image, run heimdall in the link:{{< relref "concepts.adoc#_decision_api_mode" >}}[decision] operation mode via
+Otherwise, if you've built a container image, run heimdall in the link:{{< relref "concepts.adoc#_decision_api_mode" >}}[decision] operation mode via
 
 [source, bash]
 ----

--- a/docs/content/docs/operations/install.adoc
+++ b/docs/content/docs/operations/install.adoc
@@ -72,9 +72,9 @@ curl -L https://github.com/dadrus/heimdall/releases/download/${VERSION}/heimdall
     | tar -z -x
 ----
 
-== Docker Image
+== Container Image
 
-Heimdall utilizes a minimal container multi-arch image which you can find on https://hub.docker.com/r/dadrus/heimdall[DockerHub]. As with link:{{< relref "#_binary" >}}[Binary] releases, heimdall can be pulled in several flavors. These are however currently limited to the Linux OS. Supported architectures are:
+Heimdall utilizes a minimal container multi-arch image which you can find on https://hub.docker.com/r/dadrus/heimdall[DockerHub], or on https://github.com/users/dadrus/packages?repo_name=heimdall[GHCR]. As with link:{{< relref "#_binary" >}}[Binary] releases, heimdall can be pulled in several flavors. These are however currently limited to the Linux OS. Supported architectures are:
 
 * `amd64`
 * `arm64`
@@ -86,9 +86,11 @@ As with the binary distribution, all container images are signed (see also link:
 
 === Prerequisites
 
-* https://docs.docker.com/install/[Docker]
+* https://docs.docker.com/install/[Docker], https://podman.io/[Podman], or other container runtime of your choice (examples are however using docker).
 
 === Pull Image
+
+The steps below will pull the images from https://hub.docker.com/r/dadrus/heimdall[DockerHub]. If you want to pull them from https://github.com/users/dadrus/packages?repo_name=heimdall[GHCR], specify the `ghcr.io` registry in front of the repository.
 
 Following tag patterns exist:
 

--- a/docs/content/docs/operations/install.adoc
+++ b/docs/content/docs/operations/install.adoc
@@ -16,7 +16,7 @@ Heimdall is shipped in multiple formats and architectures to suit a variety of d
 
 * link:{{< relref "#_source_code" >}}[Source code]
 * link:{{< relref "#_binary" >}}[Binary]
-* link:{{< relref "#_docker_image" >}}[Docker Image]
+* link:{{< relref "#_container_image" >}}[Container Image]
 * link:{{< relref "#_helm_chart" >}}[Helm Chart]
 
 == Source Code

--- a/docs/content/docs/operations/security.adoc
+++ b/docs/content/docs/operations/security.adoc
@@ -84,14 +84,17 @@ Heimdall binaries and container images are signed using https://docs.sigstore.de
 
 === Container Image Signature Verification
 
-The signatures are stored in the same repository as the container images they reference. To verify the container image using Cosign, execute the following command:
+The signatures are stored in a repository named `dadrus/heimdall-signatures`. To verify the container image using Cosign, execute the following command:
 
 [source, bash]
 ----
+COSIGN_REPOSITORY=dadrus/heimdall-signatures \
 cosign verify dadrus/heimdall:<tag> \
   --certificate-identity-regexp=https://github.com/dadrus/heimdall/.github/workflows/ci.yaml* \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com | jq
 ----
+
+NOTE: If you pull heimdall images from ghcr.io, reference the `ghcr.io` registry while specifying the repository names. So `dadrus/heimdall-signatures` becomes `ghcr.io/dadrus/heimdall-signatures` and `dadrus/heimdall:<tag>` becomes `ghcr.io/dadrus/heimdall:<tag>`.
 
 In successful verification case, cosign will print similar output to the one shown below and exit with `0`.
 
@@ -166,15 +169,18 @@ Heimdall is shipped with an SBOM in https://cyclonedx.org/[CyclonDX] (json) form
 
 If you use a released binary of heimdall, the corresponding file is part of the platform specific archive. That way, if you verify the signature of the archive (see above), you do also get evidence about the validity of the SBOM.
 
-If you use a container image, the same SBOM is attached to the image as attestation signed with Cosign. These attestations are stored in the same repository as the container images. To verify the attestation and retrieve the SBOM execute the following command once Cosign is installed:
+If you use a container image, the same SBOM is attached to the image as attestation signed with Cosign. These attestations are stored in the `dadrus/heimdall-sbom` repository. To verify the attestation and retrieve the SBOM execute the following command once Cosign is installed:
 
 [source, bash]
 ----
+COSIGN_REPOSITORY=dadrus/heimdall-sbom \
 cosign verify-attestation dadrus/heimdall:<tag> \
   --certificate-identity-regexp=https://github.com/dadrus/heimdall/.github/workflows/ci.yaml* \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
   --type=cyclonedx
 ----
+
+NOTE: If you pull heimdall images from ghcr.io, reference the `ghcr.io` registry while specifying the repository names. So `dadrus/heimdall-sbom` becomes `ghcr.io/dadrus/heimdall-sbom` and `dadrus/heimdall:<tag>` becomes `ghcr.io/dadrus/heimdall:<tag>`.
 
 In successful verification case, cosign will print similar output to the one shown below and exit with `0`.
 
@@ -198,6 +204,7 @@ As one-liner, you can verify the signature and extract the SBOM as follows:
 
 [source, bash]
 ----
+COSIGN_REPOSITORY=dadrus/heimdall-sbom \
 cosign verify-attestation dadrus/heimdall:<tag> \
   --certificate-identity-regexp=https://github.com/dadrus/heimdall/.github/workflows/ci.yaml* \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com \

--- a/docs/content/docs/operations/security.adoc
+++ b/docs/content/docs/operations/security.adoc
@@ -48,7 +48,7 @@ As written above, heimdall makes use of the OS wide trust store to build the cer
 
 [NOTE]
 ====
-heimdall Docker image is shipped without any certificates by intention to ensure you take care about the up-to-date status of the trust store. This way, if you use heimdall in a container, you have to mount the OS trust store into heimdall's container to enable its usage.
+heimdall container image is shipped without any certificates by intention to ensure you take care about the up-to-date status of the trust store. This way, if you use heimdall in a container, you have to mount the OS trust store into heimdall's container to enable its usage.
 
 E.g.
 [source, bash]


### PR DESCRIPTION
## Related issue(s)

none

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have updated the documentation.

## Description

This PR updates the CI pipeline to publish the built container images to GHCR in addition to DockerHub.

In addition, this PR publishes the created container signatures and SBOM attestations to separate repositores/packages to avoid scattering of version/tag information in the "main" repository.

