### PR TITLE
chore: Add security-config for hugo, so that gems of asciidoctor can be loaded in newer hugo-versions

### DIFF
--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -100,3 +100,9 @@ module:
       target: assets/js/bootstrap.bundle.js
     - source: node_modules/bootstrap-icons/font/fonts
       target: static/css/fonts
+security:
+  exec:
+    osEnv:
+      - (?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM|GEM_PATH)$ # Note this GEM_PATH
+    allow:
+      - asciidoctor


### PR DESCRIPTION

## Related issue(s)

n/a

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [X] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [X] I have read the [Security Policy](../SECURITY.md).
- [ ] I have referenced an issue describing the bug/feature request.
- [ ] I have added tests that prove the correctness of my implementation.
- [ ] I have updated the documentation.

## Description
This PR solves problems running asciidoctor through newer versions starting with version 0.91 of hugo as described in https://stackoverflow.com/a/71734790