### PR TITLE
feat: Helm chart pulls heimdall container image from ghcr.io instead from DockerHub

### DIFF
--- a/charts/heimdall/README.adoc
+++ b/charts/heimdall/README.adoc
@@ -243,7 +243,7 @@ a| `/$request_uri`
 a| `image.repository`
 
 The image repository to load heimdall image from
-a| `dadrus/heimdall`
+a| `ghcr.io/dadrus/heimdall`
 
 a| `image.tag`
 

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -34,7 +34,7 @@ demo:
 
 # Default values for heimdall.
 image:
-  repository: dadrus/heimdall
+  repository: ghcr.io/dadrus/heimdall
   pullPolicy: IfNotPresent
   tag: ""
   pullSecrets: [ ]


### PR DESCRIPTION
## Related issue(s)

closes #1049

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have updated the documentation.

## Description

As stated in the title of this PR, it changes the helm chart configuration to pull heimdall images from ghcr.io instead of pulling them from DockerHub.

If pulling the container image is desired to happen from DockerHub, one can set `image.repository` to `dadrus/heimdall`  while using the chart.