### PR TITLE
refactor!: Deprecated OTEL attributes replaced

### DIFF
--- a/internal/handler/middleware/grpc/otelmetrics/interceptor.go
+++ b/internal/handler/middleware/grpc/otelmetrics/interceptor.go
@@ -24,7 +24,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 

--- a/internal/handler/middleware/grpc/otelmetrics/interceptor.go
+++ b/internal/handler/middleware/grpc/otelmetrics/interceptor.go
@@ -134,7 +134,7 @@ func peerAttr(addr string) []attribute.KeyValue {
 		return []attribute.KeyValue{semconv.NetworkPeerAddress(host), semconv.NetworkPeerPort(port)}
 	}
 
-	return []attribute.KeyValue{semconv.ServerAddress(host), semconv.ServerPort(port)}
+	return []attribute.KeyValue{semconv.ClientAddress(host), semconv.ClientPort(port)}
 }
 
 func parseFullMethod(fullMethod string) (string, []attribute.KeyValue) {
@@ -187,7 +187,7 @@ func serverAttr(addr string) []attribute.KeyValue {
 	}
 
 	return []attribute.KeyValue{
-		attribute.Key("server.address").String(host),
-		attribute.Key("server.port").Int(port),
+		semconv.ServerAddress(host),
+		semconv.ServerPort(port),
 	}
 }

--- a/internal/handler/middleware/grpc/otelmetrics/interceptor.go
+++ b/internal/handler/middleware/grpc/otelmetrics/interceptor.go
@@ -24,7 +24,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 
@@ -131,10 +131,10 @@ func peerAttr(addr string) []attribute.KeyValue {
 	}
 
 	if ip := net.ParseIP(host); ip != nil {
-		return []attribute.KeyValue{semconv.NetSockPeerAddr(host), semconv.NetSockPeerPort(port)} // nolint: staticcheck
+		return []attribute.KeyValue{semconv.NetworkPeerAddress(host), semconv.NetworkPeerPort(port)}
 	}
 
-	return []attribute.KeyValue{semconv.NetPeerName(host), semconv.NetPeerPort(port)} // nolint: staticcheck
+	return []attribute.KeyValue{semconv.ServerAddress(host), semconv.ServerPort(port)}
 }
 
 func parseFullMethod(fullMethod string) (string, []attribute.KeyValue) {

--- a/internal/handler/middleware/grpc/otelmetrics/interceptor_test.go
+++ b/internal/handler/middleware/grpc/otelmetrics/interceptor_test.go
@@ -31,7 +31,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 	rpc_status "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -101,8 +101,8 @@ func TestHandlerObserveKnownRequests(t *testing.T) {
 				assert.Equal(t, "heimdall.local",
 					attributeValue(activeRequests.DataPoints[0].Attributes, "server.address").AsString())
 				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue("server.port"))
-				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetSockPeerAddrKey))
-				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetSockPeerPortKey))
+				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetworkPeerAddressKey))
+				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetworkPeerPortKey))
 			},
 		},
 		{
@@ -152,8 +152,8 @@ func TestHandlerObserveKnownRequests(t *testing.T) {
 				assert.Equal(t, "heimdall.local",
 					attributeValue(activeRequests.DataPoints[0].Attributes, "server.address").AsString())
 				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue("server.port"))
-				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetSockPeerAddrKey))
-				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetSockPeerPortKey))
+				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetworkPeerAddressKey))
+				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetworkPeerPortKey))
 			},
 		},
 		{
@@ -197,8 +197,8 @@ func TestHandlerObserveKnownRequests(t *testing.T) {
 				assert.Equal(t, "heimdall.local",
 					attributeValue(activeRequests.DataPoints[0].Attributes, "server.address").AsString())
 				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue("server.port"))
-				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetSockPeerAddrKey))
-				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetSockPeerPortKey))
+				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetworkPeerAddressKey))
+				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetworkPeerPortKey))
 			},
 		},
 	} {
@@ -347,6 +347,6 @@ func TestHandlerObserveUnknownRequests(t *testing.T) {
 	assert.Equal(t, "127.0.0.1",
 		attributeValue(activeRequests.DataPoints[0].Attributes, "server.address").AsString())
 	assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue("server.port"))
-	assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetSockPeerAddrKey))
-	assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetSockPeerPortKey))
+	assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetworkPeerAddressKey))
+	assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue(semconv.NetworkPeerAddressKey))
 }

