### PR TITLE
fix: `audience` assertion adheres to RFC-7519, section 4.1.3

### DIFF
--- a/docs/content/docs/configuration/types.adoc
+++ b/docs/content/docs/configuration/types.adoc
@@ -21,7 +21,7 @@ Required scopes given to the client.
 
 * *`audience`*: _string array_ (optional)
 +
-Required entries in the `aud` claim. Both cases, either as whitespace separated string, or a JSON array are considered.
+Values to be matched in the `aud` claim. This assertion evaluates to `true` if at least one entry in the given `audience` array is present in the `aud` claim. Both cases, either as whitespace separated string, or a JSON array are considered.
 
 * *`issuers`*: _string array_ (optional)
 +

--- a/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
@@ -189,7 +189,7 @@ assertions:
 
 				// assertions settings
 				require.NoError(t, auth.a.ScopesMatcher.Match([]string{}))
-				assert.Empty(t, auth.a.TargetAudiences)
+				assert.Empty(t, auth.a.Audiences)
 				assert.Len(t, auth.a.TrustedIssuers, 1)
 				assert.Contains(t, auth.a.TrustedIssuers, "foobar")
 				assert.Len(t, auth.a.AllowedAlgorithms, 6)
@@ -255,7 +255,7 @@ cache_ttl: 5s`),
 
 				// assertions settings
 				require.NoError(t, auth.a.ScopesMatcher.Match([]string{}))
-				assert.Empty(t, auth.a.TargetAudiences)
+				assert.Empty(t, auth.a.Audiences)
 				assert.Len(t, auth.a.TrustedIssuers, 1)
 				assert.Contains(t, auth.a.TrustedIssuers, "foobar")
 				assert.Len(t, auth.a.AllowedAlgorithms, 6)
@@ -343,7 +343,7 @@ trust_store: ` + trustStorePath),
 				// assertions settings
 				assert.NotNil(t, auth.a.ScopesMatcher)
 				require.NoError(t, auth.a.ScopesMatcher.Match([]string{"foo"}))
-				assert.Empty(t, auth.a.TargetAudiences)
+				assert.Empty(t, auth.a.Audiences)
 				assert.Len(t, auth.a.TrustedIssuers, 1)
 				assert.Contains(t, auth.a.TrustedIssuers, "foobar")
 				assert.Len(t, auth.a.AllowedAlgorithms, 1)
@@ -412,7 +412,7 @@ cache_ttl: 5s`),
 
 				// assertions settings
 				require.NoError(t, auth.a.ScopesMatcher.Match([]string{}))
-				assert.Empty(t, auth.a.TargetAudiences)
+				assert.Empty(t, auth.a.Audiences)
 				assert.Empty(t, auth.a.TrustedIssuers)
 				assert.Len(t, auth.a.AllowedAlgorithms, 6)
 				assert.ElementsMatch(t, auth.a.AllowedAlgorithms, []string{
@@ -549,7 +549,7 @@ assertions:
 				assert.NotEqual(t, prototype.a, configured.a)
 
 				require.NoError(t, configured.a.ScopesMatcher.Match([]string{}))
-				assert.Empty(t, configured.a.TargetAudiences)
+				assert.Empty(t, configured.a.Audiences)
 				assert.ElementsMatch(t, configured.a.TrustedIssuers, []string{"barfoo"})
 				assert.ElementsMatch(t, configured.a.AllowedAlgorithms, []string{string(jose.ES512)})
 
@@ -591,7 +591,7 @@ cache_ttl: 5s`),
 				assert.NotEqual(t, prototype.a, configured.a)
 
 				require.NoError(t, configured.a.ScopesMatcher.Match([]string{}))
-				assert.Empty(t, configured.a.TargetAudiences)
+				assert.Empty(t, configured.a.Audiences)
 				assert.ElementsMatch(t, configured.a.TrustedIssuers, []string{"barfoo"})
 				assert.ElementsMatch(t, configured.a.AllowedAlgorithms, []string{string(jose.ES512)})
 
@@ -632,7 +632,7 @@ assertions:
 				assert.NotEqual(t, prototype.a, configured.a)
 
 				require.NoError(t, configured.a.ScopesMatcher.Match([]string{}))
-				assert.Empty(t, configured.a.TargetAudiences)
+				assert.Empty(t, configured.a.Audiences)
 				assert.ElementsMatch(t, configured.a.TrustedIssuers, []string{"barfoo"})
 				assert.ElementsMatch(t, configured.a.AllowedAlgorithms, []string{string(jose.ES512)})
 
