### PR TITLE
chore: OSV Scanner configuration added

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,4 @@
+[[PackageOverrides]]
+name = "docs"
+ignore = true
+reason = "The results of this directory is generated static html content. Even some of the dependencies may have vulnerabilities they have no effect as neither inbound nor outbound connections are made during the generation of the content."


### PR DESCRIPTION
[OSV Scanner](https://github.com/google/osv-scanner) is used by [scorecard](https://github.com/ossf/scorecard)