### PR TITLE
feat: Helm chart supports setting environment variables by referencing either a ConfigMap or a Secret via `envFrom`

### DIFF
--- a/charts/heimdall/README.adoc
+++ b/charts/heimdall/README.adoc
@@ -435,8 +435,8 @@ Environment variables, which should be made available to the heimdall deployment
 
 ```.yaml
 env:
-  OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc
-  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://tempo.tempo.svc.cluster.local:4317
+  OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: grpc
+  OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://tempo.tempo.svc.cluster.local:4317
   EXAMPLE_KEY:
     configMapKeyRef:
       name: example-configmap

--- a/charts/heimdall/README.adoc
+++ b/charts/heimdall/README.adoc
@@ -443,7 +443,7 @@ env:
       key: EXAMPLE_KEY
 ```
 
-a| `{}` (empty array)
+a| `{}` (empty map)
 
 a| `envFrom`
 
@@ -455,7 +455,7 @@ envFrom:
     name: example-configmap
 ```
 
-a| `[]` (empty list)
+a| `[]` (empty array)
 
 a| `extraArgs`
 

--- a/charts/heimdall/README.adoc
+++ b/charts/heimdall/README.adoc
@@ -431,15 +431,31 @@ a| `5`
 
 a| `env`
 
-Environment variables, which should be made available to the heimdall deployment. E.g.
+Environment variables, which should be made available to the heimdall deployment. Variables can be specified as key-value pairs with string values or as an object referencing a ConfigMap or Secret key. E.g.
 
 ```.yaml
 env:
   OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc
   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://tempo.tempo.svc.cluster.local:4317
+  EXAMPLE_KEY:
+    configMapKeyRef:
+      name: example-configmap
+      key: EXAMPLE_KEY
 ```
 
-a| `{}` (empty map)
+a| `{}` (empty array)
+
+a| `envFrom`
+
+Environment variables, which should be made available to the heimdall deployment, but are pulled from a ConfigMap or Secret resource instead of specified directly.
+
+```.yaml
+envFrom:
+- configMapRef:
+    name: example-configmap
+```
+
+a| `[]` (empty list)
 
 a| `extraArgs`
 

--- a/charts/heimdall/templates/heimdall/deployment.yaml
+++ b/charts/heimdall/templates/heimdall/deployment.yaml
@@ -123,8 +123,17 @@ spec:
           env:
           {{- range $key, $val := .Values.env }}
             - name: {{ $key }}
+              {{- if kindIs "string" $val }}
               value: "{{ $val }}"
+              {{- else }}
+              valueFrom:
+                {{- toYaml $val | nindent 16 }}
+              {{- end }}
           {{- end }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           livenessProbe:
             httpGet:

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -151,7 +151,18 @@ admissionController:
   timeoutSeconds: 5
 
 # Configures arbitrary environment variables for the deployment
-env: { }
+# Value can be either a string (propagated to value) or an object (propagated to valueFrom)
+# Example:
+# env:
+#   HEIMDALL_EXAMPLE:
+#     configMapKeyRef:
+#       name: "my-configmap"
+#       key: "EXAMPLE_KEY"
+env: {}
+
+# Configures extra environment to be pulled from referenced configmaps/secrets
+# directly mapped to envFrom
+envFrom: []
 
 # Optional flags for heimdall to use
 extraArgs: []

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -151,13 +151,14 @@ admissionController:
   timeoutSeconds: 5
 
 # Configures arbitrary environment variables for the deployment
-# Value can be either a string (propagated to value) or an object (propagated to valueFrom)
+# The value can be either a string (propagated to value) or an object (propagated to valueFrom)
 # Example:
 # env:
-#   HEIMDALL_EXAMPLE:
+#   ENV_VAR_CONFIGMAP:
 #     configMapKeyRef:
 #       name: "my-configmap"
 #       key: "EXAMPLE_KEY"
+#   ENV_VAR_SIMPLE: "value"
 env: {}
 
 # Configures extra environment to be pulled from referenced configmaps/secrets


### PR DESCRIPTION
## Related issue(s)

No related issue, discussed in discord (https://discord.com/channels/1100447190796742698/1192143563039973529/1192143563039973529).

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [ ] I have referenced an issue describing the bug/feature request.
- [ ] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

Adds the possibility to reference other secrets and configmaps in the heimdall config, in order to consume values from other deployed softwares.
