### PR TITLE
feat: Opt-In for url-encoded slashes in URL paths

### DIFF
--- a/charts/heimdall/crds/ruleset.yaml
+++ b/charts/heimdall/crds/ruleset.yaml
@@ -62,6 +62,15 @@ spec:
                         description: The identifier of the rule
                         type: string
                         maxLength: 128
+                      allow_encoded_slashes:
+                        description: Defines how to handle url-encoded slashes in url paths while matching and forwarding the requests
+                        type: string
+                        default: off
+                        maxLength: 10
+                        enum:
+                          - off
+                          - on
+                          - no_decode
                       match:
                         description: How to match the rule
                         type: object

--- a/charts/heimdall/crds/ruleset.yaml
+++ b/charts/heimdall/crds/ruleset.yaml
@@ -65,12 +65,12 @@ spec:
                       allow_encoded_slashes:
                         description: Defines how to handle url-encoded slashes in url paths while matching and forwarding the requests
                         type: string
-                        default: off
+                        default: "off"
                         maxLength: 10
                         enum:
-                          - off
-                          - on
-                          - no_decode
+                          - "off"
+                          - "on"
+                          - "no_decode"
                       match:
                         description: How to match the rule
                         type: object

--- a/docs/content/docs/configuration/rules/configuration.adoc
+++ b/docs/content/docs/configuration/rules/configuration.adoc
@@ -244,7 +244,7 @@ In principle, a rule set is just a list of rules with some additional meta infor
 
 * *`version`*: _string_ (mandatory)
 +
-The version schema of the `RuleSet`. The current version of heimdall supports only the version `1`.
+The version schema of the `RuleSet`. The current version of heimdall supports only the version `1alpha3`.
 
 * *`name`*: _string_ (optional)
 +

--- a/docs/content/docs/configuration/rules/configuration.adoc
+++ b/docs/content/docs/configuration/rules/configuration.adoc
@@ -49,6 +49,17 @@ Which strategy to use for matching of the value, provided in the `url` property.
 * `\https://mydomain.com/<{foo*,bar*}>` matches `\https://mydomain.com/foo` or `\https://mydomain.com/bar` and doesn't match `\https://mydomain.com/any`.
 ====
 
+* *`allow_encoded_slashes`*: _string_ (optional)
++
+Defines how to handle url-encoded slashes in url paths while matching and forwarding the requests. Can be set to the one of the following values, defaulting to `off`:
+
+** *`off`* - Reject requests containing encoded slashes. Means, if the request URL contains an url-encoded slash (`%2F`), the rule will not match it.
+** *`on`* - Accept requests using encoded slashes, decoding them and making it transparent for the rules and the upstream url. That is, the `%2F` becomes a `/` and will be treated as such in all places.
+** *`no_decode`* - Accept requests using encoded slashes, but not touching them and showing them to the rules and the upstream. That is, the `%2F` just remains as is.
+
++
+CAUTION: Since heimdall and the upstream service may treat the url-encoded slashes differently, accepting requests with url-encoded slashes can, depending on your rules, lead to https://cwe.mitre.org/data/definitions/436.html[Interpretation Conflict] vulnerabilities, resulting in privilege escalations.
+
 * *`methods`*: _string array_ (optional)
 +
 Which HTTP methods (`GET`, `POST`, `PATCH`, etc) are allowed for the matched URL. If not specified, every request to that URL will result in `405 Method Not Allowed` response from heimdall. If all methods should be allowed, one can use a special `ALL` placeholder. If all, except some specific methods should be allowed, one can specify `ALL` and remove specific methods by adding the `!` sign to the to be removed method. In that case you have to specify the value in braces. See also examples below.

--- a/docs/content/docs/configuration/rules/configuration.adoc
+++ b/docs/content/docs/configuration/rules/configuration.adoc
@@ -58,7 +58,7 @@ Defines how to handle url-encoded slashes in url paths while matching and forwar
 ** *`no_decode`* - Accept requests using encoded slashes, but not touching them and showing them to the rules and the upstream. That is, the `%2F` just remains as is.
 
 +
-CAUTION: Since heimdall and the upstream service may treat the url-encoded slashes differently, accepting requests with url-encoded slashes can, depending on your rules, lead to https://cwe.mitre.org/data/definitions/436.html[Interpretation Conflict] vulnerabilities, resulting in privilege escalations.
+CAUTION: Since the proxy integrating with heimdall, heimdall by itself and the upstream service all may treat the url-encoded slashes differently, accepting requests with url-encoded slashes can, depending on your rules, lead to https://cwe.mitre.org/data/definitions/436.html[Interpretation Conflict] vulnerabilities, resulting in privilege escalations.
 
 * *`methods`*: _string array_ (optional)
 +

