### PR TITLE
feat: Access to request body in templates and CEL expressions

### DIFF
--- a/docs/content/docs/configuration/rules/pipeline_mechanisms/overview.adoc
+++ b/docs/content/docs/configuration/rules/pipeline_mechanisms/overview.adoc
@@ -228,7 +228,39 @@ NOTE: A single header may be a comma separated list of actual values as well. Be
 +
 This method expects the name of a cookie as input and returns the value of it as `string`. If the cookie is not present in the HTTP request an empty string (`""`) is returned.
 
-Here is an example:
+* *`Body()`*: _method_,
++
+The parsed body with contents depending on the `Content-Type` header. Supported content types are any MIME types with `json` or `yaml` subtype, as well as `application/x-www-form-urlencoded`. If MIME type is unsupported, the method returns a string with the actual body contents.
++
+NOTE: The actual request body is parsed only on the first use of this function. All subsequent calls return the cached result.
++
+.Example results
+====
+If the `Content-Type` header is set to `application/json` and the actual request body is a valid JSON object, shown below
+[source, json]
+----
+{ "context": "heimdall" }
+----
+The call to the `Body()` function will return exactly this representation as a map.
+ +
+
+If the `Content-Type` header is set to `application/yaml` and the actual request body is a valid YAML object, shown below
+[source, yaml]
+----
+context: heimdall
+----
+The call to the `Body()` function will return `{ "context": "heimdall" }` representation as a map.
+ +
+
+If the `Content-Type` header is set to `application/x-www-form-urlencoded` and the actual request body is a valid object, shown below
+[source, yaml]
+----
+context=heimdall
+----
+The call to the `Body()` function will return this representation as a map with each value being a string array. In this particular case as `{ "context": [ "heimdall" ] }`.
+====
+
+Here is an example for a request object:
 
 .Example request object
 ====

--- a/internal/handler/requestcontext/request_context_test.go
+++ b/internal/handler/requestcontext/request_context_test.go
@@ -176,22 +176,67 @@ func TestRequestContextCookie(t *testing.T) {
 func TestRequestContextBody(t *testing.T) {
 	t.Parallel()
 
-	req := httptest.NewRequest(http.MethodPost, "https://foo.bar/test", bytes.NewBufferString("Ping"))
-	req.Header.Set("X-Custom", "foo")
+	for _, tc := range []struct {
+		uc     string
+		ct     string
+		body   io.Reader
+		expect any
+	}{
+		{
+			uc:     "No body",
+			ct:     "empty",
+			body:   nil,
+			expect: "",
+		},
+		{
+			uc:     "No body",
+			ct:     "empty",
+			body:   bytes.NewBufferString(""),
+			expect: "",
+		},
+		{
+			uc:     "Wrong content type",
+			ct:     "application/json",
+			body:   bytes.NewBufferString("foo: bar"),
+			expect: "foo: bar",
+		},
+		{
+			uc:     "x-www-form-urlencoded encoded",
+			ct:     "application/x-www-form-urlencoded; charset=utf-8",
+			body:   bytes.NewBufferString("content=heimdall"),
+			expect: map[string]any{"content": []string{"heimdall"}},
+		},
+		{
+			uc:     "json encoded",
+			ct:     "application/json; charset=utf-8",
+			body:   bytes.NewBufferString(`{ "content": "heimdall" }`),
+			expect: map[string]any{"content": "heimdall"},
+		},
+		{
+			uc:     "yaml encoded",
+			ct:     "application/yaml; charset=utf-8",
+			body:   bytes.NewBufferString("content: heimdall"),
+			expect: map[string]any{"content": "heimdall"},
+		},
+		{
+			uc:     "plain text",
+			ct:     "text/plain",
+			body:   bytes.NewBufferString("content=heimdall"),
+			expect: "content=heimdall",
+		},
+	} {
+		t.Run(tc.uc, func(t *testing.T) {
+			// GIVEN
+			req := httptest.NewRequest(http.MethodPost, "https://foo.bar/test", tc.body)
+			req.Header.Set("Content-Type", tc.ct)
 
-	ctx := New(nil, req)
-	ctx.AddHeaderForUpstream("X-Foo", "bar")
+			ctx := New(nil, req)
 
-	// just consume body
-	first := ctx.Request().Body()
-	// there should be no difference
-	second := ctx.Request().Body()
+			// WHEN
+			data := ctx.Request().Body()
 
-	// WHEN
-	orig, err := io.ReadAll(req.Body)
-	require.NoError(t, err)
-
-	// THEN
-	require.Equal(t, orig, first)
-	require.Equal(t, first, second)
+			// THEN
+			assert.Equal(t, tc.expect, data)
+		})
+	}
 }

--- a/internal/heimdall/context.go
+++ b/internal/heimdall/context.go
@@ -42,7 +42,7 @@ type RequestFunctions interface {
 	Header(name string) string
 	Cookie(name string) string
 	Headers() map[string]string
-	Body() []byte
+	Body() any
 }
 
 type Request struct {

--- a/internal/heimdall/mocks/request_functions.go
+++ b/internal/heimdall/mocks/request_functions.go
@@ -18,15 +18,15 @@ func (_m *RequestFunctionsMock) EXPECT() *RequestFunctionsMock_Expecter {
 }
 
 // Body provides a mock function with given fields:
-func (_m *RequestFunctionsMock) Body() []byte {
+func (_m *RequestFunctionsMock) Body() interface{} {
 	ret := _m.Called()
 
-	var r0 []byte
-	if rf, ok := ret.Get(0).(func() []byte); ok {
+	var r0 interface{}
+	if rf, ok := ret.Get(0).(func() interface{}); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]byte)
+			r0 = ret.Get(0).(interface{})
 		}
 	}
 
@@ -50,12 +50,12 @@ func (_c *RequestFunctionsMock_Body_Call) Run(run func()) *RequestFunctionsMock_
 	return _c
 }
 
