### PR TITLE
fix: MIME type decoder covers optional parameters

### DIFF
--- a/internal/rules/mechanisms/authenticators/extractors/body_parameter_extract_strategy_test.go
+++ b/internal/rules/mechanisms/authenticators/extractors/body_parameter_extract_strategy_test.go
@@ -61,7 +61,7 @@ func TestExtractBodyParameter(t *testing.T) {
 				t.Helper()
 
 				fnt := mocks.NewRequestFunctionsMock(t)
-				fnt.EXPECT().Header("Content-Type").Return("application/json")
+				fnt.EXPECT().Header("Content-Type").Return("application/json; charset=utf-8")
 				fnt.EXPECT().Body().Return([]byte("foo:?:bar"))
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: fnt})
@@ -81,7 +81,7 @@ func TestExtractBodyParameter(t *testing.T) {
 				t.Helper()
 
 				fnt := mocks.NewRequestFunctionsMock(t)
-				fnt.EXPECT().Header("Content-Type").Return("application/x-www-form-urlencoded")
+				fnt.EXPECT().Header("Content-Type").Return("application/x-www-form-urlencoded; charset=utf-8")
 				fnt.EXPECT().Body().Return([]byte("foo;"))
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: fnt})

--- a/internal/rules/mechanisms/contenttype/decoder.go
+++ b/internal/rules/mechanisms/contenttype/decoder.go
@@ -31,7 +31,7 @@ func NewDecoder(contentType string) (Decoder, error) {
 	switch {
 	case strings.Contains(contentType, "json"):
 		return JSONDecoder{}, nil
-	case contentType == "application/x-www-form-urlencoded":
+	case strings.Contains(contentType, "application/x-www-form-urlencoded"):
 		return WWWFormUrlencodedDecoder{}, nil
 	default:
 		return nil, ErrUnsupportedContentType


### PR DESCRIPTION
## Related issue(s)

closes #1058

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

Before this PR, the content type decoder expected the `application/x-www-form-urlencoded` MIME type as is while dispatching between different decoder implementations. This fix takes into account that a MIME type can have parameters.

