### PR TITLE
fix: OAuth2 `iss` claim verification in JWT/OIDC authenticators when used with `metadata_endpoint`

### DIFF
--- a/internal/rules/mechanisms/authenticators/jwt_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator.go
@@ -208,9 +208,9 @@ func (a *jwtAuthenticator) WithConfig(config map[string]any) (Authenticator, err
 	}
 
 	type Config struct {
-		Assertions           *oauth2.Expectation `mapstructure:"assertions"              validate:"-"`
-		CacheTTL             *time.Duration      `mapstructure:"cache_ttl"`
-		AllowFallbackOnError *bool               `mapstructure:"allow_fallback_on_error"`
+		Assertions           oauth2.Expectation `mapstructure:"assertions"              validate:"-"`
+		CacheTTL             *time.Duration     `mapstructure:"cache_ttl"`
+		AllowFallbackOnError *bool              `mapstructure:"allow_fallback_on_error"`
 	}
 
 	var conf Config
@@ -221,7 +221,7 @@ func (a *jwtAuthenticator) WithConfig(config map[string]any) (Authenticator, err
 	return &jwtAuthenticator{
 		id:  a.id,
 		r:   a.r,
-		a:   conf.Assertions.Merge(&a.a),
+		a:   conf.Assertions.Merge(a.a),
 		ttl: x.IfThenElse(conf.CacheTTL != nil, conf.CacheTTL, a.ttl),
 		sf:  a.sf,
 		ads: a.ads,
@@ -314,7 +314,7 @@ func (a *jwtAuthenticator) verifyToken(ctx heimdall.Context, token *jwt.JSONWebT
 	}
 
 	// configured assertions take precedence over those available in the metadata
-	assertions := a.a.Merge(&oauth2.Expectation{
+	assertions := a.a.Merge(oauth2.Expectation{
 		TrustedIssuers: []string{metadata.Issuer},
 	})
 

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
@@ -192,9 +192,9 @@ func (a *oauth2IntrospectionAuthenticator) WithConfig(rawConfig map[string]any) 
 	}
 
 	type Config struct {
-		Assertions           *oauth2.Expectation `mapstructure:"assertions"`
-		CacheTTL             *time.Duration      `mapstructure:"cache_ttl"`
-		AllowFallbackOnError *bool               `mapstructure:"allow_fallback_on_error"`
+		Assertions           oauth2.Expectation `mapstructure:"assertions"`
+		CacheTTL             *time.Duration     `mapstructure:"cache_ttl"`
+		AllowFallbackOnError *bool              `mapstructure:"allow_fallback_on_error"`
 	}
 
 	var conf Config
@@ -205,7 +205,7 @@ func (a *oauth2IntrospectionAuthenticator) WithConfig(rawConfig map[string]any) 
 	return &oauth2IntrospectionAuthenticator{
 		id:  a.id,
 		r:   a.r,
-		a:   conf.Assertions.Merge(&a.a),
+		a:   conf.Assertions.Merge(a.a),
 		sf:  a.sf,
 		ads: a.ads,
 		ttl: x.IfThenElse(conf.CacheTTL != nil, conf.CacheTTL, a.ttl),
@@ -299,7 +299,7 @@ func (a *oauth2IntrospectionAuthenticator) getSubjectInformation(ctx heimdall.Co
 	}
 
 	// configured assertions take precedence over those available in the metadata
-	assertions := a.a.Merge(&oauth2.Expectation{
+	assertions := a.a.Merge(oauth2.Expectation{
 		TrustedIssuers: []string{metadata.Issuer},
 	})
 

--- a/internal/rules/mechanisms/oauth2/expectation_test.go
+++ b/internal/rules/mechanisms/oauth2/expectation_test.go
@@ -524,35 +524,26 @@ func TestExpectationAssertScopes(t *testing.T) {
 	}
 }
 
-func TestMergeExpectations(t *testing.T) {
+func TestExpectationMerge(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
 		uc     string
-		target *Expectation
-		source *Expectation
-		assert func(t *testing.T, merged *Expectation, source *Expectation, target *Expectation)
+		target Expectation
+		source Expectation
+		assert func(t *testing.T, merged Expectation, source Expectation, target Expectation)
 	}{
 		{
-			uc:     "with nil target",
-			source: &Expectation{},
-			assert: func(t *testing.T, merged *Expectation, source *Expectation, _ *Expectation) {
-				t.Helper()
-
-				require.Equal(t, source, merged)
-			},
-		},
-		{
 			uc: "with empty target",
-			source: &Expectation{
+			source: Expectation{
 				ScopesMatcher:     ExactScopeStrategyMatcher{},
 				Audiences:         []string{"foo"},
 				TrustedIssuers:    []string{"bar"},
 				AllowedAlgorithms: []string{"RS512"},
 				ValidityLeeway:    10 * time.Second,
 			},
-			target: &Expectation{},
-			assert: func(t *testing.T, merged *Expectation, source *Expectation, _ *Expectation) {
+			target: Expectation{},
+			assert: func(t *testing.T, merged Expectation, source Expectation, _ Expectation) {
 				t.Helper()
 
 				require.Equal(t, source, merged)
@@ -560,15 +551,15 @@ func TestMergeExpectations(t *testing.T) {
 		},
 		{
 			uc: "with target having only scopes configured",
-			source: &Expectation{
+			source: Expectation{
 				ScopesMatcher:     ExactScopeStrategyMatcher{},
 				Audiences:         []string{"foo"},
 				TrustedIssuers:    []string{"bar"},
 				AllowedAlgorithms: []string{"RS512"},
 				ValidityLeeway:    10 * time.Second,
 			},
-			target: &Expectation{ScopesMatcher: HierarchicScopeStrategyMatcher{}},
-			assert: func(t *testing.T, merged *Expectation, source *Expectation, target *Expectation) {
+			target: Expectation{ScopesMatcher: HierarchicScopeStrategyMatcher{}},
+			assert: func(t *testing.T, merged Expectation, source Expectation, target Expectation) {
 				t.Helper()
 
 				assert.NotEqual(t, source, merged)
@@ -582,18 +573,18 @@ func TestMergeExpectations(t *testing.T) {
 		},
 		{
 			uc: "with target having scopes and audience configured",
-			source: &Expectation{
+			source: Expectation{
 				ScopesMatcher:     ExactScopeStrategyMatcher{},
 				Audiences:         []string{"foo"},
 				TrustedIssuers:    []string{"bar"},
 				AllowedAlgorithms: []string{"RS512"},
 				ValidityLeeway:    10 * time.Second,
 			},
-			target: &Expectation{
+			target: Expectation{
 				ScopesMatcher: HierarchicScopeStrategyMatcher{},
 				Audiences:     []string{"baz"},
 			},
-			assert: func(t *testing.T, merged *Expectation, source *Expectation, target *Expectation) {
+			assert: func(t *testing.T, merged Expectation, source Expectation, target Expectation) {
 				t.Helper()
 
 				assert.NotEqual(t, source, merged)
@@ -608,19 +599,19 @@ func TestMergeExpectations(t *testing.T) {
 		},
 		{
 			uc: "with target having scopes, audience and trusted issuers configured",
-			source: &Expectation{
+			source: Expectation{
 				ScopesMatcher:     ExactScopeStrategyMatcher{},
 				Audiences:         []string{"foo"},
 				TrustedIssuers:    []string{"bar"},
 				AllowedAlgorithms: []string{"RS512"},
 				ValidityLeeway:    10 * time.Second,
 			},
-			target: &Expectation{
+			target: Expectation{
 				ScopesMatcher:  HierarchicScopeStrategyMatcher{},
 				Audiences:      []string{"baz"},
 				TrustedIssuers: []string{"zab"},
 			},
-			assert: func(t *testing.T, merged *Expectation, source *Expectation, target *Expectation) {
+			assert: func(t *testing.T, merged Expectation, source Expectation, target Expectation) {
 				t.Helper()
 
 				assert.NotEqual(t, source, merged)
@@ -636,20 +627,20 @@ func TestMergeExpectations(t *testing.T) {
 		},
 		{
 			uc: "with target having scopes, audience, trusted issuers and allowed algorithms configured",
-			source: &Expectation{
+			source: Expectation{
 				ScopesMatcher:     ExactScopeStrategyMatcher{},
 				Audiences:         []string{"foo"},
 				TrustedIssuers:    []string{"bar"},
 				AllowedAlgorithms: []string{"RS512"},
 				ValidityLeeway:    10 * time.Second,
 			},
-			target: &Expectation{
+			target: Expectation{
 				ScopesMatcher:     HierarchicScopeStrategyMatcher{},
 				Audiences:         []string{"baz"},
 				TrustedIssuers:    []string{"zab"},
 				AllowedAlgorithms: []string{"BAR128"},
 			},
-			assert: func(t *testing.T, merged *Expectation, source *Expectation, target *Expectation) {
+			assert: func(t *testing.T, merged Expectation, source Expectation, target Expectation) {
 				t.Helper()
 
 				assert.NotEqual(t, source, merged)
@@ -666,21 +657,21 @@ func TestMergeExpectations(t *testing.T) {
 		},
 		{
 			uc: "with target having everything reconfigured",
-			source: &Expectation{
+			source: Expectation{
 				ScopesMatcher:     ExactScopeStrategyMatcher{},
 				Audiences:         []string{"foo"},
 				TrustedIssuers:    []string{"bar"},
 				AllowedAlgorithms: []string{"RS512"},
 				ValidityLeeway:    10 * time.Second,
 			},
-			target: &Expectation{
+			target: Expectation{
 				ScopesMatcher:     HierarchicScopeStrategyMatcher{},
 				Audiences:         []string{"baz"},
 				TrustedIssuers:    []string{"zab"},
 				AllowedAlgorithms: []string{"BAR128"},
 				ValidityLeeway:    20 * time.Minute,
 			},
-			assert: func(t *testing.T, merged *Expectation, source *Expectation, target *Expectation) {
+			assert: func(t *testing.T, merged Expectation, source Expectation, target Expectation) {
 				t.Helper()
 
 				assert.NotEqual(t, source, merged)
@@ -702,7 +693,27 @@ func TestMergeExpectations(t *testing.T) {
 			exp := tc.target.Merge(tc.source)
 
 			// THEN
-			tc.assert(t, &exp, tc.source, tc.target)
+			tc.assert(t, exp, tc.source, tc.target)
 		})
 	}
+}
+
+func TestExpectationMergeIdempotency(t *testing.T) {
+	t.Parallel()
+
+	exp := Expectation{}
+
+	exp.Merge(Expectation{
+		ScopesMatcher:     ExactScopeStrategyMatcher{},
+		Audiences:         []string{"foo"},
+		TrustedIssuers:    []string{"bar"},
+		AllowedAlgorithms: []string{"RS512"},
+		ValidityLeeway:    10 * time.Second,
+	})
+
+	assert.Nil(t, exp.ScopesMatcher)
+	assert.Empty(t, exp.Audiences)
+	assert.Empty(t, exp.TrustedIssuers)
+	assert.Empty(t, exp.AllowedAlgorithms)
+	assert.Equal(t, 0*time.Second, exp.ValidityLeeway)
 }


### PR DESCRIPTION
## Related issue(s)

same as #1658 (but for the release branch, cherry pick from the referenced PR)

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

The verification of the claims is done using an `Expectation` object initially created from the `jwt` authenticator configuration. If the `metadata_endpoint` is used, a new `Expectation` object, based on the above said one, is created. The contents of that new object is a result of merging the properties from the initial object with data received from the OIDC discovery endpoint, where new data is only used in the resulting object if the old one didn't have them set. Unfortunately the implementation of the `Merge()` method, responsible for the creation of that new object was not idempotent. It updated the properties of the initial object during the merge. That way the subsequent `Expectation` objects had wrong values.

This PR changes the implementation of this method and actually all receivers of the `Expectation` struct to always work on a copy of the corresponding objects.

## Additional Info

Most uses of the function are only called once, where the bug isn't triggered. However, this prevented the JWT issuer with dynamic Issuer URLs from working correctly because only the first issuer would be taken for eternity as described in the linked bug ticket.