-func (_c *RequestFunctionsMock_Body_Call) Return(_a0 []byte) *RequestFunctionsMock_Body_Call {
+func (_c *RequestFunctionsMock_Body_Call) Return(_a0 interface{}) *RequestFunctionsMock_Body_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *RequestFunctionsMock_Body_Call) RunAndReturn(run func() []byte) *RequestFunctionsMock_Body_Call {
+func (_c *RequestFunctionsMock_Body_Call) RunAndReturn(run func() interface{}) *RequestFunctionsMock_Body_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/rules/mechanisms/authenticators/extractors/body_parameter_extract_strategy_test.go
+++ b/internal/rules/mechanisms/authenticators/extractors/body_parameter_extract_strategy_test.go
@@ -36,13 +36,13 @@ func TestExtractBodyParameter(t *testing.T) {
 		assert         func(t *testing.T, err error, authData string)
 	}{
 		{
-			uc:            "unsupported content type",
+			uc:            "body is a string",
 			parameterName: "foobar",
 			configureMocks: func(t *testing.T, ctx *mocks.ContextMock) {
 				t.Helper()
 
 				fnt := mocks.NewRequestFunctionsMock(t)
-				fnt.EXPECT().Header("Content-Type").Return("FooBar")
+				fnt.EXPECT().Body().Return("foobar=foo")
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: fnt})
 			},
@@ -51,58 +51,17 @@ func TestExtractBodyParameter(t *testing.T) {
 
 				require.Error(t, err)
 				require.ErrorIs(t, err, heimdall.ErrArgument)
-				assert.Contains(t, err.Error(), "unsupported mime type")
+				assert.Contains(t, err.Error(), "no usable body present")
 			},
 		},
 		{
-			uc:            "json body decoding error",
+			uc:            "json body does not contain required parameter",
 			parameterName: "foobar",
 			configureMocks: func(t *testing.T, ctx *mocks.ContextMock) {
 				t.Helper()
 
 				fnt := mocks.NewRequestFunctionsMock(t)
-				fnt.EXPECT().Header("Content-Type").Return("application/json; charset=utf-8")
-				fnt.EXPECT().Body().Return([]byte("foo:?:bar"))
-
-				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: fnt})
-			},
-			assert: func(t *testing.T, err error, authData string) {
-				t.Helper()
-
-				require.Error(t, err)
-				require.ErrorIs(t, err, heimdall.ErrArgument)
-				assert.Contains(t, err.Error(), "failed to decode")
-			},
-		},
-		{
-			uc:            "form url encoded body decoding error",
-			parameterName: "foobar",
-			configureMocks: func(t *testing.T, ctx *mocks.ContextMock) {
-				t.Helper()
-
-				fnt := mocks.NewRequestFunctionsMock(t)
-				fnt.EXPECT().Header("Content-Type").Return("application/x-www-form-urlencoded; charset=utf-8")
-				fnt.EXPECT().Body().Return([]byte("foo;"))
-
-				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: fnt})
-			},
-			assert: func(t *testing.T, err error, authData string) {
-				t.Helper()
-
-				require.Error(t, err)
-				require.ErrorIs(t, err, heimdall.ErrArgument)
-				assert.Contains(t, err.Error(), "failed to decode")
-			},
-		},
-		{
-			uc:            "json encoded body does not contain required parameter",
-			parameterName: "foobar",
-			configureMocks: func(t *testing.T, ctx *mocks.ContextMock) {
-				t.Helper()
-
-				fnt := mocks.NewRequestFunctionsMock(t)
-				fnt.EXPECT().Header("Content-Type").Return("application/json")
-				fnt.EXPECT().Body().Return([]byte(`{"bar": "foo"}`))
+				fnt.EXPECT().Body().Return(map[string]any{"foo": "bar"})
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: fnt})
 			},