@@ -705,7 +705,7 @@ assertions:
 				assert.Equal(t, prototype.ttl, configured.ttl)
 
 				assert.Equal(t, prototype.a.TrustedIssuers, configured.a.TrustedIssuers)
-				assert.Equal(t, prototype.a.TargetAudiences, configured.a.TargetAudiences)
+				assert.Equal(t, prototype.a.Audiences, configured.a.Audiences)
 				assert.Equal(t, prototype.a.AllowedAlgorithms, configured.a.AllowedAlgorithms)
 				assert.Equal(t, prototype.a.ValidityLeeway, configured.a.ValidityLeeway)
 				assert.NotEqual(t, prototype.a.ScopesMatcher, configured.a.ScopesMatcher)

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
@@ -161,7 +161,7 @@ assertions:
 				assert.Contains(t, auth.a.TrustedIssuers, "foobar")
 				require.NoError(t, auth.a.ScopesMatcher.Match([]string{}))
 				assert.Equal(t, time.Duration(0), auth.a.ValidityLeeway)
-				assert.Empty(t, auth.a.TargetAudiences)
+				assert.Empty(t, auth.a.Audiences)
 
 				// assert ttl
 				assert.Nil(t, auth.ttl)
@@ -240,7 +240,7 @@ allow_fallback_on_error: true
 				assert.Contains(t, auth.a.TrustedIssuers, "foobar")
 				require.NoError(t, auth.a.ScopesMatcher.Match([]string{"foo"}))
 				assert.Equal(t, time.Duration(0), auth.a.ValidityLeeway)
-				assert.Empty(t, auth.a.TargetAudiences)
+				assert.Empty(t, auth.a.Audiences)
 
 				// assert ttl
 				assert.Equal(t, 5*time.Second, *auth.ttl)
@@ -302,7 +302,7 @@ metadata_endpoint:
 				assert.Empty(t, auth.a.TrustedIssuers, 1)
 				require.NoError(t, auth.a.ScopesMatcher.Match([]string{}))
 				assert.Equal(t, time.Duration(0), auth.a.ValidityLeeway)
-				assert.Empty(t, auth.a.TargetAudiences)
+				assert.Empty(t, auth.a.Audiences)
 
 				// assert ttl
 				assert.Nil(t, auth.ttl)
@@ -430,7 +430,7 @@ assertions:
 				assert.NotEqual(t, prototype.a, configured.a)
 
 				require.NoError(t, configured.a.ScopesMatcher.Match([]string{}))
-				assert.ElementsMatch(t, configured.a.TargetAudiences, []string{"baz"})
+				assert.ElementsMatch(t, configured.a.Audiences, []string{"baz"})
 				assert.ElementsMatch(t, configured.a.TrustedIssuers, []string{"barfoo"})
 				assert.ElementsMatch(t, configured.a.AllowedAlgorithms, []string{string(jose.ES512)})
 
