### PR TITLE
fix: OAuth2 Expectations merge being in-place and then returning a copy

### DIFF
--- a/internal/rules/mechanisms/oauth2/expectations.go
+++ b/internal/rules/mechanisms/oauth2/expectations.go
@@ -43,13 +43,15 @@ func (e *Expectation) Merge(other *Expectation) Expectation {
 		return *other
 	}
 
-	e.TrustedIssuers = x.IfThenElse(len(e.TrustedIssuers) != 0, e.TrustedIssuers, other.TrustedIssuers)
-	e.ScopesMatcher = x.IfThenElse(e.ScopesMatcher != nil, e.ScopesMatcher, other.ScopesMatcher)
-	e.Audiences = x.IfThenElse(len(e.Audiences) != 0, e.Audiences, other.Audiences)
-	e.AllowedAlgorithms = x.IfThenElse(len(e.AllowedAlgorithms) != 0, e.AllowedAlgorithms, other.AllowedAlgorithms)
-	e.ValidityLeeway = x.IfThenElse(e.ValidityLeeway != 0, e.ValidityLeeway, other.ValidityLeeway)
+	exp := *e
 
-	return *e
+	exp.TrustedIssuers = x.IfThenElse(len(e.TrustedIssuers) != 0, e.TrustedIssuers, other.TrustedIssuers)
+	exp.ScopesMatcher = x.IfThenElse(e.ScopesMatcher != nil, e.ScopesMatcher, other.ScopesMatcher)
+	exp.Audiences = x.IfThenElse(len(e.Audiences) != 0, e.Audiences, other.Audiences)
+	exp.AllowedAlgorithms = x.IfThenElse(len(e.AllowedAlgorithms) != 0, e.AllowedAlgorithms, other.AllowedAlgorithms)
+	exp.ValidityLeeway = x.IfThenElse(e.ValidityLeeway != 0, e.ValidityLeeway, other.ValidityLeeway)
+
+	return exp
 }
 
 func (e *Expectation) AssertAlgorithm(alg string) error {


### PR DESCRIPTION
## Related issue(s)

Doesn't have a issue number yet.

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).

## Description

.Merge() used to work on the receiver, silently changing the receiver and afterwards returning a copy. This commit changes the method to create a copy and work on the copy. Most uses of the function are only called once, where the bug isn't triggered. However, this prevented the JWT issuer with dynamic Issuer URLs from working correctly because only the first issuer would be taken for eternity.

## Changelist

fix: OAuth2 Dynamic Issuer usage in JWT/OIDC authenticators when used with metadata_endpoint