@@ -121,8 +80,7 @@ func TestExtractBodyParameter(t *testing.T) {
 				t.Helper()
 
 				fnt := mocks.NewRequestFunctionsMock(t)
-				fnt.EXPECT().Header("Content-Type").Return("application/x-www-form-urlencoded")
-				fnt.EXPECT().Body().Return([]byte(`foo=bar`))
+				fnt.EXPECT().Body().Return(map[string]any{"foo": []any{"bar"}})
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: fnt})
 			},
@@ -135,14 +93,13 @@ func TestExtractBodyParameter(t *testing.T) {
 			},
 		},
 		{
-			uc:            "json encoded body contains required parameter multiple times",
+			uc:            "body contains required parameter multiple times #1",
 			parameterName: "foobar",
 			configureMocks: func(t *testing.T, ctx *mocks.ContextMock) {
 				t.Helper()
 
 				fnt := mocks.NewRequestFunctionsMock(t)
-				fnt.EXPECT().Header("Content-Type").Return("application/json")
-				fnt.EXPECT().Body().Return([]byte(`{"foobar": ["foo", "bar"]}`))
+				fnt.EXPECT().Body().Return(map[string]any{"foobar": []any{"foo", "bar"}})
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: fnt})
 			},
@@ -155,14 +112,13 @@ func TestExtractBodyParameter(t *testing.T) {
 			},
 		},
 		{
-			uc:            "form url encoded body contains required parameter multiple times",
+			uc:            "body contains required parameter multiple times #2",
 			parameterName: "foobar",
 			configureMocks: func(t *testing.T, ctx *mocks.ContextMock) {
 				t.Helper()
 
 				fnt := mocks.NewRequestFunctionsMock(t)
-				fnt.EXPECT().Header("Content-Type").Return("application/x-www-form-urlencoded")
-				fnt.EXPECT().Body().Return([]byte(`foobar=foo&foobar=bar`))
+				fnt.EXPECT().Body().Return(map[string]any{"foobar": []string{"foo", "bar"}})
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: fnt})
 			},
@@ -175,14 +131,13 @@ func TestExtractBodyParameter(t *testing.T) {
 			},
 		},
 		{
-			uc:            "json encoded body contains required parameter in wrong format #1",
+			uc:            "body contains required parameter in wrong format #1",
 			parameterName: "foobar",
 			configureMocks: func(t *testing.T, ctx *mocks.ContextMock) {
 				t.Helper()
 
 				fnt := mocks.NewRequestFunctionsMock(t)
-				fnt.EXPECT().Header("Content-Type").Return("application/json")
-				fnt.EXPECT().Body().Return([]byte(`{"foobar": [1]}`))
+				fnt.EXPECT().Body().Return(map[string]any{"foobar": []any{1}})
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: fnt})
 			},
