### PR TITLE
fix: Accept header usage

### DIFF
--- a/internal/rules/mechanisms/authenticators/jwt_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator.go
@@ -95,8 +95,8 @@ func newJwtAuthenticator(id string, rawConfig map[string]any) (*jwtAuthenticator
 		conf.Endpoint.Headers = make(map[string]string)
 	}
 
-	if _, ok := conf.Endpoint.Headers["Accept-Type"]; !ok {
-		conf.Endpoint.Headers["Accept-Type"] = "application/json"
+	if _, ok := conf.Endpoint.Headers["Accept"]; !ok {
+		conf.Endpoint.Headers["Accept"] = "application/json"
 	}
 
 	if len(conf.Endpoint.Method) == 0 {

--- a/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
@@ -155,8 +155,8 @@ assertions:
 				assert.Equal(t, "http://test.com", auth.e.URL)
 				assert.Equal(t, "GET", auth.e.Method)
 				assert.Len(t, auth.e.Headers, 1)
-				assert.Contains(t, auth.e.Headers, "Accept-Type")
-				assert.Equal(t, "application/json", auth.e.Headers["Accept-Type"])
+				assert.Contains(t, auth.e.Headers, "Accept")
+				assert.Equal(t, "application/json", auth.e.Headers["Accept"])
 
 				// token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
@@ -217,8 +217,8 @@ cache_ttl: 5s`),
 				assert.Equal(t, "http://test.com", auth.e.URL)
 				assert.Equal(t, "GET", auth.e.Method)
 				assert.Len(t, auth.e.Headers, 1)
-				assert.Contains(t, auth.e.Headers, "Accept-Type")
-				assert.Equal(t, "application/json", auth.e.Headers["Accept-Type"])
+				assert.Contains(t, auth.e.Headers, "Accept")
+				assert.Equal(t, "application/json", auth.e.Headers["Accept"])
 
 				// token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
@@ -269,7 +269,7 @@ jwks_endpoint:
   url: http://test.com
   method: POST
   headers:
-    Accept-Type: application/foobar
+    Accept: application/foobar
 jwt_source:
   - header: foo-header
     scheme: foo
@@ -298,8 +298,8 @@ trust_store: ` + trustStorePath),
 				assert.Equal(t, "http://test.com", auth.e.URL)
 				assert.Equal(t, "POST", auth.e.Method)
 				assert.Len(t, auth.e.Headers, 1)
-				assert.Contains(t, auth.e.Headers, "Accept-Type")
-				assert.Equal(t, "application/foobar", auth.e.Headers["Accept-Type"])
+				assert.Contains(t, auth.e.Headers, "Accept")
+				assert.Equal(t, "application/foobar", auth.e.Headers["Accept"])
 
 				// token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)

--- a/internal/rules/oauth2/clientcredentials/clientcredentials.go
+++ b/internal/rules/oauth2/clientcredentials/clientcredentials.go
@@ -154,7 +154,7 @@ func (c *Config) fetchToken(ctx context.Context) (*TokenInfo, error) {
 		AuthStrategy: c,
 		Headers: map[string]string{
 			"Content-Type": "application/x-www-form-urlencoded",
-			"Accept-Type":  "application/json",
+			"Accept":       "application/json",
 		},
 	}
 

--- a/internal/rules/oauth2/clientcredentials/clientcredentials_test.go
+++ b/internal/rules/oauth2/clientcredentials/clientcredentials_test.go
@@ -130,7 +130,7 @@ func TestClientCredentialsToken(t *testing.T) {
 				assert.Equal(t, "bar", clientIDAndSecret[1])
 
 				assert.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
-				assert.Equal(t, "application/json", req.Header.Get("Accept-Type"))
+				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				assert.Equal(t, "client_credentials", req.FormValue("grant_type"))
 				assert.Empty(t, req.FormValue("scope"))
 			},
@@ -180,7 +180,7 @@ func TestClientCredentialsToken(t *testing.T) {
 				assert.Equal(t, "foo", clientIDAndSecret[1])
 
 				assert.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
-				assert.Equal(t, "application/json", req.Header.Get("Accept-Type"))
+				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				assert.Equal(t, "client_credentials", req.FormValue("grant_type"))
 				assert.Empty(t, req.FormValue("scope"))
 			},
@@ -293,7 +293,7 @@ func TestClientCredentialsToken(t *testing.T) {
 				assert.Equal(t, "foo", clientIDAndSecret[1])
 
 				assert.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
-				assert.Equal(t, "application/json", req.Header.Get("Accept-Type"))
+				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				assert.Equal(t, "client_credentials", req.FormValue("grant_type"))
 				scopes := strings.Split(req.FormValue("scope"), " ")
 				assert.Len(t, scopes, 2)
@@ -360,7 +360,7 @@ func TestClientCredentialsToken(t *testing.T) {
 				assert.Equal(t, "foo", clientIDAndSecret[1])
 
 				assert.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
-				assert.Equal(t, "application/json", req.Header.Get("Accept-Type"))
+				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				assert.Equal(t, "client_credentials", req.FormValue("grant_type"))
 				scopes := strings.Split(req.FormValue("scope"), " ")
 				assert.Len(t, scopes, 2)
@@ -415,7 +415,7 @@ func TestClientCredentialsToken(t *testing.T) {
 				assert.Equal(t, "foo", clientIDAndSecret[1])
 
 				assert.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
-				assert.Equal(t, "application/json", req.Header.Get("Accept-Type"))
+				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				assert.Equal(t, "client_credentials", req.FormValue("grant_type"))
 				scopes := strings.Split(req.FormValue("scope"), " ")
 				assert.Len(t, scopes, 2)
@@ -463,7 +463,7 @@ func TestClientCredentialsToken(t *testing.T) {
 				t.Helper()
 
 				assert.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
-				assert.Equal(t, "application/json", req.Header.Get("Accept-Type"))
+				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				assert.Equal(t, "bar foo", req.FormValue("client_id"))
 				assert.Equal(t, "foo bar", req.FormValue("client_secret"))
 				assert.Equal(t, "client_credentials", req.FormValue("grant_type"))
@@ -512,7 +512,7 @@ func TestClientCredentialsToken(t *testing.T) {
 				assert.Equal(t, "foo", clientIDAndSecret[1])
 
 				assert.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
-				assert.Equal(t, "application/json", req.Header.Get("Accept-Type"))
+				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				assert.Equal(t, "client_credentials", req.FormValue("grant_type"))
 			},
 			buildResponse: func(t *testing.T) (any, int) {
@@ -594,7 +594,7 @@ func TestClientCredentialsToken(t *testing.T) {
 				assert.Equal(t, "foo", clientIDAndSecret[1])
 
 				assert.Equal(t, "application/x-www-form-urlencoded", req.Header.Get("Content-Type"))
-				assert.Equal(t, "application/json", req.Header.Get("Accept-Type"))
+				assert.Equal(t, "application/json", req.Header.Get("Accept"))
 				assert.Equal(t, "client_credentials", req.FormValue("grant_type"))
 			},
 			buildResponse: func(t *testing.T) (any, int) {


### PR DESCRIPTION
## Related issue(s)

Not documented. Encountered during the review of #1043 

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have added tests that prove the correctness of my implementation.

## Description

In many places, heimdall implements useful defaults. Among other things, these are HTTP headers. On of such defaults is the `Accept` header, which has unfortunately been set as `Accept-Type`, which just does not exist. In principle, there should not be any issues because of this, as many implementations are just ignoring such headers, especially in m2m contexts.