### PR TITLE
refactor: Cache interface expects a `Context` object as first argument

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -17,6 +17,7 @@
 package cache
 
 import (
+	"context"
 	"time"
 )
 
@@ -25,7 +26,7 @@ import (
 type Cache interface {
 	Evictor
 
-	Get(key string) any
-	Set(key string, value any, ttl time.Duration)
-	Delete(key string)
+	Get(ctx context.Context, key string) any
+	Set(ctx context.Context, key string, value any, ttl time.Duration)
+	Delete(ctx context.Context, key string)
 }

--- a/internal/cache/memory/cache.go
+++ b/internal/cache/memory/cache.go
@@ -43,7 +43,7 @@ func (c *InMemoryCache) Stop(_ context.Context) error {
 	return nil
 }
 
-func (c *InMemoryCache) Get(key string) any {
+func (c *InMemoryCache) Get(_ context.Context, key string) any {
 	item := c.c.Get(key)
 	if item != nil && !item.IsExpired() {
 		return item.Value()
@@ -52,6 +52,8 @@ func (c *InMemoryCache) Get(key string) any {
 	return nil
 }
 
-func (c *InMemoryCache) Set(key string, value any, ttl time.Duration) { c.c.Set(key, value, ttl) }
+func (c *InMemoryCache) Set(_ context.Context, key string, value any, ttl time.Duration) {
+	c.c.Set(key, value, ttl)
+}
 
-func (c *InMemoryCache) Delete(key string) { c.c.Delete(key) }
+func (c *InMemoryCache) Delete(_ context.Context, key string) { c.c.Delete(key) }

--- a/internal/cache/memory/cache_test.go
+++ b/internal/cache/memory/cache_test.go
@@ -17,6 +17,7 @@
 package memory
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -38,7 +39,7 @@ func TestCacheUsage(t *testing.T) {
 			configureCache: func(t *testing.T, cache *InMemoryCache) {
 				t.Helper()
 
-				cache.Set("foo", "bar", 10*time.Minute)
+				cache.Set(context.TODO(), "foo", "bar", 10*time.Minute)
 			},
 			assert: func(t *testing.T, data any) {
 				t.Helper()
@@ -52,7 +53,7 @@ func TestCacheUsage(t *testing.T) {
 			configureCache: func(t *testing.T, cache *InMemoryCache) {
 				t.Helper()
 
-				cache.Set("bar", "baz", 1*time.Microsecond)
+				cache.Set(context.TODO(), "bar", "baz", 1*time.Microsecond)
 
 				time.Sleep(200 * time.Millisecond)
 			},
@@ -68,8 +69,8 @@ func TestCacheUsage(t *testing.T) {
 			configureCache: func(t *testing.T, cache *InMemoryCache) {
 				t.Helper()
 
-				cache.Set("baz", "bar", 1*time.Second)
-				cache.Delete("baz")
+				cache.Set(context.TODO(), "baz", "bar", 1*time.Second)
+				cache.Delete(context.TODO(), "baz")
 			},
 			assert: func(t *testing.T, data any) {
 				t.Helper()
@@ -97,7 +98,7 @@ func TestCacheUsage(t *testing.T) {
 			// WHEN
 			tc.configureCache(t, cache)
 
-			data := cache.Get(tc.key)
+			data := cache.Get(context.TODO(), tc.key)
 
 			// THEN
 			tc.assert(t, data)
@@ -109,14 +110,14 @@ func TestCacheExpiration(t *testing.T) {
 	t.Parallel()
 
 	cache := New()
-	cache.Set("baz", "bar", 1*time.Second)
+	cache.Set(context.TODO(), "baz", "bar", 1*time.Second)
 
 	hits := 0
 
 	for i := 0; i < 8; i++ {
 		time.Sleep(250 * time.Millisecond)
 
-		item := cache.Get("baz")
+		item := cache.Get(context.TODO(), "baz")
 		if item != nil {
 			hits++
 		}

--- a/internal/cache/mocks/cache.go
+++ b/internal/cache/mocks/cache.go
@@ -22,9 +22,9 @@ func (_m *CacheMock) EXPECT() *CacheMock_Expecter {
 	return &CacheMock_Expecter{mock: &_m.Mock}
 }
 
-// Delete provides a mock function with given fields: key
-func (_m *CacheMock) Delete(key string) {
-	_m.Called(key)
+// Delete provides a mock function with given fields: ctx, key
+func (_m *CacheMock) Delete(ctx context.Context, key string) {
+	_m.Called(ctx, key)
 }
 
 // CacheMock_Delete_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Delete'
@@ -33,14 +33,15 @@ type CacheMock_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
+//   - ctx context.Context
 //   - key string
-func (_e *CacheMock_Expecter) Delete(key interface{}) *CacheMock_Delete_Call {
-	return &CacheMock_Delete_Call{Call: _e.mock.On("Delete", key)}
+func (_e *CacheMock_Expecter) Delete(ctx interface{}, key interface{}) *CacheMock_Delete_Call {
+	return &CacheMock_Delete_Call{Call: _e.mock.On("Delete", ctx, key)}
 }
 
-func (_c *CacheMock_Delete_Call) Run(run func(key string)) *CacheMock_Delete_Call {
+func (_c *CacheMock_Delete_Call) Run(run func(ctx context.Context, key string)) *CacheMock_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -50,18 +51,18 @@ func (_c *CacheMock_Delete_Call) Return() *CacheMock_Delete_Call {
 	return _c
 }
 
-func (_c *CacheMock_Delete_Call) RunAndReturn(run func(string)) *CacheMock_Delete_Call {
+func (_c *CacheMock_Delete_Call) RunAndReturn(run func(context.Context, string)) *CacheMock_Delete_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// Get provides a mock function with given fields: key
-func (_m *CacheMock) Get(key string) interface{} {
-	ret := _m.Called(key)
+// Get provides a mock function with given fields: ctx, key
+func (_m *CacheMock) Get(ctx context.Context, key string) interface{} {
+	ret := _m.Called(ctx, key)
 
 	var r0 interface{}
-	if rf, ok := ret.Get(0).(func(string) interface{}); ok {
-		r0 = rf(key)
+	if rf, ok := ret.Get(0).(func(context.Context, string) interface{}); ok {
+		r0 = rf(ctx, key)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(interface{})
@@ -77,14 +78,15 @@ type CacheMock_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
+//   - ctx context.Context
 //   - key string
-func (_e *CacheMock_Expecter) Get(key interface{}) *CacheMock_Get_Call {
-	return &CacheMock_Get_Call{Call: _e.mock.On("Get", key)}
+func (_e *CacheMock_Expecter) Get(ctx interface{}, key interface{}) *CacheMock_Get_Call {
+	return &CacheMock_Get_Call{Call: _e.mock.On("Get", ctx, key)}
 }
 
-func (_c *CacheMock_Get_Call) Run(run func(key string)) *CacheMock_Get_Call {
+func (_c *CacheMock_Get_Call) Run(run func(ctx context.Context, key string)) *CacheMock_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -94,14 +96,14 @@ func (_c *CacheMock_Get_Call) Return(_a0 interface{}) *CacheMock_Get_Call {
 	return _c
 }
 
-func (_c *CacheMock_Get_Call) RunAndReturn(run func(string) interface{}) *CacheMock_Get_Call {
+func (_c *CacheMock_Get_Call) RunAndReturn(run func(context.Context, string) interface{}) *CacheMock_Get_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// Set provides a mock function with given fields: key, value, ttl
-func (_m *CacheMock) Set(key string, value interface{}, ttl time.Duration) {
-	_m.Called(key, value, ttl)
+// Set provides a mock function with given fields: ctx, key, value, ttl
+func (_m *CacheMock) Set(ctx context.Context, key string, value interface{}, ttl time.Duration) {
+	_m.Called(ctx, key, value, ttl)
 }
 
 // CacheMock_Set_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Set'
@@ -110,16 +112,17 @@ type CacheMock_Set_Call struct {
 }
 
 // Set is a helper method to define mock.On call
+//   - ctx context.Context
 //   - key string
 //   - value interface{}
 //   - ttl time.Duration
-func (_e *CacheMock_Expecter) Set(key interface{}, value interface{}, ttl interface{}) *CacheMock_Set_Call {
-	return &CacheMock_Set_Call{Call: _e.mock.On("Set", key, value, ttl)}
+func (_e *CacheMock_Expecter) Set(ctx interface{}, key interface{}, value interface{}, ttl interface{}) *CacheMock_Set_Call {
+	return &CacheMock_Set_Call{Call: _e.mock.On("Set", ctx, key, value, ttl)}
 }
 
-func (_c *CacheMock_Set_Call) Run(run func(key string, value interface{}, ttl time.Duration)) *CacheMock_Set_Call {
+func (_c *CacheMock_Set_Call) Run(run func(ctx context.Context, key string, value interface{}, ttl time.Duration)) *CacheMock_Set_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(interface{}), args[2].(time.Duration))
+		run(args[0].(context.Context), args[1].(string), args[2].(interface{}), args[3].(time.Duration))
 	})
 	return _c
 }
@@ -129,7 +132,7 @@ func (_c *CacheMock_Set_Call) Return() *CacheMock_Set_Call {
 	return _c
 }
 
-func (_c *CacheMock_Set_Call) RunAndReturn(run func(string, interface{}, time.Duration)) *CacheMock_Set_Call {
+func (_c *CacheMock_Set_Call) RunAndReturn(run func(context.Context, string, interface{}, time.Duration)) *CacheMock_Set_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/cache/noop_cache.go
+++ b/internal/cache/noop_cache.go
@@ -23,12 +23,8 @@ import (
 
 type noopCache struct{}
 
-func (noopCache) Get(_ string) any { return nil }
-
-func (noopCache) Set(_ string, _ any, _ time.Duration) {}
-
-func (noopCache) Delete(_ string) {}
-
-func (noopCache) Start(_ context.Context) error { return nil }
-
-func (noopCache) Stop(_ context.Context) error { return nil }
+func (noopCache) Get(_ context.Context, _ string) any                     { return nil }
+func (noopCache) Set(_ context.Context, _ string, _ any, _ time.Duration) {}
+func (noopCache) Delete(_ context.Context, _ string)                      {}
+func (noopCache) Start(_ context.Context) error                           { return nil }
+func (noopCache) Stop(_ context.Context) error                            { return nil }

--- a/internal/httpcache/round_tripper.go
+++ b/internal/httpcache/round_tripper.go
@@ -59,9 +59,10 @@ func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func (rt *RoundTripper) cachedResponse(req *http.Request) (*http.Response, error) {
-	cch := cache.Ctx(req.Context())
+	ctx := req.Context()
+	cch := cache.Ctx(ctx)
 
-	cachedValue := cch.Get(cacheKey(req))
+	cachedValue := cch.Get(ctx, cacheKey(req))
 	if cachedValue == nil {
 		return nil, ErrNoCacheEntry
 	}
@@ -87,8 +88,9 @@ func (rt *RoundTripper) cacheResponse(req *http.Request, resp *http.Response) {
 		return
 	}
 
-	cch := cache.Ctx(req.Context())
-	cch.Set(cacheKey(req), respDump, time.Until(expires))
+	ctx := req.Context()
+	cch := cache.Ctx(ctx)
+	cch.Set(ctx, cacheKey(req), respDump, time.Until(expires))
 }
 
 func cacheKey(req *http.Request) string {

--- a/internal/rules/endpoint/authstrategy/client_credentials_test.go
+++ b/internal/rules/endpoint/authstrategy/client_credentials_test.go
@@ -106,7 +106,7 @@ func TestApplyClientCredentialsStrategy(t *testing.T) {
 			configureMocks: func(t *testing.T, cch *mocks.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(&clientcredentials.TokenInfo{
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(&clientcredentials.TokenInfo{
 					AccessToken: "foobar", TokenType: "Bearer",
 				})
 			},
@@ -128,7 +128,7 @@ func TestApplyClientCredentialsStrategy(t *testing.T) {
 			configureMocks: func(t *testing.T, cch *mocks.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
 			},
 			assertRequest: func(t *testing.T, req *http.Request) { t.Helper() },
 			buildResponse: func(t *testing.T) (any, int) {
@@ -163,8 +163,8 @@ func TestApplyClientCredentialsStrategy(t *testing.T) {
 			configureMocks: func(t *testing.T, cch *mocks.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
-				cch.EXPECT().Set(mock.Anything, mock.Anything, 3*time.Minute).Return()
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
+				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything, 3*time.Minute).Return()
 			},
 			assertRequest: func(t *testing.T, req *http.Request) {
 				t.Helper()

--- a/internal/rules/mechanisms/authenticators/generic_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/generic_authenticator.go
@@ -186,13 +186,13 @@ func (a *genericAuthenticator) getSubjectInformation(ctx heimdall.Context, authD
 
 	if a.ttl > 0 {
 		cacheKey = a.calculateCacheKey(authData)
-		cacheEntry = cch.Get(cacheKey)
+		cacheEntry = cch.Get(ctx.AppContext(), cacheKey)
 	}
 
 	if cacheEntry != nil {
 		if cachedResponse, ok = cacheEntry.([]byte); !ok {
 			logger.Warn().Msg("Wrong object type from cache")
-			cch.Delete(cacheKey)
+			cch.Delete(ctx.AppContext(), cacheKey)
 		} else {
 			logger.Debug().Msg("Reusing subject information from cache")
 
@@ -219,7 +219,7 @@ func (a *genericAuthenticator) getSubjectInformation(ctx heimdall.Context, authD
 	}
 
 	if cacheTTL := a.getCacheTTL(session); cacheTTL > 0 {
-		cch.Set(cacheKey, payload, cacheTTL)
+		cch.Set(ctx.AppContext(), cacheKey, payload, cacheTTL)
 	}
 
 	return payload, nil

--- a/internal/rules/mechanisms/authenticators/generic_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/generic_authenticator_test.go
@@ -1077,9 +1077,9 @@ func TestGenericAuthenticatorExecute(t *testing.T) {
 				t.Helper()
 
 				ads.EXPECT().GetAuthData(ctx).Return("session_token", nil)
-				cch.EXPECT().Get(mock.Anything).Return(time.Duration(10))
-				cch.EXPECT().Delete(mock.Anything)
-				cch.EXPECT().Set(mock.Anything, []byte(`{ "user_id": "barbar" }`), auth.ttl)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(time.Duration(10))
+				cch.EXPECT().Delete(mock.Anything, mock.Anything)
+				cch.EXPECT().Set(mock.Anything, mock.Anything, []byte(`{ "user_id": "barbar" }`), auth.ttl)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -1131,7 +1131,7 @@ func TestGenericAuthenticatorExecute(t *testing.T) {
 				t.Helper()
 
 				ads.EXPECT().GetAuthData(ctx).Return("session_token", nil)
-				cch.EXPECT().Get(mock.Anything).Return([]byte(`{ "user_id": "barbar" }`))
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return([]byte(`{ "user_id": "barbar" }`))
 			},
 			assert: func(t *testing.T, err error, sub *subject.Subject) {
 				t.Helper()
@@ -1173,8 +1173,8 @@ func TestGenericAuthenticatorExecute(t *testing.T) {
 				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: reqFuns})
 
 				ads.EXPECT().GetAuthData(ctx).Return("session_token", nil)
-				cch.EXPECT().Get(mock.Anything).Return(nil)
-				cch.EXPECT().Set(mock.Anything, []byte(`{ "user_id": "barbar" }`), auth.ttl)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
+				cch.EXPECT().Set(mock.Anything, mock.Anything, []byte(`{ "user_id": "barbar" }`), auth.ttl)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -1233,7 +1233,7 @@ func TestGenericAuthenticatorExecute(t *testing.T) {
 				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: reqFuns})
 
 				ads.EXPECT().GetAuthData(ctx).Return("session_token", nil)
-				cch.EXPECT().Get(mock.Anything).Return(nil)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -1291,7 +1291,7 @@ func TestGenericAuthenticatorExecute(t *testing.T) {
 				t.Helper()
 
 				ads.EXPECT().GetAuthData(ctx).Return("session_token", nil)
-				cch.EXPECT().Get(mock.Anything).Return(nil)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -1353,8 +1353,8 @@ func TestGenericAuthenticatorExecute(t *testing.T) {
 				exp := strconv.FormatInt(time.Now().Add(15*time.Second).Unix(), 10)
 
 				ads.EXPECT().GetAuthData(ctx).Return("session_token", nil)
-				cch.EXPECT().Get(mock.Anything).Return(nil)
-				cch.EXPECT().Set(mock.Anything, []byte(`{ "user_id": "barbar", "exp": `+exp+` }`), 5*time.Second)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
+				cch.EXPECT().Set(mock.Anything, mock.Anything, []byte(`{ "user_id": "barbar", "exp": `+exp+` }`), 5*time.Second)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()

--- a/internal/rules/mechanisms/authenticators/jwt_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator.go
@@ -330,13 +330,13 @@ func (a *jwtAuthenticator) getKey(ctx heimdall.Context, keyID string) (*jose.JSO
 
 	if a.isCacheEnabled() {
 		cacheKey = a.calculateCacheKey(keyID)
-		cacheEntry = cch.Get(cacheKey)
+		cacheEntry = cch.Get(ctx.AppContext(), cacheKey)
 	}
 
 	if cacheEntry != nil {
 		if jwk, ok = cacheEntry.(*jose.JSONWebKey); !ok {
 			logger.Warn().Msg("Wrong object type from cache")
-			cch.Delete(cacheKey)
+			cch.Delete(ctx.AppContext(), cacheKey)
 		} else {
 			logger.Debug().Msg("Reusing JWK from cache")
 		}
@@ -368,7 +368,7 @@ func (a *jwtAuthenticator) getKey(ctx heimdall.Context, keyID string) (*jose.JSO
 	}
 
 	if cacheTTL := a.getCacheTTL(jwk); cacheTTL > 0 {
-		cch.Set(cacheKey, jwk, cacheTTL)
+		cch.Set(ctx.AppContext(), cacheKey, jwk, cacheTTL)
 	}
 
 	return jwk, nil

--- a/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
@@ -1072,7 +1073,7 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				keys := jwks.Key(kidKeyWithoutCert)
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyOnlyJWK, nil)
-				cch.EXPECT().Get(cacheKey).Return(&keys[0])
+				cch.EXPECT().Get(mock.Anything, cacheKey).Return(&keys[0])
 			},
 			assert: func(t *testing.T, err error, sub *subject.Subject) {
 				t.Helper()
@@ -1117,7 +1118,7 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				keys := jwks.Key(kidKeyWithoutCert)
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyAndCertJWK, nil)
-				cch.EXPECT().Get(cacheKey).Return(&keys[0])
+				cch.EXPECT().Get(mock.Anything, cacheKey).Return(&keys[0])
 			},
 			assert: func(t *testing.T, err error, sub *subject.Subject) {
 				t.Helper()
@@ -1162,7 +1163,7 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				keys := jwks.Key(kidKeyWithoutCert)
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyOnlyJWK, nil)
-				cch.EXPECT().Get(cacheKey).Return(&keys[0])
+				cch.EXPECT().Get(mock.Anything, cacheKey).Return(&keys[0])
 			},
 			assert: func(t *testing.T, err error, sub *subject.Subject) {
 				t.Helper()
@@ -1212,7 +1213,7 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				keys := jwks.Key(kidKeyWithoutCert)
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyOnlyJWK, nil)
-				cch.EXPECT().Get(cacheKey).Return(&keys[0])
+				cch.EXPECT().Get(mock.Anything, cacheKey).Return(&keys[0])
 			},
 			assert: func(t *testing.T, err error, sub *subject.Subject) {
 				t.Helper()
@@ -1261,7 +1262,7 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				keys := jwks.Key(kidKeyWithoutCert)
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyOnlyJWK, nil)
-				cch.EXPECT().Get(cacheKey).Return(&keys[0])
+				cch.EXPECT().Get(mock.Anything, cacheKey).Return(&keys[0])
 			},
 			assert: func(t *testing.T, err error, sub *subject.Subject) {
 				t.Helper()
@@ -1316,8 +1317,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				keys := jwks.Key(kidKeyWithoutCert)
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyOnlyJWK, nil)
-				cch.EXPECT().Get(cacheKey).Return(nil)
-				cch.EXPECT().Set(cacheKey, &keys[0], *auth.ttl)
+				cch.EXPECT().Get(mock.Anything, cacheKey).Return(nil)
+				cch.EXPECT().Set(mock.Anything, cacheKey, &keys[0], *auth.ttl)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -1383,8 +1384,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				keys := jwks.Key(kidKeyWithCert)
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyAndCertJWK, nil)
-				cch.EXPECT().Get(cacheKey).Return(nil)
-				cch.EXPECT().Set(cacheKey, &keys[0], *auth.ttl)
+				cch.EXPECT().Get(mock.Anything, cacheKey).Return(nil)
+				cch.EXPECT().Set(mock.Anything, cacheKey, &keys[0], *auth.ttl)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -1450,7 +1451,7 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				require.NoError(t, err)
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyAndCertJWK, nil)
-				cch.EXPECT().Get(cacheKey).Return(nil)
+				cch.EXPECT().Get(mock.Anything, cacheKey).Return(nil)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -1512,8 +1513,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				keys := jwks.Key(kidKeyWithCert)
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyAndCertJWK, nil)
-				cch.EXPECT().Get(cacheKey).Return(nil)
-				cch.EXPECT().Set(cacheKey, &keys[0], *auth.ttl)
+				cch.EXPECT().Get(mock.Anything, cacheKey).Return(nil)
+				cch.EXPECT().Set(mock.Anything, cacheKey, &keys[0], *auth.ttl)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -1579,9 +1580,9 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				keys := jwks.Key(kidKeyWithoutCert)
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyOnlyJWK, nil)
-				cch.EXPECT().Get(cacheKey).Return("Hi Foo")
-				cch.EXPECT().Delete(cacheKey)
-				cch.EXPECT().Set(cacheKey, &keys[0], *auth.ttl)
+				cch.EXPECT().Get(mock.Anything, cacheKey).Return("Hi Foo")
+				cch.EXPECT().Delete(mock.Anything, cacheKey)
+				cch.EXPECT().Set(mock.Anything, cacheKey, &keys[0], *auth.ttl)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
@@ -214,13 +214,13 @@ func (a *oauth2IntrospectionAuthenticator) getSubjectInformation(ctx heimdall.Co
 
 	if a.isCacheEnabled() {
 		cacheKey = a.calculateCacheKey(token)
-		cacheEntry = cch.Get(cacheKey)
+		cacheEntry = cch.Get(ctx.AppContext(), cacheKey)
 	}
 
 	if cacheEntry != nil {
 		if cachedResponse, ok = cacheEntry.([]byte); !ok {
 			logger.Warn().Msg("Wrong object type from cache")
-			cch.Delete(cacheKey)
+			cch.Delete(ctx.AppContext(), cacheKey)
 		} else {
 			logger.Debug().Msg("Reusing introspection response from cache")
 
@@ -241,7 +241,7 @@ func (a *oauth2IntrospectionAuthenticator) getSubjectInformation(ctx heimdall.Co
 	}
 
 	if cacheTTL := a.getCacheTTL(introspectResp); cacheTTL > 0 {
-		cch.Set(cacheKey, rawResp, cacheTTL)
+		cch.Set(ctx.AppContext(), cacheKey, rawResp, cacheTTL)
 	}
 
 	return rawResp, nil

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
@@ -939,8 +939,8 @@ func TestOauth2IntrospectionAuthenticatorExecute(t *testing.T) {
 				t.Helper()
 
 				ads.EXPECT().GetAuthData(ctx).Return("test_access_token", nil)
-				cch.EXPECT().Get(mock.Anything).Return(nil)
-				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
+				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -1023,9 +1023,9 @@ func TestOauth2IntrospectionAuthenticatorExecute(t *testing.T) {
 				t.Helper()
 
 				ads.EXPECT().GetAuthData(ctx).Return("test_access_token", nil)
-				cch.EXPECT().Get(mock.Anything).Return(zeroTTL)
-				cch.EXPECT().Delete(mock.Anything)
-				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(zeroTTL)
+				cch.EXPECT().Delete(mock.Anything, mock.Anything)
+				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -1123,7 +1123,7 @@ func TestOauth2IntrospectionAuthenticatorExecute(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				cch.EXPECT().Get(mock.Anything).Return(rawIntrospectResponse)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(rawIntrospectResponse)
 			},
 			assert: func(t *testing.T, err error, sub *subject.Subject) {
 				t.Helper()

--- a/internal/rules/mechanisms/authorizers/remote_authorizer.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer.go
@@ -152,13 +152,13 @@ func (a *remoteAuthorizer) Execute(ctx heimdall.Context, sub *subject.Subject) e
 
 	if a.ttl > 0 {
 		cacheKey = a.calculateCacheKey(sub)
-		cacheEntry = cch.Get(cacheKey)
+		cacheEntry = cch.Get(ctx.AppContext(), cacheKey)
 	}
 
 	if cacheEntry != nil {
 		if authInfo, ok = cacheEntry.(*authorizationInformation); !ok {
 			logger.Warn().Msg("Wrong object type from cache")
-			cch.Delete(cacheKey)
+			cch.Delete(ctx.AppContext(), cacheKey)
 		} else {
 			logger.Debug().Msg("Reusing authorization information from cache")
 		}
@@ -171,7 +171,7 @@ func (a *remoteAuthorizer) Execute(ctx heimdall.Context, sub *subject.Subject) e
 		}
 
 		if a.ttl > 0 && len(cacheKey) != 0 {
-			cch.Set(cacheKey, authInfo, a.ttl)
+			cch.Set(ctx.AppContext(), cacheKey, authInfo, a.ttl)
 		}
 	}
 

--- a/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
@@ -730,8 +730,8 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 				cacheKey := auth.calculateCacheKey(sub)
 
-				cch.EXPECT().Get(cacheKey).Return(nil)
-				cch.EXPECT().Set(cacheKey,
+				cch.EXPECT().Get(mock.Anything, cacheKey).Return(nil)
+				cch.EXPECT().Set(mock.Anything, cacheKey,
 					mock.MatchedBy(func(val *authorizationInformation) bool {
 						return val != nil && val.payload == nil && len(val.headers.Get("X-Foo-Bar")) != 0
 					}), auth.ttl)
@@ -780,8 +780,8 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 				cacheKey := auth.calculateCacheKey(sub)
 
-				cch.EXPECT().Get(cacheKey).Return(nil)
-				cch.EXPECT().Set(cacheKey, mock.Anything, auth.ttl)
+				cch.EXPECT().Get(mock.Anything, cacheKey).Return(nil)
+				cch.EXPECT().Set(mock.Anything, cacheKey, mock.Anything, auth.ttl)
 			},
 			assert: func(t *testing.T, err error, sub *subject.Subject) {
 				t.Helper()
@@ -827,7 +827,7 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 			configureCache: func(t *testing.T, cch *mocks.CacheMock, auth *remoteAuthorizer, sub *subject.Subject) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(&authorizationInformation{
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(&authorizationInformation{
 					headers: http.Header{
 						"X-Foo-Bar": {"HeyFoo"},
 						"X-Bar-Foo": {"HeyBar"},
@@ -884,9 +884,9 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 			configureCache: func(t *testing.T, cch *mocks.CacheMock, auth *remoteAuthorizer, sub *subject.Subject) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return("Hello Foo")
-				cch.EXPECT().Delete(mock.Anything)
-				cch.EXPECT().Set(mock.Anything, mock.Anything, auth.ttl)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return("Hello Foo")
+				cch.EXPECT().Delete(mock.Anything, mock.Anything)
+				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything, auth.ttl)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
@@ -133,13 +133,13 @@ func (h *genericContextualizer) Execute(ctx heimdall.Context, sub *subject.Subje
 
 	if h.ttl > 0 {
 		cacheKey = h.calculateCacheKey(sub)
-		cacheEntry = cch.Get(cacheKey)
+		cacheEntry = cch.Get(ctx.AppContext(), cacheKey)
 	}
 
 	if cacheEntry != nil {
 		if response, ok = cacheEntry.(*contextualizerData); !ok {
 			logger.Warn().Msg("Wrong object type from cache")
-			cch.Delete(cacheKey)
+			cch.Delete(ctx.AppContext(), cacheKey)
 		} else {
 			logger.Debug().Msg("Reusing contextualizer response from cache")
 		}
@@ -152,7 +152,7 @@ func (h *genericContextualizer) Execute(ctx heimdall.Context, sub *subject.Subje
 		}
 
 		if h.ttl > 0 && len(cacheKey) != 0 {
-			cch.Set(cacheKey, response, h.ttl)
+			cch.Set(ctx.AppContext(), cacheKey, response, h.ttl)
 		}
 	}
 

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer_test.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer_test.go
@@ -560,7 +560,7 @@ func TestGenericContextualizerExecute(t *testing.T) {
 				t.Helper()
 
 				key := contextualizer.calculateCacheKey(sub)
-				cch.EXPECT().Get(key).Return(&contextualizerData{payload: "Hi Foo"})
+				cch.EXPECT().Get(mock.Anything, key).Return(&contextualizerData{payload: "Hi Foo"})
 			},
 			assert: func(t *testing.T, err error, sub *subject.Subject) {
 				t.Helper()
@@ -591,9 +591,9 @@ func TestGenericContextualizerExecute(t *testing.T) {
 				t.Helper()
 
 				key := contextualizer.calculateCacheKey(sub)
-				cch.EXPECT().Get(key).Return("Hi Foo")
-				cch.EXPECT().Delete(key)
-				cch.EXPECT().Set(key, mock.MatchedBy(func(val *contextualizerData) bool {
+				cch.EXPECT().Get(mock.Anything, key).Return("Hi Foo")
+				cch.EXPECT().Delete(mock.Anything, key)
+				cch.EXPECT().Set(mock.Anything, key, mock.MatchedBy(func(val *contextualizerData) bool {
 					return val != nil && val.payload == "Hi from endpoint"
 				}), 5*time.Second)
 			},
@@ -740,8 +740,8 @@ func TestGenericContextualizerExecute(t *testing.T) {
 				t.Helper()
 
 				key := contextualizer.calculateCacheKey(sub)
-				cch.EXPECT().Get(key).Return(nil)
-				cch.EXPECT().Set(key, mock.MatchedBy(func(val *contextualizerData) bool {
+				cch.EXPECT().Get(mock.Anything, key).Return(nil)
+				cch.EXPECT().Set(mock.Anything, key, mock.MatchedBy(func(val *contextualizerData) bool {
 					return val != nil && val.payload == "Hi from endpoint"
 				}), contextualizer.ttl)
 			},

--- a/internal/rules/mechanisms/finalizers/jwt_finalizer.go
+++ b/internal/rules/mechanisms/finalizers/jwt_finalizer.go
@@ -116,12 +116,12 @@ func (u *jwtFinalizer) Execute(ctx heimdall.Context, sub *subject.Subject) error
 	)
 
 	cacheKey := u.calculateCacheKey(sub, ctx.Signer())
-	cacheEntry = cch.Get(cacheKey)
+	cacheEntry = cch.Get(ctx.AppContext(), cacheKey)
 
 	if cacheEntry != nil {
 		if jwtToken, ok = cacheEntry.(string); !ok {
 			logger.Warn().Msg("Wrong object type from cache")
-			cch.Delete(cacheKey)
+			cch.Delete(ctx.AppContext(), cacheKey)
 		} else {
 			logger.Debug().Msg("Reusing JWT from cache")
 		}
@@ -136,7 +136,7 @@ func (u *jwtFinalizer) Execute(ctx heimdall.Context, sub *subject.Subject) error
 		}
 
 		if len(cacheKey) != 0 && u.ttl > defaultCacheLeeway {
-			cch.Set(cacheKey, jwtToken, u.ttl-defaultCacheLeeway)
+			cch.Set(ctx.AppContext(), cacheKey, jwtToken, u.ttl-defaultCacheLeeway)
 		}
 	}
 

--- a/internal/rules/mechanisms/finalizers/jwt_finalizer_test.go
+++ b/internal/rules/mechanisms/finalizers/jwt_finalizer_test.go
@@ -454,7 +454,7 @@ func TestJWTFinalizerExecute(t *testing.T) {
 				finalizer := jwtFinalizer{ttl: defaultJWTTTL}
 
 				cacheKey := finalizer.calculateCacheKey(sub, signer)
-				cch.EXPECT().Get(cacheKey).Return("TestToken")
+				cch.EXPECT().Get(mock.Anything, cacheKey).Return("TestToken")
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -481,9 +481,9 @@ func TestJWTFinalizerExecute(t *testing.T) {
 				finalizer := jwtFinalizer{ttl: configuredTTL}
 				cacheKey := finalizer.calculateCacheKey(sub, signer)
 
-				cch.EXPECT().Get(cacheKey).Return(time.Second)
-				cch.EXPECT().Delete(cacheKey)
-				cch.EXPECT().Set(cacheKey, "barfoo", configuredTTL-defaultCacheLeeway)
+				cch.EXPECT().Get(mock.Anything, cacheKey).Return(time.Second)
+				cch.EXPECT().Delete(mock.Anything, cacheKey)
+				cch.EXPECT().Set(mock.Anything, cacheKey, "barfoo", configuredTTL-defaultCacheLeeway)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -507,8 +507,8 @@ func TestJWTFinalizerExecute(t *testing.T) {
 				ctx.EXPECT().Signer().Return(signer)
 				ctx.EXPECT().AddHeaderForUpstream("Authorization", "Bearer barfoo")
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
-				cch.EXPECT().Set(mock.Anything, "barfoo", configuredTTL-defaultCacheLeeway)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
+				cch.EXPECT().Set(mock.Anything, mock.Anything, "barfoo", configuredTTL-defaultCacheLeeway)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -542,8 +542,8 @@ claims: '{
 				ctx.EXPECT().Signer().Return(signer)
 				ctx.EXPECT().AddHeaderForUpstream("X-Token", "Bar barfoo")
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
-				cch.EXPECT().Set(mock.Anything, "barfoo", defaultJWTTTL-defaultCacheLeeway)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
+				cch.EXPECT().Set(mock.Anything, mock.Anything, "barfoo", defaultJWTTTL-defaultCacheLeeway)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -565,7 +565,7 @@ claims: '{
 
 				ctx.EXPECT().Signer().Return(signer)
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -593,7 +593,7 @@ claims: '{
 
 				ctx.EXPECT().Signer().Return(signer)
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()

--- a/internal/rules/mechanisms/finalizers/oauth2_client_credentials_finalizer_test.go
+++ b/internal/rules/mechanisms/finalizers/oauth2_client_credentials_finalizer_test.go
@@ -450,7 +450,7 @@ func TestClientCredentialsFinalizerExecute(t *testing.T) {
 			configureMocks: func(t *testing.T, ctx *mocks.ContextMock, cch *mocks2.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(&clientcredentials.TokenInfo{AccessToken: "foobar", TokenType: "Bearer"})
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(&clientcredentials.TokenInfo{AccessToken: "foobar", TokenType: "Bearer"})
 				ctx.EXPECT().AddHeaderForUpstream("Authorization", "Bearer foobar")
 			},
 			assert: func(t *testing.T, err error, tokenEndpointCalled bool) {
@@ -473,7 +473,7 @@ func TestClientCredentialsFinalizerExecute(t *testing.T) {
 			configureMocks: func(t *testing.T, ctx *mocks.ContextMock, cch *mocks2.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
 			},
 			assertRequest: func(t *testing.T, req *http.Request) { t.Helper() },
 			buildResponse: func(t *testing.T) (any, int) {
@@ -510,8 +510,8 @@ func TestClientCredentialsFinalizerExecute(t *testing.T) {
 			configureMocks: func(t *testing.T, ctx *mocks.ContextMock, cch *mocks2.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
-				cch.EXPECT().Set(mock.Anything, mock.Anything, 3*time.Minute).Return()
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
+				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything, 3*time.Minute).Return()
 				ctx.EXPECT().AddHeaderForUpstream("X-My-Header", "Bar foobar").Return()
 			},
 			assertRequest: func(t *testing.T, req *http.Request) {

--- a/internal/rules/oauth2/clientcredentials/clientcredentials.go
+++ b/internal/rules/oauth2/clientcredentials/clientcredentials.go
@@ -67,13 +67,13 @@ func (c *Config) Token(ctx context.Context) (*TokenInfo, error) {
 
 	if c.isCacheEnabled() {
 		cacheKey = c.calculateCacheKey()
-		cacheEntry = cch.Get(cacheKey)
+		cacheEntry = cch.Get(ctx, cacheKey)
 	}
 
 	if cacheEntry != nil {
 		if tokenInfo, ok = cacheEntry.(*TokenInfo); !ok {
 			logger.Warn().Msg("Wrong object type from cache")
-			cch.Delete(cacheKey)
+			cch.Delete(ctx, cacheKey)
 		} else {
 			logger.Debug().Msg("Reusing access token from cache")
 		}
@@ -88,7 +88,7 @@ func (c *Config) Token(ctx context.Context) (*TokenInfo, error) {
 		}
 
 		if cacheTTL := c.getCacheTTL(tokenInfo); cacheTTL > 0 {
-			cch.Set(cacheKey, tokenInfo, cacheTTL)
+			cch.Set(ctx, cacheKey, tokenInfo, cacheTTL)
 		}
 	}
 

--- a/internal/rules/oauth2/clientcredentials/clientcredentials_test.go
+++ b/internal/rules/oauth2/clientcredentials/clientcredentials_test.go
@@ -99,7 +99,7 @@ func TestClientCredentialsToken(t *testing.T) {
 			configureMocks: func(t *testing.T, cch *mocks.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(&TokenInfo{TokenType: "Bearer", AccessToken: "foobar"})
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(&TokenInfo{TokenType: "Bearer", AccessToken: "foobar"})
 			},
 			assert: func(t *testing.T, err error, tokenEndpointCalled bool, token *TokenInfo) {
 				t.Helper()
@@ -116,8 +116,8 @@ func TestClientCredentialsToken(t *testing.T) {
 			configureMocks: func(t *testing.T, cch *mocks.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(10)
-				cch.EXPECT().Delete(mock.Anything)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(10)
+				cch.EXPECT().Delete(mock.Anything, mock.Anything)
 			},
 			assertRequest: func(t *testing.T, req *http.Request) {
 				t.Helper()
@@ -162,8 +162,8 @@ func TestClientCredentialsToken(t *testing.T) {
 			configureMocks: func(t *testing.T, cch *mocks.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
-				cch.EXPECT().Set(mock.Anything, mock.Anything,
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
+				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything,
 					mock.MatchedBy(func(ttl time.Duration) bool {
 						return ttl.Round(time.Second) == 5*time.Minute-5*time.Second
 					}),
@@ -209,7 +209,7 @@ func TestClientCredentialsToken(t *testing.T) {
 			configureMocks: func(t *testing.T, cch *mocks.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
 			},
 			assertRequest: func(t *testing.T, req *http.Request) { t.Helper() },
 			buildResponse: func(t *testing.T) (any, int) {
@@ -231,7 +231,7 @@ func TestClientCredentialsToken(t *testing.T) {
 			configureMocks: func(t *testing.T, cch *mocks.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
 			},
 			assertRequest: func(t *testing.T, req *http.Request) { t.Helper() },
 			buildResponse: func(t *testing.T) (any, int) {
@@ -253,7 +253,7 @@ func TestClientCredentialsToken(t *testing.T) {
 			configureMocks: func(t *testing.T, cch *mocks.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
 			},
 			assert: func(t *testing.T, err error, tokenEndpointCalled bool, token *TokenInfo) {
 				t.Helper()
@@ -279,8 +279,8 @@ func TestClientCredentialsToken(t *testing.T) {
 			configureMocks: func(t *testing.T, cch *mocks.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
-				cch.EXPECT().Set(mock.Anything, mock.Anything, 3*time.Minute).Return()
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
+				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything, 3*time.Minute).Return()
 			},
 			assertRequest: func(t *testing.T, req *http.Request) {
 				t.Helper()
@@ -401,8 +401,8 @@ func TestClientCredentialsToken(t *testing.T) {
 			configureMocks: func(t *testing.T, cch *mocks.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
-				cch.EXPECT().Set(mock.Anything, mock.Anything, 3*time.Minute).Return()
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
+				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything, 3*time.Minute).Return()
 			},
 			assertRequest: func(t *testing.T, req *http.Request) {
 				t.Helper()
@@ -456,8 +456,8 @@ func TestClientCredentialsToken(t *testing.T) {
 			configureMocks: func(t *testing.T, cch *mocks.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
-				cch.EXPECT().Set(mock.Anything, mock.Anything, 3*time.Minute).Return()
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
+				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything, 3*time.Minute).Return()
 			},
 			assertRequest: func(t *testing.T, req *http.Request) {
 				t.Helper()
@@ -581,7 +581,7 @@ func TestClientCredentialsToken(t *testing.T) {
 			configureMocks: func(t *testing.T, cch *mocks.CacheMock) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything).Return(nil)
+				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil)
 			},
 			assertRequest: func(t *testing.T, req *http.Request) {
 				t.Helper()


### PR DESCRIPTION
## Related issue(s)

relates to #999

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

This PR extends the `Cache` interface as described in the title. That decouples the development of #999 from potential package changes and allows parallel implementation of other cache types.