--- a/internal/handler/requestcontext/extract_url.go
+++ b/internal/handler/requestcontext/extract_url.go
@@ -42,7 +42,7 @@ func extractURL(req *http.Request) *url.URL {
 
 	if val := req.Header.Get("X-Forwarded-Uri"); len(val) != 0 {
 		if forwardedURI, err := url.Parse(val); err == nil {
-			rawPath = forwardedURI.Path
+			rawPath = forwardedURI.EscapedPath()
 			query = forwardedURI.Query().Encode()
 		}
 	} else {
@@ -50,7 +50,7 @@ func extractURL(req *http.Request) *url.URL {
 	}
 
 	if len(rawPath) == 0 {
-		rawPath = req.URL.Path
+		rawPath = req.URL.EscapedPath()
 	}
 
 	if len(query) == 0 {
@@ -63,6 +63,7 @@ func extractURL(req *http.Request) *url.URL {
 		Scheme:   proto,
 		Host:     host,
 		Path:     path,
+		RawPath:  rawPath,
 		RawQuery: query,
 	}
 }

--- a/internal/handler/requestcontext/extract_url_test.go
+++ b/internal/handler/requestcontext/extract_url_test.go
@@ -17,12 +17,13 @@
 package requestcontext
 
 import (
+	"context"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractURL(t *testing.T) {
@@ -46,7 +47,7 @@ func TestExtractURL(t *testing.T) {
 
 				assert.Equal(t, "https", extracted.Scheme)
 				assert.Equal(t, "heimdall.test.local", extracted.Host)
-				assert.Equal(t, "/test", extracted.Path)
+				assert.Equal(t, "/test%2Ffoo/bar/%5Bval%5D", extracted.EscapedPath())
 				assert.Equal(t, url.Values{"foo": []string{"bar"}}, extracted.Query())
 			},
 		},
@@ -63,7 +64,7 @@ func TestExtractURL(t *testing.T) {
 
 				assert.Equal(t, "http", extracted.Scheme)
 				assert.Equal(t, "foobar", extracted.Host)
-				assert.Equal(t, "/test", extracted.Path)
+				assert.Equal(t, "/test%2Ffoo/bar/%5Bval%5D", extracted.EscapedPath())
 				assert.Equal(t, url.Values{"foo": []string{"bar"}}, extracted.Query())
 			},
 		},
@@ -72,7 +73,7 @@ func TestExtractURL(t *testing.T) {
 			configureRequest: func(t *testing.T, req *http.Request) {
 				t.Helper()
 
-				req.Header.Set("X-Forwarded-Path", "foobar")
+				req.Header.Set("X-Forwarded-Path", "/bar%2Ftest/foo/%5Bval%5D")
 				req.URL.RawQuery = url.Values{"foo": []string{"bar"}}.Encode()
 			},
 			assert: func(t *testing.T, extracted *url.URL) {
@@ -80,7 +81,7 @@ func TestExtractURL(t *testing.T) {
 
 				assert.Equal(t, "http", extracted.Scheme)
 				assert.Equal(t, "heimdall.test.local", extracted.Host)
-				assert.Equal(t, "foobar", extracted.Path)
+				assert.Equal(t, "/bar%2Ftest/foo/%5Bval%5D", extracted.EscapedPath())
 				assert.Equal(t, url.Values{"foo": []string{"bar"}}, extracted.Query())
 			},
 		},
@@ -89,7 +90,7 @@ func TestExtractURL(t *testing.T) {
 			configureRequest: func(t *testing.T, req *http.Request) {
 				t.Helper()
 
-				req.Header.Set("X-Forwarded-Uri", "/bar?bar=foo")
+				req.Header.Set("X-Forwarded-Uri", "/bar%2Ftest/foo/%5Bval%5D?bar=foo")
 				req.URL.RawQuery = url.Values{"foo": []string{"bar"}}.Encode()
 			},
 			assert: func(t *testing.T, extracted *url.URL) {
@@ -97,14 +98,20 @@ func TestExtractURL(t *testing.T) {
 
 				assert.Equal(t, "http", extracted.Scheme)
 				assert.Equal(t, "heimdall.test.local", extracted.Host)
-				assert.Equal(t, "/bar", extracted.Path)
+				assert.Equal(t, "/bar%2Ftest/foo/%5Bval%5D", extracted.EscapedPath())
 				assert.Equal(t, url.Values{"bar": []string{"foo"}}, extracted.Query())
 			},
 		},
 	} {
 		t.Run("case="+tc.uc, func(t *testing.T) {
 			// GIVEN
-			req := httptest.NewRequest(http.MethodGet, "http://heimdall.test.local/test", nil)
+			req, err := http.NewRequestWithContext(
+				context.TODO(),
+				http.MethodGet,
+				"http://heimdall.test.local/test%2Ffoo/bar/%5Bval%5D",
+				nil,
+			)
+			require.NoError(t, err)
 
 			tc.configureRequest(t, req)
 

--- a/internal/rules/config/backend.go
+++ b/internal/rules/config/backend.go
@@ -32,6 +32,7 @@ func (f *Backend) CreateURL(value *url.URL) *url.URL {
 		Scheme:   value.Scheme,
 		Host:     f.Host,
 		Path:     value.Path,
+		RawPath:  value.RawPath,
 		RawQuery: value.RawQuery,
 	}
 

--- a/internal/rules/config/decoder.go
+++ b/internal/rules/config/decoder.go
@@ -18,6 +18,10 @@ package config
 
 import (
 	"github.com/mitchellh/mapstructure"
+
+	"github.com/dadrus/heimdall/internal/heimdall"
+	"github.com/dadrus/heimdall/internal/validation"
+	"github.com/dadrus/heimdall/internal/x/errorchain"
 )
 
 func DecodeConfig(input any, output any) error {
@@ -35,5 +39,15 @@ func DecodeConfig(input any, output any) error {
 		return err
 	}
 
-	return dec.Decode(input)
+	if err = dec.Decode(input); err != nil {
+		return errorchain.NewWithMessage(heimdall.ErrConfiguration,
+			"failed decoding ruleset config").CausedBy(err)
+	}
+
+	if err = validation.ValidateStruct(output); err != nil {
+		return errorchain.NewWithMessage(heimdall.ErrConfiguration,
+			"failed validating ruleset config").CausedBy(err)
+	}
+
+	return nil
 }

--- a/internal/rules/config/parser.go
+++ b/internal/rules/config/parser.go
@@ -81,7 +81,9 @@ func parseYAML(reader io.Reader, envUsageEnabled bool) (*RuleSet, error) {
 		return nil, err
 	}
 
-	err := DecodeConfig(rawConfig, &ruleSet)
+	if err := DecodeConfig(rawConfig, &ruleSet); err != nil {
+		return nil, err
+	}
 
-	return &ruleSet, err
+	return &ruleSet, nil
 }

--- a/internal/rules/config/parser_test.go
+++ b/internal/rules/config/parser_test.go
@@ -76,6 +76,21 @@ func TestParseRules(t *testing.T) {
 			},
 		},
 		{
+			uc:          "JSON content type with validation error",
+			contentType: "application/json",
+			content: []byte(`{
+"version": "1",
+"name": "foo",
+"rules": [{"id": "bar", "allow_encoded_slashes": "foo"}]
+}`),
+			assert: func(t *testing.T, err error, ruleSet *RuleSet) {
+				t.Helper()
+
+				require.ErrorIs(t, err, heimdall.ErrConfiguration)
+				require.Nil(t, ruleSet)
+			},
+		},
+		{
 			uc:          "JSON content type and empty contents",
 			contentType: "application/json",
 			assert: func(t *testing.T, err error, ruleSet *RuleSet) {
@@ -93,6 +108,7 @@ version: "1"
 name: foo
 rules:
 - id: bar
+  allow_encoded_slashes: off
 `),
 			assert: func(t *testing.T, err error, ruleSet *RuleSet) {
 				t.Helper()
@@ -102,6 +118,23 @@ rules:
 				assert.Equal(t, "1", ruleSet.Version)
 				assert.Equal(t, "foo", ruleSet.Name)
 				assert.Len(t, ruleSet.Rules, 1)
+			},
+		},
+		{
+			uc:          "YAML content type and validation error",
+			contentType: "application/yaml",
+			content: []byte(`
+version: "1"
+name: foo
+rules:
+- id: bar
+  allow_encoded_slashes: foo
+`),
+			assert: func(t *testing.T, err error, ruleSet *RuleSet) {
+				t.Helper()
+
+				require.ErrorIs(t, err, heimdall.ErrConfiguration)
+				require.Nil(t, ruleSet)
 			},
 		},
 		{

--- a/internal/rules/config/rule.go
+++ b/internal/rules/config/rule.go
@@ -20,13 +20,22 @@ import (
 	"github.com/dadrus/heimdall/internal/config"
 )
 
+type EncodedSlashesHandling string
+
+const (
+	EncodedSlashesOff      EncodedSlashesHandling = "off"
+	EncodedSlashesOn       EncodedSlashesHandling = "on"
+	EncodedSlashesNoDecode EncodedSlashesHandling = "no_decode"
+)
+
 type Rule struct {
-	ID           string                   `json:"id"         yaml:"id"`
-	RuleMatcher  Matcher                  `json:"match"      yaml:"match"`
-	Backend      *Backend                 `json:"forward_to" yaml:"forward_to"`
-	Methods      []string                 `json:"methods"    yaml:"methods"`
-	Execute      []config.MechanismConfig `json:"execute"    yaml:"execute"`
-	ErrorHandler []config.MechanismConfig `json:"on_error"   yaml:"on_error"`
+	ID                     string                   `json:"id"                    yaml:"id"`
+	EncodedSlashesHandling EncodedSlashesHandling   `json:"allow_encoded_slashes" yaml:"allow_encoded_slashes"  validate:"omitempty,oneof=off on no_decode"` //nolint:lll
+	RuleMatcher            Matcher                  `json:"match"                 yaml:"match"`
+	Backend                *Backend                 `json:"forward_to"            yaml:"forward_to"`
+	Methods                []string                 `json:"methods"               yaml:"methods"`
+	Execute                []config.MechanismConfig `json:"execute"               yaml:"execute"`
+	ErrorHandler           []config.MechanismConfig `json:"on_error"              yaml:"on_error"`
 }
 
 func (in *Rule) DeepCopyInto(out *Rule) {

--- a/internal/rules/config/rule.go
+++ b/internal/rules/config/rule.go
@@ -30,7 +30,7 @@ const (
 
 type Rule struct {
 	ID                     string                   `json:"id"                    yaml:"id"`
-	EncodedSlashesHandling EncodedSlashesHandling   `json:"allow_encoded_slashes" yaml:"allow_encoded_slashes"  validate:"omitempty,oneof=off on no_decode"` //nolint:lll
+	EncodedSlashesHandling EncodedSlashesHandling   `json:"allow_encoded_slashes" yaml:"allow_encoded_slashes" validate:"omitempty,oneof=off on no_decode"` //nolint:lll,tagalign
 	RuleMatcher            Matcher                  `json:"match"                 yaml:"match"`
 	Backend                *Backend                 `json:"forward_to"            yaml:"forward_to"`
 	Methods                []string                 `json:"methods"               yaml:"methods"`

--- a/internal/rules/config/rule_set.go
+++ b/internal/rules/config/rule_set.go
@@ -35,7 +35,7 @@ type RuleSet struct {
 
 	Version string `json:"version" yaml:"version"`
 	Name    string `json:"name"    yaml:"name"`
-	Rules   []Rule `json:"rules"   yaml:"rules"     validate:"dive"`
+	Rules   []Rule `json:"rules"   validate:"dive" yaml:"rules"`
 }
 
 func (rs RuleSet) VerifyPathPrefix(prefix string) error {

--- a/internal/rules/config/rule_set.go
+++ b/internal/rules/config/rule_set.go
@@ -35,7 +35,7 @@ type RuleSet struct {
 
 	Version string `json:"version" yaml:"version"`
 	Name    string `json:"name"    yaml:"name"`
-	Rules   []Rule `json:"rules"   yaml:"rules"`
+	Rules   []Rule `json:"rules"   yaml:"rules"     validate:"dive"`
 }
 
 func (rs RuleSet) VerifyPathPrefix(prefix string) error {

--- a/internal/rules/config/url_rewriter.go
+++ b/internal/rules/config/url_rewriter.go
@@ -78,7 +78,19 @@ func (r *URLRewriter) Rewrite(value *url.URL) {
 		func() string { return r.Scheme },
 		func() string { return value.Scheme },
 	)
-	value.Path = r.transformPath(value.Path)
+
+	rawPath := r.transformPath(value.EscapedPath())
+	if len(value.RawPath) != 0 {
+		// if the original url path had url encoded parts
+		value.RawPath = rawPath
+	}
+
+	value.Path, _ = url.PathUnescape(rawPath)
+	if value.Path != rawPath {
+		// if the new path contains url encoded parts
+		value.RawPath = rawPath
+	}
+
 	value.RawQuery = r.transformQuery(value.RawQuery)
 }
 

--- a/internal/rules/config/url_rewriter_test.go
+++ b/internal/rules/config/url_rewriter_test.go
@@ -91,14 +91,26 @@ func TestURLRewriterRewrite(t *testing.T) {
 		{
 			uc:       "cut only the urlencoded path prefix",
 			original: "http://foo.bar/%5Bid%5D/bar?baz=bar&bar=foo&foo=baz",
-			rewriter: &URLRewriter{PathPrefixToCut: "/[id]"},
+			rewriter: &URLRewriter{PathPrefixToCut: "/%5Bid%5D"},
 			expected: "http://foo.bar/bar?baz=bar&bar=foo&foo=baz",
+		},
+		{
+			uc:       "cut only the urlencoded path prefix with encoded slash",
+			original: "http://foo.bar/foo%2Ftest/%5Bid%5D/bar?baz=bar&bar=foo&foo=baz",
+			rewriter: &URLRewriter{PathPrefixToCut: "/foo%2Ftest"},
+			expected: "http://foo.bar/%5Bid%5D/bar?baz=bar&bar=foo&foo=baz",
 		},
 		{
 			uc:       "add only a path prefix",
 			original: "http://foo.bar/foo/bar?baz=bar&bar=foo&foo=baz",
 			rewriter: &URLRewriter{PathPrefixToAdd: "/baz"},
 			expected: "http://foo.bar/baz/foo/bar?baz=bar&bar=foo&foo=baz",
+		},
+		{
+			uc:       "add a path prefix with urlencoded slash",
+			original: "http://foo.bar/foo/bar?baz=bar&bar=foo&foo=baz",
+			rewriter: &URLRewriter{PathPrefixToAdd: "/foo%2Ftest"},
+			expected: "http://foo.bar/foo%2Ftest/foo/bar?baz=bar&bar=foo&foo=baz",
 		},
 		{
 			uc:       "remove only a query param",

--- a/internal/rules/rule_factory_impl.go
+++ b/internal/rules/rule_factory_impl.go
@@ -218,7 +218,12 @@ func (f *ruleFactory) CreateRule(version, srcID string, ruleConfig config2.Rule)
 	}
 
 	return &ruleImpl{
-		id:         ruleConfig.ID,
+		id: ruleConfig.ID,
+		encodedSlashesHandling: x.IfThenElse(
+			len(ruleConfig.EncodedSlashesHandling) != 0,
+			ruleConfig.EncodedSlashesHandling,
+			config2.EncodedSlashesOff,
+		),
 		urlMatcher: matcher,
 		backend:    ruleConfig.Backend,
 		methods:    methods,
@@ -346,14 +351,15 @@ func (f *ruleFactory) initWithDefaultRule(ruleConfig *config.DefaultRule, logger
 	}
 
 	f.defaultRule = &ruleImpl{
-		id:        "default",
-		methods:   methods,
-		srcID:     "config",
-		isDefault: true,
-		sc:        authenticators,
-		sh:        subHandlers,
-		fi:        finalizers,
-		eh:        errorHandlers,
+		id:                     "default",
+		encodedSlashesHandling: config2.EncodedSlashesOff,
+		methods:                methods,
+		srcID:                  "config",
+		isDefault:              true,
+		sc:                     authenticators,
+		sh:                     subHandlers,
+		fi:                     finalizers,
+		eh:                     errorHandlers,
 	}
 
 	f.hasDefaultRule = true

--- a/internal/rules/rule_impl_test.go
+++ b/internal/rules/rule_impl_test.go
@@ -110,7 +110,7 @@ func TestRuleMatchURL(t *testing.T) {
 			matcher: func(t *testing.T) patternmatcher.PatternMatcher {
 				t.Helper()
 
-				matcher, err := patternmatcher.NewPatternMatcher("glob", "http://foo.bar/%5Bid%5D/baz")
+				matcher, err := patternmatcher.NewPatternMatcher("glob", "http://foo.bar/[id]/baz")
 				require.NoError(t, err)
 
 				return matcher
@@ -145,12 +145,12 @@ func TestRuleMatchURL(t *testing.T) {
 			matcher: func(t *testing.T) patternmatcher.PatternMatcher {
 				t.Helper()
 
-				matcher, err := patternmatcher.NewPatternMatcher("glob", "http://foo.bar/foo/baz")
+				matcher, err := patternmatcher.NewPatternMatcher("glob", "http://foo.bar/foo/baz/[id]")
 				require.NoError(t, err)
 
 				return matcher
 			},
-			toBeMatched: "http://foo.bar/foo%2Fbaz",
+			toBeMatched: "http://foo.bar/foo%2Fbaz/%5Bid%5D",
 			assert: func(t *testing.T, matched bool) {
 				t.Helper()
 
@@ -163,12 +163,12 @@ func TestRuleMatchURL(t *testing.T) {
 			matcher: func(t *testing.T) patternmatcher.PatternMatcher {
 				t.Helper()
 
-				matcher, err := patternmatcher.NewPatternMatcher("glob", "http://foo.bar/foo%2Fbaz")
+				matcher, err := patternmatcher.NewPatternMatcher("glob", "http://foo.bar/foo%2Fbaz/[id]")
 				require.NoError(t, err)
 
 				return matcher
 			},
-			toBeMatched: "http://foo.bar/foo%2Fbaz",
+			toBeMatched: "http://foo.bar/foo%2Fbaz/%5Bid%5D",
 			assert: func(t *testing.T, matched bool) {
 				t.Helper()
 

--- a/internal/rules/rule_impl_test.go
+++ b/internal/rules/rule_impl_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dadrus/heimdall/internal/rules/mocks"
 	"github.com/dadrus/heimdall/internal/rules/patternmatcher"
 	"github.com/dadrus/heimdall/internal/rules/rule"
+	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/testsupport"
 )
 
@@ -81,10 +82,11 @@ func TestRuleMatchURL(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
-		uc          string
-		matcher     func(t *testing.T) patternmatcher.PatternMatcher
-		toBeMatched string
-		assert      func(t *testing.T, matched bool)
+		uc            string
+		slashHandling config.EncodedSlashesHandling
+		matcher       func(t *testing.T) patternmatcher.PatternMatcher
+		toBeMatched   string
+		assert        func(t *testing.T, matched bool)
 	}{
 		{
 			uc: "matches",
@@ -108,12 +110,65 @@ func TestRuleMatchURL(t *testing.T) {
 			matcher: func(t *testing.T) patternmatcher.PatternMatcher {
 				t.Helper()
 
-				matcher, err := patternmatcher.NewPatternMatcher("glob", "http://foo.bar/[id]/baz")
+				matcher, err := patternmatcher.NewPatternMatcher("glob", "http://foo.bar/%5Bid%5D/baz")
 				require.NoError(t, err)
 
 				return matcher
 			},
 			toBeMatched: "http://foo.bar/%5Bid%5D/baz",
+			assert: func(t *testing.T, matched bool) {
+				t.Helper()
+
+				assert.True(t, matched)
+			},
+		},
+		{
+			uc: "doesn't match with urlencoded slash in path",
+			matcher: func(t *testing.T) patternmatcher.PatternMatcher {
+				t.Helper()
+
+				matcher, err := patternmatcher.NewPatternMatcher("glob", "http://foo.bar/foo%2Fbaz")
+				require.NoError(t, err)
+
+				return matcher
+			},
+			toBeMatched: "http://foo.bar/foo%2Fbaz",
+			assert: func(t *testing.T, matched bool) {
+				t.Helper()
+
+				assert.False(t, matched)
+			},
+		},
+		{
+			uc:            "matches with urlencoded slash in path if allowed with decoding",
+			slashHandling: config.EncodedSlashesOn,
+			matcher: func(t *testing.T) patternmatcher.PatternMatcher {
+				t.Helper()
+
+				matcher, err := patternmatcher.NewPatternMatcher("glob", "http://foo.bar/foo/baz")
+				require.NoError(t, err)
+
+				return matcher
+			},
+			toBeMatched: "http://foo.bar/foo%2Fbaz",
+			assert: func(t *testing.T, matched bool) {
+				t.Helper()
+
+				assert.True(t, matched)
+			},
+		},
+		{
+			uc:            "matches with urlencoded slash in path if allowed without decoding",
+			slashHandling: config.EncodedSlashesNoDecode,
+			matcher: func(t *testing.T) patternmatcher.PatternMatcher {
+				t.Helper()
+
+				matcher, err := patternmatcher.NewPatternMatcher("glob", "http://foo.bar/foo%2Fbaz")
+				require.NoError(t, err)
+
+				return matcher
+			},
+			toBeMatched: "http://foo.bar/foo%2Fbaz",
 			assert: func(t *testing.T, matched bool) {
 				t.Helper()
 
@@ -157,7 +212,10 @@ func TestRuleMatchURL(t *testing.T) {
 	} {
 		t.Run("case="+tc.uc, func(t *testing.T) {
 			// GIVEN
-			rul := &ruleImpl{urlMatcher: tc.matcher(t)}
+			rul := &ruleImpl{
+				urlMatcher:             tc.matcher(t),
+				encodedSlashesHandling: x.IfThenElse(len(tc.slashHandling) != 0, tc.slashHandling, config.EncodedSlashesOff),
+			}
 
 			tbmu, err := url.Parse(tc.toBeMatched)
 			require.NoError(t, err)
@@ -177,6 +235,7 @@ func TestRuleExecute(t *testing.T) {
 	for _, tc := range []struct {
 		uc             string
 		backend        *config.Backend
+		slashHandling  config.EncodedSlashesHandling
 		configureMocks func(
 			t *testing.T,
 			ctx *heimdallmocks.ContextMock,
@@ -325,7 +384,7 @@ func TestRuleExecute(t *testing.T) {
 			},
 		},
 		{
-			uc: "all handler succeed",
+			uc: "all handler succeed with disallowed urlencoded slashes",
 			backend: &config.Backend{
 				Host: "foo.bar",
 			},
@@ -341,13 +400,106 @@ func TestRuleExecute(t *testing.T) {
 				authorizer.EXPECT().Execute(ctx, sub).Return(nil)
 				finalizer.EXPECT().Execute(ctx, sub).Return(nil)
 
-				ctx.EXPECT().Request().Return(&heimdall.Request{URL: &url.URL{Scheme: "http", Host: "foo.local", Path: "/api/v1/foo"}})
+				targetURL, _ := url.Parse("http://foo.local/api/v1/foo%5Bid%5D")
+				ctx.EXPECT().Request().Return(&heimdall.Request{URL: targetURL})
 			},
 			assert: func(t *testing.T, err error, backend rule.Backend) {
 				t.Helper()
 
 				require.NoError(t, err)
-				assert.Equal(t, &url.URL{Scheme: "http", Host: "foo.bar", Path: "/api/v1/foo"}, backend.URL())
+
+				expectedURL, _ := url.Parse("http://foo.bar/api/v1/foo%5Bid%5D")
+				assert.Equal(t, expectedURL, backend.URL())
+			},
+		},
+		{
+			uc:            "all handler succeed with urlencoded slashes on without urlencoded slash",
+			slashHandling: config.EncodedSlashesOn,
+			backend: &config.Backend{
+				Host: "foo.bar",
+			},
+			configureMocks: func(t *testing.T, ctx *heimdallmocks.ContextMock, authenticator *mocks.SubjectCreatorMock,
+				authorizer *mocks.SubjectHandlerMock, finalizer *mocks.SubjectHandlerMock,
+				_ *mocks.ErrorHandlerMock,
+			) {
+				t.Helper()
+
+				sub := &subject.Subject{ID: "Foo"}
+
+				authenticator.EXPECT().Execute(ctx).Return(sub, nil)
+				authorizer.EXPECT().Execute(ctx, sub).Return(nil)
+				finalizer.EXPECT().Execute(ctx, sub).Return(nil)
+
+				targetURL, _ := url.Parse("http://foo.local/api/v1/foo%5Bid%5D")
+				ctx.EXPECT().Request().Return(&heimdall.Request{URL: targetURL})
+			},
+			assert: func(t *testing.T, err error, backend rule.Backend) {
+				t.Helper()
+
+				require.NoError(t, err)
+
+				expectedURL, _ := url.Parse("http://foo.bar/api/v1/foo%5Bid%5D")
+				assert.Equal(t, expectedURL, backend.URL())
+			},
+		},
+		{
+			uc:            "all handler succeed with urlencoded slashes on with urlencoded slash",
+			slashHandling: config.EncodedSlashesOn,
+			backend: &config.Backend{
+				Host: "foo.bar",
+			},
+			configureMocks: func(t *testing.T, ctx *heimdallmocks.ContextMock, authenticator *mocks.SubjectCreatorMock,
+				authorizer *mocks.SubjectHandlerMock, finalizer *mocks.SubjectHandlerMock,
+				_ *mocks.ErrorHandlerMock,
+			) {
+				t.Helper()
+
+				sub := &subject.Subject{ID: "Foo"}
+
+				authenticator.EXPECT().Execute(ctx).Return(sub, nil)
+				authorizer.EXPECT().Execute(ctx, sub).Return(nil)
+				finalizer.EXPECT().Execute(ctx, sub).Return(nil)
+
+				targetURL, _ := url.Parse("http://foo.local/api%2Fv1/foo%5Bid%5D")
+				ctx.EXPECT().Request().Return(&heimdall.Request{URL: targetURL})
+			},
+			assert: func(t *testing.T, err error, backend rule.Backend) {
+				t.Helper()
+
+				require.NoError(t, err)
+
+				expectedURL, _ := url.Parse("http://foo.bar/api/v1/foo%5Bid%5D")
+				assert.Equal(t, expectedURL, backend.URL())
+			},
+		},
+		{
+			uc:            "all handler succeed with urlencoded slashes on with urlencoded slash but without decoding it",
+			slashHandling: config.EncodedSlashesNoDecode,
+			backend: &config.Backend{
+				Host: "foo.bar",
+			},
+			configureMocks: func(t *testing.T, ctx *heimdallmocks.ContextMock, authenticator *mocks.SubjectCreatorMock,
+				authorizer *mocks.SubjectHandlerMock, finalizer *mocks.SubjectHandlerMock,
+				_ *mocks.ErrorHandlerMock,
+			) {
+				t.Helper()
+
+				sub := &subject.Subject{ID: "Foo"}
+
+				authenticator.EXPECT().Execute(ctx).Return(sub, nil)
+				authorizer.EXPECT().Execute(ctx, sub).Return(nil)
+				finalizer.EXPECT().Execute(ctx, sub).Return(nil)
+
+				targetURL, _ := url.Parse("http://foo.local/api%2Fv1/foo%5Bid%5D")
+				ctx.EXPECT().Request().Return(&heimdall.Request{URL: targetURL})
+			},
+			assert: func(t *testing.T, err error, backend rule.Backend) {
+				t.Helper()
+
+				require.NoError(t, err)
+
+				expectedURL, _ := url.Parse("http://foo.bar/api%2Fv1/foo%5Bid%5D")
+				assert.Equal(t, expectedURL, backend.URL())
 			},
 		},
 		{
@@ -368,13 +520,16 @@ func TestRuleExecute(t *testing.T) {
 				authorizer.EXPECT().Execute(ctx, sub).Return(nil)
 				finalizer.EXPECT().Execute(ctx, sub).Return(nil)
 
-				ctx.EXPECT().Request().Return(&heimdall.Request{URL: &url.URL{Scheme: "http", Host: "foo.local", Path: "/api/v1/foo"}})
+				targetURL, _ := url.Parse("http://foo.local/api/v1/foo")
+				ctx.EXPECT().Request().Return(&heimdall.Request{URL: targetURL})
 			},
 			assert: func(t *testing.T, err error, backend rule.Backend) {
 				t.Helper()
 
 				require.NoError(t, err)
-				assert.Equal(t, &url.URL{Scheme: "http", Host: "foo.bar", Path: "/foo"}, backend.URL())
+
+				expectedURL, _ := url.Parse("http://foo.bar/foo")
+				assert.Equal(t, expectedURL, backend.URL())
 			},
 		},
 	} {
@@ -389,11 +544,12 @@ func TestRuleExecute(t *testing.T) {
 			errHandler := mocks.NewErrorHandlerMock(t)
 
 			rul := &ruleImpl{
-				backend: tc.backend,
-				sc:      compositeSubjectCreator{authenticator},
-				sh:      compositeSubjectHandler{authorizer},
-				fi:      compositeSubjectHandler{finalizer},
-				eh:      compositeErrorHandler{errHandler},
+				backend:                tc.backend,
+				encodedSlashesHandling: x.IfThenElse(len(tc.slashHandling) != 0, tc.slashHandling, config.EncodedSlashesOff),
+				sc:                     compositeSubjectCreator{authenticator},
+				sh:                     compositeSubjectHandler{authorizer},
+				fi:                     compositeSubjectHandler{finalizer},
+				eh:                     compositeErrorHandler{errHandler},
 			}
 
 			tc.configureMocks(t, ctx, authenticator, authorizer, finalizer, errHandler)


### PR DESCRIPTION
## Related issue(s)

closes #1070

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

This PR implements an explicit opt-in for url-encoded slashes in URL paths, used while matching a request in all operation modes, as well as when forwarding the request to the upstream service in proxy mode.

The new rule-level configuration property is named `allow_encoded_slashes` and can be set to the following values:
* `off` - Reject requests containing encoded slashes. Means, if the request URL contains an url-encoded slash (`%2F`), the rule will not match it. This is also the default setting, if the property is not configured explicitly.
* `on` - Accept requests using encoded slashes, decoding them and making it transparent for the rules and the upstream url. That is, the `%2F` becomes a `/` and will be treated as such in all places.
* `no_decode` - Accept requests using encoded slashes, but not touching them and showing them to the rules and the upstream. That is, the `%2F` just remains as is.


