### PR TITLE
refactor!: `Request.ClientIP` renamed to `Request.ClientIPAddresses` to reflect the actual contents

### DIFF
--- a/docs/content/docs/configuration/rules/pipeline_mechanisms/overview.adoc
+++ b/docs/content/docs/configuration/rules/pipeline_mechanisms/overview.adoc
@@ -218,7 +218,7 @@ This method returns the URL as valid URL string of a form `scheme:host/path?quer
 +
 The parsed query with each key-value pair being a string to array of strings mapping.
 
-* *`ClientIP`*: _string array_
+* *`ClientIPAddresses`*: _string array_
 +
 The list of IP addresses the request passed through with the first entry being the ultimate client of the request. Only available if heimdall is configured to trust the client, sending this information, e.g. in the `X-Forwarded-From` header (see e.g. Decision Service link:{{< relref "/docs/configuration/services/decision.adoc#_trusted_proxies" >}}[trusted_proxies] configuration for more details).
 

--- a/internal/handler/envoyextauth/grpcv3/request_context.go
+++ b/internal/handler/envoyextauth/grpcv3/request_context.go
@@ -90,10 +90,10 @@ func canonicalizeHeaders(headers map[string]string) map[string]string {
 
 func (s *RequestContext) Request() *heimdall.Request {
 	return &heimdall.Request{
-		RequestFunctions: s,
-		Method:           s.reqMethod,
-		URL:              s.reqURL,
-		ClientIP:         s.ips,
+		RequestFunctions:  s,
+		Method:            s.reqMethod,
+		URL:               s.reqURL,
+		ClientIPAddresses: s.ips,
 	}
 }
 

--- a/internal/handler/envoyextauth/grpcv3/request_context_test.go
+++ b/internal/handler/envoyextauth/grpcv3/request_context_test.go
@@ -88,7 +88,7 @@ func TestNewRequestContext(t *testing.T) {
 	require.Empty(t, ctx.Request().Cookie("baz"))
 	require.NotNil(t, ctx.AppContext())
 	require.NotNil(t, ctx.Signer())
-	assert.Equal(t, []string{"127.0.0.1", "192.168.1.1"}, ctx.Request().ClientIP)
+	assert.Equal(t, []string{"127.0.0.1", "192.168.1.1"}, ctx.Request().ClientIPAddresses)
 }
 
 func TestFinalizeRequestContext(t *testing.T) {

--- a/internal/handler/requestcontext/request_context.go
+++ b/internal/handler/requestcontext/request_context.go
@@ -118,10 +118,10 @@ func (r *RequestContext) Body() []byte {
 func (r *RequestContext) Request() *heimdall.Request {
 	if r.hmdlReq == nil {
 		r.hmdlReq = &heimdall.Request{
-			RequestFunctions: r,
-			Method:           r.reqMethod,
-			URL:              r.reqURL,
-			ClientIP:         r.requestClientIPs(),
+			RequestFunctions:  r,
+			Method:            r.reqMethod,
+			URL:               r.reqURL,
+			ClientIPAddresses: r.requestClientIPs(),
 		}
 	}
 

--- a/internal/heimdall/context.go
+++ b/internal/heimdall/context.go
@@ -48,7 +48,7 @@ type RequestFunctions interface {
 type Request struct {
 	RequestFunctions
 
-	Method   string
-	URL      *url.URL
-	ClientIP []string
+	Method            string
+	URL               *url.URL
+	ClientIPAddresses []string
 }

--- a/internal/rules/cel_execution_condition_test.go
+++ b/internal/rules/cel_execution_condition_test.go
@@ -105,7 +105,7 @@ func TestCelExecutionConditionCanExecute(t *testing.T) {
 					Path:     "/test",
 					RawQuery: "foo=bar&baz=zab",
 				},
-				ClientIP: []string{"127.0.0.1", "10.10.10.10"},
+				ClientIPAddresses: []string{"127.0.0.1", "10.10.10.10"},
 			})
 
 			condition, err := newCelExecutionCondition(tc.expression)

--- a/internal/rules/mechanisms/authorizers/cel_authorizer_test.go
+++ b/internal/rules/mechanisms/authorizers/cel_authorizer_test.go
@@ -286,7 +286,7 @@ expressions:
   - expression: size(Request.URL.Query()) == 2
   - expression: Request.URL.Query().foo == ["bar"]
   - expression: Request.Header('X-Custom-Header') == "foobar"
-  - expression: Request.ClientIP.exists_one(v, v == '127.0.0.1')
+  - expression: Request.ClientIPAddresses.exists_one(v, v == '127.0.0.1')
   - expression: Request.Cookie("FooCookie") == "barfoo"
   - expression: Request.URL.String() == "http://localhost/test?foo=bar&baz=zab"
   - expression: Request.URL.Path.split("/").last() == "test"
@@ -314,7 +314,7 @@ expressions:
 						Path:     "/test",
 						RawQuery: "foo=bar&baz=zab",
 					},
-					ClientIP: []string{"127.0.0.1", "10.10.10.10"},
+					ClientIPAddresses: []string{"127.0.0.1", "10.10.10.10"},
 				})
 			},
 			assert: func(t *testing.T, err error) {

--- a/internal/rules/mechanisms/cellib/requests_test.go
+++ b/internal/rules/mechanisms/cellib/requests_test.go
@@ -31,10 +31,10 @@ func TestRequests(t *testing.T) {
 	reqf.EXPECT().Header("bar").Return("baz")
 
 	req := &heimdall.Request{
-		RequestFunctions: reqf,
-		Method:           http.MethodHead,
-		URL:              uri,
-		ClientIP:         []string{"1.1.1.1"},
+		RequestFunctions:  reqf,
+		Method:            http.MethodHead,
+		URL:               uri,
+		ClientIPAddresses: []string{"1.1.1.1"},
 	}
 
 	for _, tc := range []struct {

--- a/internal/rules/mechanisms/errorhandlers/matcher/error_condition_matcher.go
+++ b/internal/rules/mechanisms/errorhandlers/matcher/error_condition_matcher.go
@@ -33,7 +33,7 @@ func (ecm ErrorConditionMatcher) Match(ctx heimdall.Context, err error) bool {
 		func() bool { return true })
 
 	ipMatched := x.IfThenElseExec(ecm.CIDR != nil,
-		func() bool { return ecm.CIDR.Match(ctx.Request().ClientIP...) },
+		func() bool { return ecm.CIDR.Match(ctx.Request().ClientIPAddresses...) },
 		func() bool { return true })
 
 	headerMatched := x.IfThenElseExec(ecm.Headers != nil,

--- a/internal/rules/mechanisms/errorhandlers/matcher/error_condition_matcher_test.go
+++ b/internal/rules/mechanisms/errorhandlers/matcher/error_condition_matcher_test.go
@@ -61,8 +61,8 @@ func TestErrorConditionMatcherMatch(t *testing.T) {
 				})
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{
-					RequestFunctions: fnt,
-					ClientIP:         []string{"192.168.10.2"},
+					RequestFunctions:  fnt,
+					ClientIPAddresses: []string{"192.168.10.2"},
 				})
 			},
 			err:      heimdall.ErrConfiguration,
@@ -90,8 +90,8 @@ func TestErrorConditionMatcherMatch(t *testing.T) {
 				})
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{
-					RequestFunctions: fnt,
-					ClientIP:         []string{"192.168.1.2"},
+					RequestFunctions:  fnt,
+					ClientIPAddresses: []string{"192.168.1.2"},
 				})
 			},
 			err:      heimdall.ErrArgument,
@@ -119,8 +119,8 @@ func TestErrorConditionMatcherMatch(t *testing.T) {
 				})
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{
-					RequestFunctions: fnt,
-					ClientIP:         []string{"192.168.10.2"},
+					RequestFunctions:  fnt,
+					ClientIPAddresses: []string{"192.168.10.2"},
 				})
 			},
 			err:      heimdall.ErrArgument,
@@ -148,8 +148,8 @@ func TestErrorConditionMatcherMatch(t *testing.T) {
 				})
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{
-					RequestFunctions: fnt,
-					ClientIP:         []string{"192.168.10.2"},
+					RequestFunctions:  fnt,
+					ClientIPAddresses: []string{"192.168.10.2"},
 				})
 			},
 			err:      heimdall.ErrArgument,
@@ -177,8 +177,8 @@ func TestErrorConditionMatcherMatch(t *testing.T) {
 				})
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{
-					RequestFunctions: fnt,
-					ClientIP:         []string{"192.168.1.2"},
+					RequestFunctions:  fnt,
+					ClientIPAddresses: []string{"192.168.1.2"},
 				})
 			},
 			err:      heimdall.ErrConfiguration,
@@ -230,7 +230,7 @@ func TestErrorConditionMatcherMatch(t *testing.T) {
 				t.Helper()
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{
-					ClientIP: []string{"192.168.1.2"},
+					ClientIPAddresses: []string{"192.168.1.2"},
 				})
 			},
 			err:      heimdall.ErrConfiguration,

--- a/internal/rules/mechanisms/template/template_test.go
+++ b/internal/rules/mechanisms/template/template_test.go
@@ -40,10 +40,10 @@ func TestTemplateRender(t *testing.T) {
 
 	ctx := mocks.NewContextMock(t)
 	ctx.EXPECT().Request().Return(&heimdall.Request{
-		RequestFunctions: reqf,
-		Method:           http.MethodPatch,
-		URL:              &url.URL{Scheme: "http", Host: "foobar.baz", Path: "zab", RawQuery: "my_query_param=query_value"},
-		ClientIP:         []string{"192.168.1.1"},
+		RequestFunctions:  reqf,
+		Method:            http.MethodPatch,
+		URL:               &url.URL{Scheme: "http", Host: "foobar.baz", Path: "zab", RawQuery: "my_query_param=query_value"},
+		ClientIPAddresses: []string{"192.168.1.1"},
 	})
 
 	sub := &subject.Subject{
@@ -65,7 +65,7 @@ func TestTemplateRender(t *testing.T) {
 "my_header": {{ .Request.Header "X-My-Header" | quote }},
 "my_cookie": {{ .Request.Cookie "session_cookie" | quote }},
 "my_query_param": {{ index .Request.URL.Query.my_query_param 0 | quote }},
-"ips": {{ range $i, $el := .Request.ClientIP -}}{{ if $i }} {{ end }}{{ quote $el }}{{ end }},
+"ips": {{ range $i, $el := .Request.ClientIPAddresses -}}{{ if $i }} {{ end }}{{ quote $el }}{{ end }},
 "values": [{{ quote .Values.key1 }}, {{ quote .Values.key2 }}]
 }`)
 	require.NoError(t, err)


### PR DESCRIPTION
## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

The type of `Request.ClientIP` property was always an array of strings. Unfortunately, the name `ClientIP` does not reflect this and is misleading. This PR resolves this by renaming this property to `ClientIPAddresses`.
