### PR TITLE
refactor: Recover retrieval of header values as it was before #889

### DIFF
--- a/docs/content/docs/configuration/rules/pipeline_mechanisms/overview.adoc
+++ b/docs/content/docs/configuration/rules/pipeline_mechanisms/overview.adoc
@@ -224,7 +224,9 @@ The list of IP addresses the request passed through with the first entry being t
 
 * *`Header(name)`*: _method_,
 +
-This method expects the name of a header as input and returns the value of it as `string`. If the header is not present in the HTTP request an empty string (`""`) is returned.
+This method expects the name of a header as input and returns its value as a `string`. If the header is not present in the HTTP request an empty string (`""`) is returned. If a header appears multiple times in the request, the returned `string` is a comma separated list of all values.
++
+NOTE: A single header may be a comma separated list of actual values as well. Best example is the `Accept` header, which might be set to e.g. `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`).
 
 * *`Cookie(name)`*: _method_,
 +

--- a/internal/handler/requestcontext/request_context.go
+++ b/internal/handler/requestcontext/request_context.go
@@ -63,12 +63,7 @@ func (r *RequestContext) Header(name string) string {
 		return r.req.Host
 	}
 
-	value := r.req.Header[key]
-	if len(value) == 0 {
-		return ""
-	}
-
-	return value[0]
+	return strings.Join(r.req.Header.Values(key), ",")
 }
 
 func (r *RequestContext) Cookie(name string) string {

--- a/internal/handler/requestcontext/request_context_test.go
+++ b/internal/handler/requestcontext/request_context_test.go
@@ -150,7 +150,7 @@ func TestRequestContextHeader(t *testing.T) {
 	emptyValue := ctx.Request().Header("X-Not-Present")
 
 	// THEN
-	assert.Equal(t, "foo", xFooBarValue)
+	assert.Equal(t, "foo,bar", xFooBarValue)
 	assert.Equal(t, "bar.foo", hostValue)
 	assert.Empty(t, emptyValue)
 }


### PR DESCRIPTION
## Related issue(s)

relates to #889

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

Before the referenced PR, the call to `Request.Header(name)` returned a string containing all values for all header occurrences in the request with the same name separated by a comma. During the migration from fasthttp to build-in http engine that behavior has been changed to return only the first values of a header, even if the actual header contents were a comma separated list of multiple  values.

This PR recovers this functionality.