### PR TITLE
chore: SLSA badge added

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Security-Scan](https://github.com/dadrus/heimdall/actions/workflows/security.yaml/badge.svg)](https://github.com/dadrus/heimdall/actions/workflows/security.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/7738/badge)](https://www.bestpractices.dev/projects/7738)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/dadrus/heimdall/badge)](https://securityscorecards.dev/viewer/?uri=github.com/dadrus/heimdall)
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
 [![Go Report Card](https://goreportcard.com/badge/github.com/dadrus/heimdall)](https://goreportcard.com/report/github.com/dadrus/heimdall)
 [![codecov](https://codecov.io/gh/dadrus/heimdall/branch/main/graph/badge.svg)](https://codecov.io/gh/dadrus/heimdall)
 [![Docker](https://img.shields.io/docker/v/dadrus/heimdall/latest?color=lightblue&label=docker&logo=docker)](https://hub.docker.com/r/dadrus/heimdall)


### PR DESCRIPTION
According to [SLSA documentation](https://slsa.dev) and also answers from the SLSA comunity, this Project certifies for [SLSA Level 3](https://slsa.dev/get-started#slsa-3). There is currently only a self-assessment option possible. There are however plans to have project audits in the future which would officially certify the project.