@@ -195,14 +150,13 @@ func TestExtractBodyParameter(t *testing.T) {
 			},
 		},
 		{
-			uc:            "json encoded body contains required parameter in wrong format #2",
+			uc:            "body contains required parameter in wrong format #2",
 			parameterName: "foobar",
 			configureMocks: func(t *testing.T, ctx *mocks.ContextMock) {
 				t.Helper()
 
 				fnt := mocks.NewRequestFunctionsMock(t)
-				fnt.EXPECT().Header("Content-Type").Return("application/json")
-				fnt.EXPECT().Body().Return([]byte(`{"foobar": { "foo": "bar" }}`))
+				fnt.EXPECT().Body().Return(map[string]any{"foobar": map[string]any{"foo": "bar"}})
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: fnt})
 			},
@@ -215,14 +169,13 @@ func TestExtractBodyParameter(t *testing.T) {
 			},
 		},
 		{
-			uc:            "json encoded body contains required parameter",
+			uc:            "body contains required parameter #1",
 			parameterName: "foobar",
 			configureMocks: func(t *testing.T, ctx *mocks.ContextMock) {
 				t.Helper()
 
 				fnt := mocks.NewRequestFunctionsMock(t)
-				fnt.EXPECT().Header("Content-Type").Return("application/json")
-				fnt.EXPECT().Body().Return([]byte(`{"foobar": "foo"}`))
+				fnt.EXPECT().Body().Return(map[string]any{"foobar": "foo"})
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: fnt})
 			},
@@ -240,8 +193,7 @@ func TestExtractBodyParameter(t *testing.T) {
 				t.Helper()
 
 				fnt := mocks.NewRequestFunctionsMock(t)
-				fnt.EXPECT().Header("Content-Type").Return("application/x-www-form-urlencoded")
-				fnt.EXPECT().Body().Return([]byte(`foobar=foo`))
+				fnt.EXPECT().Body().Return(map[string]any{"foobar": []string{"foo"}})
 
 				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: fnt})
 			},

--- a/internal/rules/mechanisms/contenttype/decoder.go
+++ b/internal/rules/mechanisms/contenttype/decoder.go
@@ -33,6 +33,8 @@ func NewDecoder(contentType string) (Decoder, error) {
 		return JSONDecoder{}, nil
 	case strings.Contains(contentType, "application/x-www-form-urlencoded"):
 		return WWWFormUrlencodedDecoder{}, nil
+	case strings.Contains(contentType, "yaml"):
+		return YAMLDecoder{}, nil
 	default:
 		return nil, ErrUnsupportedContentType
 	}

--- a/internal/rules/mechanisms/contenttype/yaml_decoder.go
+++ b/internal/rules/mechanisms/contenttype/yaml_decoder.go
@@ -1,0 +1,14 @@
+package contenttype
+
+import "gopkg.in/yaml.v3"
+
+type YAMLDecoder struct{}
+
+func (YAMLDecoder) Decode(rawData []byte) (map[string]any, error) {
+	var mapData map[string]any
+	if err := yaml.Unmarshal(rawData, &mapData); err != nil {
+		return nil, err
+	}
+
+	return mapData, nil
+}


### PR DESCRIPTION
## Related issue(s)

closes #1051

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

This PR exposes the `Request.Body()` function, which depending on the `Content-Type` header returns either a string, or a structured object as a map. Latter is available if the MIME subtype set in the `Content-Type` header is either `json` or `string`, or the MIME type is `application/x-www-form-urlencoded`. In latter case the values in the returned map are string arrays. 

E.g. if the request body is set to 

`grant_type=password&username=johndoe&password=A3ddj3w`,

the aforesaid map can be represented as the following JSON object: 

`{"grant_type": ["password"], "username": ["johndoe"], "password": ["A3ddj3w"]}`
