### PR TITLE
chore: type for the `Outputs` removed and made it `map[string]any` to have better support in templates

### DIFF
--- a/internal/handler/envoyextauth/grpcv3/request_context.go
+++ b/internal/handler/envoyextauth/grpcv3/request_context.go
@@ -144,9 +144,9 @@ func (r *RequestContext) SetPipelineError(err error)              { r.err = err 
 func (r *RequestContext) AddHeaderForUpstream(name, value string) { r.upstreamHeaders.Add(name, value) }
 func (r *RequestContext) AddCookieForUpstream(name, value string) { r.upstreamCookies[name] = value }
 
-func (r *RequestContext) Outputs() heimdall.Outputs {
+func (r *RequestContext) Outputs() map[string]any {
 	if r.outputs == nil {
-		r.outputs = make(heimdall.Outputs)
+		r.outputs = make(map[string]any)
 	}
 
 	return r.outputs

--- a/internal/handler/requestcontext/mocks/context.go
+++ b/internal/handler/requestcontext/mocks/context.go
@@ -186,19 +186,19 @@ func (_c *ContextMock_Finalize_Call) RunAndReturn(run func(rule.Backend) error) 
 }
 
 // Outputs provides a mock function with given fields:
-func (_m *ContextMock) Outputs() heimdall.Outputs {
+func (_m *ContextMock) Outputs() map[string]interface{} {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for Outputs")
 	}
 
-	var r0 heimdall.Outputs
-	if rf, ok := ret.Get(0).(func() heimdall.Outputs); ok {
+	var r0 map[string]interface{}
+	if rf, ok := ret.Get(0).(func() map[string]interface{}); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(heimdall.Outputs)
+			r0 = ret.Get(0).(map[string]interface{})
 		}
 	}
 
@@ -222,12 +222,12 @@ func (_c *ContextMock_Outputs_Call) Run(run func()) *ContextMock_Outputs_Call {
 	return _c
 }
 
-func (_c *ContextMock_Outputs_Call) Return(_a0 heimdall.Outputs) *ContextMock_Outputs_Call {
+func (_c *ContextMock_Outputs_Call) Return(_a0 map[string]interface{}) *ContextMock_Outputs_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *ContextMock_Outputs_Call) RunAndReturn(run func() heimdall.Outputs) *ContextMock_Outputs_Call {
+func (_c *ContextMock_Outputs_Call) RunAndReturn(run func() map[string]interface{}) *ContextMock_Outputs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/handler/requestcontext/request_context.go
+++ b/internal/handler/requestcontext/request_context.go
@@ -173,9 +173,9 @@ func (r *RequestContext) UpstreamCookies() map[string]string      { return r.ups
 func (r *RequestContext) AppContext() context.Context             { return r.req.Context() }
 func (r *RequestContext) SetPipelineError(err error)              { r.err = err }
 func (r *RequestContext) PipelineError() error                    { return r.err }
-func (r *RequestContext) Outputs() heimdall.Outputs {
+func (r *RequestContext) Outputs() map[string]any {
 	if r.outputs == nil {
-		r.outputs = make(heimdall.Outputs)
+		r.outputs = make(map[string]any)
 	}
 
 	return r.outputs

--- a/internal/heimdall/context.go
+++ b/internal/heimdall/context.go
@@ -18,22 +18,8 @@ package heimdall
 
 import (
 	"context"
-	"crypto/sha256"
 	"net/url"
-
-	"github.com/goccy/go-json"
 )
-
-type Outputs map[string]any
-
-func (o Outputs) Hash() []byte {
-	hash := sha256.New()
-	rawSub, _ := json.Marshal(o)
-
-	hash.Write(rawSub)
-
-	return hash.Sum(nil)
-}
 
 //go:generate mockery --name Context --structname ContextMock
 
@@ -47,7 +33,7 @@ type Context interface {
 
 	SetPipelineError(err error)
 
-	Outputs() Outputs
+	Outputs() map[string]any
 }
 
 //go:generate mockery --name RequestFunctions --structname RequestFunctionsMock

--- a/internal/heimdall/mocks/context.go
+++ b/internal/heimdall/mocks/context.go
@@ -138,19 +138,19 @@ func (_c *ContextMock_AppContext_Call) RunAndReturn(run func() context.Context) 
 }
 
 // Outputs provides a mock function with given fields:
-func (_m *ContextMock) Outputs() heimdall.Outputs {
+func (_m *ContextMock) Outputs() map[string]interface{} {
 	ret := _m.Called()
 
 	if len(ret) == 0 {
 		panic("no return value specified for Outputs")
 	}
 
-	var r0 heimdall.Outputs
-	if rf, ok := ret.Get(0).(func() heimdall.Outputs); ok {
+	var r0 map[string]interface{}
+	if rf, ok := ret.Get(0).(func() map[string]interface{}); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(heimdall.Outputs)
+			r0 = ret.Get(0).(map[string]interface{})
 		}
 	}
 
@@ -174,12 +174,12 @@ func (_c *ContextMock_Outputs_Call) Run(run func()) *ContextMock_Outputs_Call {
 	return _c
 }
 
-func (_c *ContextMock_Outputs_Call) Return(_a0 heimdall.Outputs) *ContextMock_Outputs_Call {
+func (_c *ContextMock_Outputs_Call) Return(_a0 map[string]interface{}) *ContextMock_Outputs_Call {
 	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *ContextMock_Outputs_Call) RunAndReturn(run func() heimdall.Outputs) *ContextMock_Outputs_Call {
+func (_c *ContextMock_Outputs_Call) RunAndReturn(run func() map[string]interface{}) *ContextMock_Outputs_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/rules/mechanisms/finalizers/cookie_finalizer_test.go
+++ b/internal/rules/mechanisms/finalizers/cookie_finalizer_test.go
@@ -277,7 +277,7 @@ cookies:
 				ctx.EXPECT().AddCookieForUpstream("x_foo", "Bar")
 				ctx.EXPECT().AddCookieForUpstream("x_bar", "bar")
 				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: reqf})
-				ctx.EXPECT().Outputs().Return(heimdall.Outputs{"foo": "bar"})
+				ctx.EXPECT().Outputs().Return(map[string]any{"foo": "bar"})
 			},
 			createSubject: func(t *testing.T) *subject.Subject {
 				t.Helper()

--- a/internal/rules/mechanisms/finalizers/header_finalizer_test.go
+++ b/internal/rules/mechanisms/finalizers/header_finalizer_test.go
@@ -276,7 +276,7 @@ headers:
 				ctx.EXPECT().AddHeaderForUpstream("X-Baz", "Bar")
 				ctx.EXPECT().AddHeaderForUpstream("X-Foo", "bar")
 				ctx.EXPECT().Request().Return(&heimdall.Request{RequestFunctions: reqf})
-				ctx.EXPECT().Outputs().Return(heimdall.Outputs{"foo": "bar"})
+				ctx.EXPECT().Outputs().Return(map[string]any{"foo": "bar"})
 			},
 			createSubject: func(t *testing.T) *subject.Subject {
 				t.Helper()

--- a/internal/rules/mechanisms/finalizers/jwt_finalizer.go
+++ b/internal/rules/mechanisms/finalizers/jwt_finalizer.go
@@ -236,7 +236,9 @@ func (f *jwtFinalizer) calculateCacheKey(ctx heimdall.Context, sub *subject.Subj
 		func() []byte { return []byte{} }))
 	hash.Write(ttlBytes)
 	hash.Write(sub.Hash())
-	hash.Write(ctx.Outputs().Hash())
+
+	rawSub, _ := json.Marshal(ctx.Outputs())
+	hash.Write(rawSub)
 
 	return hex.EncodeToString(hash.Sum(nil))
 }

--- a/internal/rules/mechanisms/finalizers/jwt_finalizer_test.go
+++ b/internal/rules/mechanisms/finalizers/jwt_finalizer_test.go
@@ -751,7 +751,7 @@ signer:
 				t.Helper()
 
 				ctx.EXPECT().AddHeaderForUpstream("Authorization", "Bearer TestToken")
-				ctx.EXPECT().Outputs().Return(heimdall.Outputs{"foo": "bar"})
+				ctx.EXPECT().Outputs().Return(map[string]any{"foo": "bar"})
 
 				cacheKey := fin.calculateCacheKey(ctx, sub)
 				cch.EXPECT().Get(mock.Anything, cacheKey).Return([]byte("TestToken"), nil)
@@ -778,7 +778,7 @@ ttl: 1m
 
 				ctx.EXPECT().AddHeaderForUpstream("Authorization",
 					mock.MatchedBy(func(val string) bool { return strings.HasPrefix(val, "Bearer ") }))
-				ctx.EXPECT().Outputs().Return(heimdall.Outputs{})
+				ctx.EXPECT().Outputs().Return(map[string]any{})
 
 				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil, errors.New("no cache entry"))
 				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything, configuredTTL-defaultCacheLeeway).Return(nil)
@@ -812,7 +812,7 @@ claims: '{
 
 				ctx.EXPECT().AddHeaderForUpstream("X-Token",
 					mock.MatchedBy(func(val string) bool { return strings.HasPrefix(val, "Bar ") }))
-				ctx.EXPECT().Outputs().Return(heimdall.Outputs{"foo": "bar"})
+				ctx.EXPECT().Outputs().Return(map[string]any{"foo": "bar"})
 
 				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil, errors.New("no cache entry"))
 				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything, defaultJWTTTL-defaultCacheLeeway).Return(nil)
@@ -838,7 +838,7 @@ claims: "foo: bar"
 			) {
 				t.Helper()
 
-				ctx.EXPECT().Outputs().Return(heimdall.Outputs{})
+				ctx.EXPECT().Outputs().Return(map[string]any{})
 
 				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil, errors.New("no cache entry"))
 			},
@@ -869,7 +869,7 @@ claims: "{{ len .foobar }}"
 			) {
 				t.Helper()
 
-				ctx.EXPECT().Outputs().Return(heimdall.Outputs{})
+				ctx.EXPECT().Outputs().Return(map[string]any{})
 
 				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil, errors.New("no cache entry"))
 			},


### PR DESCRIPTION
fix for #1487.

Before it usage of the `dig` template function resulted in an internal error due to a type conversation issue.