--- a/internal/handler/middleware/grpc/otelmetrics/interceptor_test.go
+++ b/internal/handler/middleware/grpc/otelmetrics/interceptor_test.go
@@ -31,7 +31,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	rpc_status "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/internal/handler/middleware/http/otelmetrics/handler.go
+++ b/internal/handler/middleware/http/otelmetrics/handler.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 
 	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/httpx"
@@ -136,7 +136,7 @@ func methodMetric(method string) attribute.KeyValue {
 	return semconv.HTTPRequestMethodKey.String(method)
 }
 
-func requiredHTTPPort(https bool, port int) int { // nolint:revive
+func requiredHTTPPort(https bool, port int) int {
 	if https {
 		if port > 0 && port != 443 {
 			return port

--- a/internal/handler/middleware/http/otelmetrics/handler.go
+++ b/internal/handler/middleware/http/otelmetrics/handler.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 
 	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/httpx"
@@ -139,15 +139,15 @@ func methodMetric(method string) attribute.KeyValue {
 func flavor(proto string) attribute.KeyValue {
 	switch proto {
 	case "HTTP/1.0":
-		return semconv.HTTPFlavorHTTP10 // nolint: staticcheck
+		return semconv.HTTPFlavorHTTP10
 	case "HTTP/1.1":
-		return semconv.HTTPFlavorHTTP11 // nolint: staticcheck
+		return semconv.HTTPFlavorHTTP11
 	case "HTTP/2":
-		return semconv.HTTPFlavorHTTP20 // nolint: staticcheck
+		return semconv.HTTPFlavorHTTP20
 	case "HTTP/3":
-		return semconv.HTTPFlavorHTTP30 // nolint: staticcheck
+		return semconv.HTTPFlavorHTTP30
 	default:
-		return semconv.HTTPFlavorKey.String(proto) // nolint: staticcheck
+		return semconv.HTTPFlavorKey.String(proto)
 	}
 }
 

--- a/internal/handler/middleware/http/otelmetrics/handler.go
+++ b/internal/handler/middleware/http/otelmetrics/handler.go
@@ -18,6 +18,7 @@ package otelmetrics
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -104,14 +105,13 @@ func serverRequestMetrics(server string, req *http.Request) []attribute.KeyValue
 
 	attrs := make([]attribute.KeyValue, 0, attrsCount)
 	attrs = append(attrs, methodMetric(req.Method))
-	attrs = append(attrs, x.IfThenElse(req.TLS != nil,
-		semconv.HTTPSchemeKey.String("https"), // nolint: staticcheck
-		semconv.HTTPSchemeKey.String("http"))) // nolint: staticcheck
-	attrs = append(attrs, flavor(req.Proto))
-	attrs = append(attrs, semconv.NetHostNameKey.String(host)) // nolint: staticcheck
+	attrs = append(attrs, x.IfThenElse(req.TLS != nil, semconv.URLScheme("https"), semconv.URLScheme("http")))
+	attrs = append(attrs, semconv.NetworkProtocolName("http"))
+	attrs = append(attrs, semconv.NetworkProtocolVersion(strconv.Itoa(req.ProtoMajor)+"."+strconv.Itoa(req.ProtoMinor)))
+	attrs = append(attrs, semconv.ServerAddress(host))
 
 	if hostPort > 0 {
-		attrs = append(attrs, semconv.NetHostPortKey.Int(hostPort)) // nolint: staticcheck
+		attrs = append(attrs, semconv.ServerPort(hostPort))
 	}
 
 	return attrs
@@ -133,22 +133,7 @@ func methodMetric(method string) attribute.KeyValue {
 		method = "_OTHER"
 	}
 
-	return semconv.HTTPMethodKey.String(method)
-}
-
-func flavor(proto string) attribute.KeyValue {
-	switch proto {
-	case "HTTP/1.0":
-		return semconv.HTTPFlavorHTTP10
-	case "HTTP/1.1":
-		return semconv.HTTPFlavorHTTP11
-	case "HTTP/2":
-		return semconv.HTTPFlavorHTTP20
-	case "HTTP/3":
-		return semconv.HTTPFlavorHTTP30
-	default:
-		return semconv.HTTPFlavorKey.String(proto)
-	}
+	return semconv.HTTPRequestMethodKey.String(method)
 }
 
 func requiredHTTPPort(https bool, port int) int { // nolint:revive

--- a/internal/handler/middleware/http/otelmetrics/handler_test.go
+++ b/internal/handler/middleware/http/otelmetrics/handler_test.go
@@ -82,20 +82,22 @@ func TestHandlerExecution(t *testing.T) {
 				assert.False(t, activeRequests.IsMonotonic)
 				require.Len(t, activeRequests.DataPoints, 1)
 				require.InDelta(t, float64(0), activeRequests.DataPoints[0].Value, 0.00)
-				require.Equal(t, 7, activeRequests.DataPoints[0].Attributes.Len())
+				require.Equal(t, 8, activeRequests.DataPoints[0].Attributes.Len())
 				assert.Equal(t, "foobar",
 					attributeValue(activeRequests.DataPoints[0].Attributes, "service.subsystem").AsString())
 				assert.Equal(t, "zab",
 					attributeValue(activeRequests.DataPoints[0].Attributes, "baz").AsString())
-				assert.Equal(t, "1.1",
-					attributeValue(activeRequests.DataPoints[0].Attributes, "http.flavor").AsString())
-				assert.Equal(t, http.MethodGet,
-					attributeValue(activeRequests.DataPoints[0].Attributes, "http.method").AsString())
 				assert.Equal(t, "http",
-					attributeValue(activeRequests.DataPoints[0].Attributes, "http.scheme").AsString())
+					attributeValue(activeRequests.DataPoints[0].Attributes, "network.protocol.name").AsString())
+				assert.Equal(t, "1.1",
+					attributeValue(activeRequests.DataPoints[0].Attributes, "network.protocol.version").AsString())
+				assert.Equal(t, http.MethodGet,
+					attributeValue(activeRequests.DataPoints[0].Attributes, "http.request.method").AsString())
+				assert.Equal(t, "http",
+					attributeValue(activeRequests.DataPoints[0].Attributes, "url.scheme").AsString())
 				assert.Equal(t, "127.0.0.1",
-					attributeValue(activeRequests.DataPoints[0].Attributes, "net.host.name").AsString())
-				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue("net.host.port"))
+					attributeValue(activeRequests.DataPoints[0].Attributes, "server.address").AsString())
+				assert.True(t, activeRequests.DataPoints[0].Attributes.HasValue("server.port"))
 			},
 		},
 	} {

--- a/internal/otel/resource.go
+++ b/internal/otel/resource.go
@@ -18,7 +18,7 @@ package otel
 
 import (
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 
 	"github.com/dadrus/heimdall/version"
 )

--- a/internal/otel/resource.go
+++ b/internal/otel/resource.go
@@ -18,7 +18,7 @@ package otel
 
 import (
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 
 	"github.com/dadrus/heimdall/version"
 )

--- a/internal/x/opentelemetry/mocks/mock.go
+++ b/internal/x/opentelemetry/mocks/mock.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/bridge/opentracing/migration"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/embedded"
 	"go.opentelemetry.io/otel/trace/noop"

--- a/internal/x/opentelemetry/mocks/mock.go
+++ b/internal/x/opentelemetry/mocks/mock.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/bridge/opentracing/migration"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.25.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/embedded"
 	"go.opentelemetry.io/otel/trace/noop"


### PR DESCRIPTION
## Related issue(s)

OTEL has deprecated some of the attributes used so far in exposed metrics/traces. See also [HTTP semantic conventions declared stable](https://opentelemetry.io/blog/2023/http-conventions-declared-stable/) and [Network Deprecated Attributes](https://opentelemetry.io/docs/specs/semconv/attributes-registry/network/#network-deprecated-attributes)

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).
- [x] I have added tests that prove the correctness of my implementation.

## Description

This PR updates the code to 
* use semconv 1.26.0, 
* use `client.address` instead of the deprecated `net.peer.name`,
* use `client.port` instead of the deprecated `net.peer.port`,
* use `server.address` instead of the deprecated `net.host.name`,
* use `server.port` instead of the deprecated `net.host.port`,
* use `network.peer.address` instead of the deprecated `net.sock.peer.addr`,
* use `network.peer.port` instead of the deprecated `net.sock.peer.port`,
* use `network.protocol.name` and `network.protocol.version` instead of the deprecated `http.flavor`,
* use `http.request.method` instead of the deprecated `http.method`,
* use `url.scheme` instead of the deprecated `http.scheme`.