@@ -502,7 +502,7 @@ cache_ttl: 5s`),
 				assert.NotEqual(t, prototype.a, configured.a)
 
 				require.NoError(t, configured.a.ScopesMatcher.Match([]string{}))
-				assert.Empty(t, configured.a.TargetAudiences)
+				assert.Empty(t, configured.a.Audiences)
 				assert.ElementsMatch(t, configured.a.TrustedIssuers, []string{"barfoo"})
 				assert.ElementsMatch(t, configured.a.AllowedAlgorithms, []string{string(jose.ES512)})
 

--- a/internal/rules/mechanisms/oauth2/claims_test.go
+++ b/internal/rules/mechanisms/oauth2/claims_test.go
@@ -58,8 +58,8 @@ func TestClaimsValidate(t *testing.T) {
 				Audience: Audience{"bar"},
 			},
 			expectations: Expectation{
-				TrustedIssuers:  []string{"foo"},
-				TargetAudiences: []string{"foo"},
+				TrustedIssuers: []string{"foo"},
+				Audiences:      []string{"foo"},
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -76,8 +76,8 @@ func TestClaimsValidate(t *testing.T) {
 				NotBefore: &dateInTheFuture,
 			},
 			expectations: Expectation{
-				TrustedIssuers:  []string{"foo"},
-				TargetAudiences: []string{"bar"},
+				TrustedIssuers: []string{"foo"},
+				Audiences:      []string{"bar"},
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -95,8 +95,8 @@ func TestClaimsValidate(t *testing.T) {
 				IssuedAt:  &dateInTheFuture,
 			},
 			expectations: Expectation{
-				TrustedIssuers:  []string{"foo"},
-				TargetAudiences: []string{"bar"},
+				TrustedIssuers: []string{"foo"},
+				Audiences:      []string{"bar"},
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -115,9 +115,9 @@ func TestClaimsValidate(t *testing.T) {
 				Scp:       Scopes{"foo", "bar"},
 			},
 			expectations: Expectation{
-				TrustedIssuers:  []string{"foo"},
-				TargetAudiences: []string{"bar"},
-				ScopesMatcher:   ExactScopeStrategyMatcher{"bar", "baz"},
+				TrustedIssuers: []string{"foo"},
+				Audiences:      []string{"bar"},
+				ScopesMatcher:  ExactScopeStrategyMatcher{"bar", "baz"},
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -136,9 +136,9 @@ func TestClaimsValidate(t *testing.T) {
 				Scope:     Scopes{"foo", "bar"},
 			},
 			expectations: Expectation{
-				TrustedIssuers:  []string{"foo"},
-				TargetAudiences: []string{"bar"},
-				ScopesMatcher:   ExactScopeStrategyMatcher{"bar", "baz"},
+				TrustedIssuers: []string{"foo"},
+				Audiences:      []string{"bar"},
+				ScopesMatcher:  ExactScopeStrategyMatcher{"bar", "baz"},
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -157,9 +157,9 @@ func TestClaimsValidate(t *testing.T) {
 				Scope:     Scopes{"foo", "bar"},
 			},
 			expectations: Expectation{
-				TrustedIssuers:  []string{"foo"},
-				TargetAudiences: []string{"bar"},
-				ScopesMatcher:   ExactScopeStrategyMatcher{"foo"},
+				TrustedIssuers: []string{"foo"},
+				Audiences:      []string{"bar"},
+				ScopesMatcher:  ExactScopeStrategyMatcher{"foo"},
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -177,9 +177,9 @@ func TestClaimsValidate(t *testing.T) {
 				Scp:       Scopes{"foo", "bar"},
 			},
 			expectations: Expectation{
-				TrustedIssuers:  []string{"foo"},
-				TargetAudiences: []string{"bar"},
-				ScopesMatcher:   ExactScopeStrategyMatcher{"foo"},
+				TrustedIssuers: []string{"foo"},
+				Audiences:      []string{"bar"},
+				ScopesMatcher:  ExactScopeStrategyMatcher{"foo"},
 			},
 			assert: func(t *testing.T, err error) {
 				t.Helper()

--- a/internal/rules/mechanisms/oauth2/expectations_test.go
+++ b/internal/rules/mechanisms/oauth2/expectations_test.go
@@ -115,7 +115,7 @@ func TestExpectationAssertAudience(t *testing.T) {
 	}{
 		{
 			uc:       "assertion fails",
-			exp:      Expectation{TargetAudiences: []string{"bar"}},
+			exp:      Expectation{Audiences: []string{"bar"}},
 			audience: []string{"foo", "baz"},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
@@ -124,9 +124,29 @@ func TestExpectationAssertAudience(t *testing.T) {
 			},
 		},
 		{
-			uc:       "assertion succeeds",
-			exp:      Expectation{TargetAudiences: []string{"foo", "bar"}},
+			uc:       "assertion succeeds (full intersection)",
+			exp:      Expectation{Audiences: []string{"foo", "bar"}},
 			audience: []string{"foo", "bar"},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+			},
+		},
+		{
+			uc:       "assertion succeeds (partial intersection 1)",
+			exp:      Expectation{Audiences: []string{"bar"}},
+			audience: []string{"foo", "bar"},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+			},
+		},
+		{
+			uc:       "assertion succeeds (partial intersection 2)",
+			exp:      Expectation{Audiences: []string{"foo", "bar"}},
+			audience: []string{"foo"},
 			assert: func(t *testing.T, err error) {
 				t.Helper()
 
@@ -526,7 +546,7 @@ func TestMergeExpectations(t *testing.T) {
 			uc: "with empty target",
 			source: &Expectation{
 				ScopesMatcher:     ExactScopeStrategyMatcher{},
-				TargetAudiences:   []string{"foo"},
+				Audiences:         []string{"foo"},
 				TrustedIssuers:    []string{"bar"},
 				AllowedAlgorithms: []string{"RS512"},
 				ValidityLeeway:    10 * time.Second,
@@ -542,7 +562,7 @@ func TestMergeExpectations(t *testing.T) {
 			uc: "with target having only scopes configured",
 			source: &Expectation{
 				ScopesMatcher:     ExactScopeStrategyMatcher{},
-				TargetAudiences:   []string{"foo"},
+				Audiences:         []string{"foo"},
 				TrustedIssuers:    []string{"bar"},
 				AllowedAlgorithms: []string{"RS512"},
 				ValidityLeeway:    10 * time.Second,
@@ -554,7 +574,7 @@ func TestMergeExpectations(t *testing.T) {
 				assert.NotEqual(t, source, merged)
 				assert.NotEqual(t, source.ScopesMatcher, merged.ScopesMatcher)
 				assert.Equal(t, target.ScopesMatcher, merged.ScopesMatcher)
-				assert.Equal(t, source.TargetAudiences, merged.TargetAudiences)
+				assert.Equal(t, source.Audiences, merged.Audiences)
 				assert.Equal(t, source.TrustedIssuers, merged.TrustedIssuers)
 				assert.Equal(t, source.AllowedAlgorithms, merged.AllowedAlgorithms)
 				assert.Equal(t, source.ValidityLeeway, merged.ValidityLeeway)
@@ -564,14 +584,14 @@ func TestMergeExpectations(t *testing.T) {
 			uc: "with target having scopes and audience configured",
 			source: &Expectation{
 				ScopesMatcher:     ExactScopeStrategyMatcher{},
-				TargetAudiences:   []string{"foo"},
+				Audiences:         []string{"foo"},
 				TrustedIssuers:    []string{"bar"},
 				AllowedAlgorithms: []string{"RS512"},
 				ValidityLeeway:    10 * time.Second,
 			},
 			target: &Expectation{
-				ScopesMatcher:   HierarchicScopeStrategyMatcher{},
-				TargetAudiences: []string{"baz"},
+				ScopesMatcher: HierarchicScopeStrategyMatcher{},
+				Audiences:     []string{"baz"},
 			},
 			assert: func(t *testing.T, merged *Expectation, source *Expectation, target *Expectation) {
 				t.Helper()
@@ -579,8 +599,8 @@ func TestMergeExpectations(t *testing.T) {
 				assert.NotEqual(t, source, merged)
 				assert.NotEqual(t, source.ScopesMatcher, merged.ScopesMatcher)
 				assert.Equal(t, target.ScopesMatcher, merged.ScopesMatcher)
-				assert.NotEqual(t, source.TargetAudiences, merged.TargetAudiences)
-				assert.Equal(t, target.TargetAudiences, merged.TargetAudiences)
+				assert.NotEqual(t, source.Audiences, merged.Audiences)
+				assert.Equal(t, target.Audiences, merged.Audiences)
 				assert.Equal(t, source.TrustedIssuers, merged.TrustedIssuers)
 				assert.Equal(t, source.AllowedAlgorithms, merged.AllowedAlgorithms)
 				assert.Equal(t, source.ValidityLeeway, merged.ValidityLeeway)
@@ -590,15 +610,15 @@ func TestMergeExpectations(t *testing.T) {
 			uc: "with target having scopes, audience and trusted issuers configured",
 			source: &Expectation{
 				ScopesMatcher:     ExactScopeStrategyMatcher{},
-				TargetAudiences:   []string{"foo"},
+				Audiences:         []string{"foo"},
 				TrustedIssuers:    []string{"bar"},
 				AllowedAlgorithms: []string{"RS512"},
 				ValidityLeeway:    10 * time.Second,
 			},
 			target: &Expectation{
-				ScopesMatcher:   HierarchicScopeStrategyMatcher{},
-				TargetAudiences: []string{"baz"},
-				TrustedIssuers:  []string{"zab"},
+				ScopesMatcher:  HierarchicScopeStrategyMatcher{},
+				Audiences:      []string{"baz"},
+				TrustedIssuers: []string{"zab"},
 			},
 			assert: func(t *testing.T, merged *Expectation, source *Expectation, target *Expectation) {
 				t.Helper()
@@ -606,8 +626,8 @@ func TestMergeExpectations(t *testing.T) {
 				assert.NotEqual(t, source, merged)
 				assert.NotEqual(t, source.ScopesMatcher, merged.ScopesMatcher)
 				assert.Equal(t, target.ScopesMatcher, merged.ScopesMatcher)
-				assert.NotEqual(t, source.TargetAudiences, merged.TargetAudiences)
-				assert.Equal(t, target.TargetAudiences, merged.TargetAudiences)
+				assert.NotEqual(t, source.Audiences, merged.Audiences)
+				assert.Equal(t, target.Audiences, merged.Audiences)
 				assert.NotEqual(t, source.TrustedIssuers, merged.TrustedIssuers)
 				assert.Equal(t, target.TrustedIssuers, merged.TrustedIssuers)
 				assert.Equal(t, source.AllowedAlgorithms, merged.AllowedAlgorithms)
@@ -618,14 +638,14 @@ func TestMergeExpectations(t *testing.T) {
 			uc: "with target having scopes, audience, trusted issuers and allowed algorithms configured",
 			source: &Expectation{
 				ScopesMatcher:     ExactScopeStrategyMatcher{},
-				TargetAudiences:   []string{"foo"},
+				Audiences:         []string{"foo"},
 				TrustedIssuers:    []string{"bar"},
 				AllowedAlgorithms: []string{"RS512"},
 				ValidityLeeway:    10 * time.Second,
 			},
 			target: &Expectation{
 				ScopesMatcher:     HierarchicScopeStrategyMatcher{},
-				TargetAudiences:   []string{"baz"},
+				Audiences:         []string{"baz"},
 				TrustedIssuers:    []string{"zab"},
 				AllowedAlgorithms: []string{"BAR128"},
 			},
@@ -635,8 +655,8 @@ func TestMergeExpectations(t *testing.T) {
 				assert.NotEqual(t, source, merged)
 				assert.NotEqual(t, source.ScopesMatcher, merged.ScopesMatcher)
 				assert.Equal(t, target.ScopesMatcher, merged.ScopesMatcher)
-				assert.NotEqual(t, source.TargetAudiences, merged.TargetAudiences)
-				assert.Equal(t, target.TargetAudiences, merged.TargetAudiences)
+				assert.NotEqual(t, source.Audiences, merged.Audiences)
+				assert.Equal(t, target.Audiences, merged.Audiences)
 				assert.NotEqual(t, source.TrustedIssuers, merged.TrustedIssuers)
 				assert.Equal(t, target.TrustedIssuers, merged.TrustedIssuers)
 				assert.NotEqual(t, source.AllowedAlgorithms, merged.AllowedAlgorithms)
@@ -648,14 +668,14 @@ func TestMergeExpectations(t *testing.T) {
 			uc: "with target having everything reconfigured",
 			source: &Expectation{
 				ScopesMatcher:     ExactScopeStrategyMatcher{},
-				TargetAudiences:   []string{"foo"},
+				Audiences:         []string{"foo"},
 				TrustedIssuers:    []string{"bar"},
 				AllowedAlgorithms: []string{"RS512"},
 				ValidityLeeway:    10 * time.Second,
 			},
 			target: &Expectation{
 				ScopesMatcher:     HierarchicScopeStrategyMatcher{},
-				TargetAudiences:   []string{"baz"},
+				Audiences:         []string{"baz"},
 				TrustedIssuers:    []string{"zab"},
 				AllowedAlgorithms: []string{"BAR128"},
 				ValidityLeeway:    20 * time.Minute,
@@ -666,8 +686,8 @@ func TestMergeExpectations(t *testing.T) {
 				assert.NotEqual(t, source, merged)
 				assert.NotEqual(t, source.ScopesMatcher, merged.ScopesMatcher)
 				assert.Equal(t, target.ScopesMatcher, merged.ScopesMatcher)
-				assert.NotEqual(t, source.TargetAudiences, merged.TargetAudiences)
-				assert.Equal(t, target.TargetAudiences, merged.TargetAudiences)
+				assert.NotEqual(t, source.Audiences, merged.Audiences)
+				assert.Equal(t, target.Audiences, merged.Audiences)
 				assert.NotEqual(t, source.TrustedIssuers, merged.TrustedIssuers)
 				assert.Equal(t, target.TrustedIssuers, merged.TrustedIssuers)
 				assert.NotEqual(t, source.AllowedAlgorithms, merged.AllowedAlgorithms)

--- a/internal/x/slicex/intersection.go
+++ b/internal/x/slicex/intersection.go
@@ -8,6 +8,7 @@ func Intersects[S ~[]E, E comparable](first S, second S) bool {
 	for _, f := range first {
 		if slices.Contains(second, f) {
 			intersection = true
+
 			break
 		}
 	}

--- a/internal/x/slicex/intersection.go
+++ b/internal/x/slicex/intersection.go
@@ -1,0 +1,16 @@
+package slicex
+
+import "slices"
+
+func Intersects[S ~[]E, E comparable](first S, second S) bool {
+	var intersection bool
+
+	for _, f := range first {
+		if slices.Contains(second, f) {
+			intersection = true
+			break
+		}
+	}
+
+	return intersection
+}


### PR DESCRIPTION
## Related issue(s)

closes #1234

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

Fixes the assertion of the `aud` claim in JWTs and OAuth2 introspection endpoint responses. It adheres now to the definition in [RFC 7519, section 4.1.3](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3) and evaluates to true if at least one entry from the provided `audience`  arrays is present in the `aud` claim.