### PR TITLE
chore: Docker compose related updates

### DIFF
--- a/DockerHub-README.md
+++ b/DockerHub-README.md
@@ -133,8 +133,6 @@ rules:
 Create a `docker-compose.yaml` file with the following contents and modify it to include the correct paths to your `config.yaml` and `rule.yaml` files:
 
 ```yaml
-version: "3"
-
 services:
   heimdall:
     image: dadrus/heimdall:latest
@@ -154,7 +152,7 @@ services:
 Start the docker compose environment:
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 Call the proxy service endpoint to emulate behavior of a client application:

--- a/docker/docker-compose.template.dbg
+++ b/docker/docker-compose.template.dbg
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   ${SERVICE_NAME}:
     build:

--- a/docs/content/docs/getting_started/protect_an_app.adoc
+++ b/docs/content/docs/getting_started/protect_an_app.adoc
@@ -241,8 +241,6 @@ We will add it to the above referenced `/var/www/nginx` folder, when we define o
 +
 [source, yaml]
 ----
-version: '3.7'
-
 services:
   heimdall: # <1>
     image: dadrus/heimdall:dev
@@ -280,8 +278,6 @@ services:
 +
 [source, yaml]
 ----
-version: "3"
-
 services:
   proxy: # <1>
     image: traefik:2.11.0
@@ -345,7 +341,7 @@ Open your terminal and start the services in the directory, the above `docker-co
 
 [source, bash]
 ----
-$ docker-compose up
+$ docker compose up
 ----
 
 == Consume the API
@@ -448,5 +444,5 @@ Just stop the environment with `CTRL-C` and delete the created files. If you sta
 
 [source, bash]
 ----
-$ docker-compose down
+$ docker compose down
 ----

--- a/docs/content/guides/authn/oidc_first_party_auth.adoc
+++ b/docs/content/guides/authn/oidc_first_party_auth.adoc
@@ -227,8 +227,6 @@ EOSQL
 +
 [source, yaml]
 ----
-version: '3.7'
-
 services:
   heimdall: # <1>
     image: dadrus/heimdall:dev
@@ -321,7 +319,7 @@ volumes:
 
 With the above configuration in place, follow these steps to start Keycloak and the database, initialize both, and create the OAuth2-Proxy client:
 
-. In the root directory, run `docker-compose up postgresql keycloak`. Wait until the database is initialized and Keycloak has started.
+. In the root directory, run `docker compose up postgresql keycloak`. Wait until the database is initialized and Keycloak has started.
 . Open your browser and go to `\http://127.0.0.1:8080`. Log in using the admin credentials (both the username and password are set to `admin` in our setup).
 . Create a Realm named `test`. For detailed instructions, refer to the Keycloak documentation on https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-a-realm_server_administration_guide[ creating a realm].
 . Within the `test` realm, create an OpenID Client. Follow the Keycloak documentation on https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-oidc-client_server_administration_guide[creating an OIDC client]. Enable "Client authentication" and "Standard Flow", set `\http://127.0.0.1:9090/oauth2/callback` as the "Valid Redirect URI" and `\http://127.0.0.1:9090/` as the "Home URL" and "Valid post logout redirect URIs" and note the "Client ID" and "Client Secret" (later can be found under the "Credentials" tab after completing the client creation wizard); we will use these to complete the OAuth2-Proxy configuration in our Docker Compose file.
@@ -337,7 +335,7 @@ We can now finalize the configuration and use the proper client id and secret fo
 
 We now have almost everything set up. The final step is to create a few users, including at least one with the `admin` role assigned.
 
-. In the root directory, run `docker-compose up`. Wait until all services are up and running.
+. In the root directory, run `docker compose up`. Wait until all services are up and running.
 . Open your browser and navigate to `\http://127.0.0.1:8080`. Log in using the admin credentials (both username and password are set to `admin`).
 . Select the `test` realm and create an `admin` group with a role named `admin` assigned to it. For guidance, refer to the Keycloak documentation on creating https://www.keycloak.org/docs/latest/server_admin/index.html#proc-managing-groups_server_administration_guide[Groups] and https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-realm-roles_server_administration_guide[Roles].
 . Create several users following the Keycloak documentation on  https://www.keycloak.org/docs/latest/server_admin/index.html#proc-creating-user_server_administration_guide[managing users], and assign some of them to the `admin` group. Disable email verification during user creation to avoid sending verification emails to potentially non-existent addresses.

--- a/docs/content/guides/authz/openfga.adoc
+++ b/docs/content/guides/authz/openfga.adoc
@@ -40,8 +40,6 @@ To be able to follow this guide, you'll need the following tools installed local
 +
 [source, yaml]
 ----
-version: '3.7'
-
 services:
   heimdall: # <1>
     image: dadrus/heimdall:dev
@@ -211,7 +209,7 @@ In addition, create a file named `jwks.json` with the public key required to ver
 
 The static configuration of our services is in place. Let us now create the actual authorization model and based on it the required heimdall rules.
 
-. Start our setup with `docker-compose up` and wait until all services are up and running.
+. Start our setup with `docker compose up` and wait until all services are up and running.
 
 . Create the OpenFGA store as also described in https://openfga.dev/docs/getting-started/create-store[Create Store] with
 +
@@ -434,5 +432,5 @@ Just stop the environment with `CTRL-C` and delete the created files. If you sta
 
 [source, bash]
 ----
-$ docker-compose down
+$ docker compose down
 ----

--- a/docs/content/guides/proxies/traefik.adoc
+++ b/docs/content/guides/proxies/traefik.adoc
@@ -111,8 +111,6 @@ The following `docker-compose.yaml` file shows a minimal required configuration.
 
 [source, yaml]
 ----
-version: '3.7'
-
 services:
   proxy:
     image: traefik:2.11.0

--- a/examples/docker-compose/quickstarts/README.md
+++ b/examples/docker-compose/quickstarts/README.md
@@ -12,7 +12,7 @@ In that setup heimdall is not integrated with any other reverse proxy.
 1. Start the environment with
 
    ```bash
-   docker-compose -f docker-compose.yaml -f docker-compose-proxy.yaml up
+   docker compose -f docker-compose.yaml -f docker-compose-proxy.yaml up
    ```
 
 2. Play with it
@@ -31,10 +31,12 @@ In that setup heimdall is not integrated with any other reverse proxy.
 
 In that setup heimdall is integrated with Traefik. All requests are sent to traefik, which then contacts heimdall as external authorization middleware and depending on the response from heimdall either forwards the request to the upstream service, or directly responses with an error from heimdall.
 
+*NOTE:* This setup uses Traefik's Docker provider and mounts the `docker.sock` file into the Traefik container. It also assumes a rootless Docker installation. If your installation differs, you may need to modify the `docker.sock` volume mount in the `docker-compose-traefik.yaml` file, likely changing it to `"/var/run/docker.sock:/var/run/docker.sock:ro"`.
+
 1. Start the environment with
 
    ```bash
-   docker-compose -f docker-compose.yaml -f docker-compose-traefik.yaml up
+   docker compose -f docker-compose.yaml -f docker-compose-traefik.yaml up
    ```
 
 2. Play with it
@@ -57,13 +59,13 @@ In that setup heimdall is integrated with Envoy Proxy. All requests are sent to 
    ether
 
    ```bash
-   docker-compose -f docker-compose.yaml -f docker-compose-envoy-http.yaml up
+   docker compose -f docker-compose.yaml -f docker-compose-envoy-http.yaml up
    ```
    
    to see integration using the HTTP decision service in action, or
 
    ```bash
-   docker-compose -f docker-compose.yaml -f docker-compose-envoy-grpc.yaml up
+   docker compose -f docker-compose.yaml -f docker-compose-envoy-grpc.yaml up
    ```
 
    to see integration using the envoy GRPC extauthz decision service in action (not available before v0.7.0-alpha).

--- a/examples/docker-compose/quickstarts/docker-compose-envoy-grpc.yaml
+++ b/examples/docker-compose/quickstarts/docker-compose-envoy-grpc.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   proxy:
     image: envoyproxy/envoy:v1.29.1

--- a/examples/docker-compose/quickstarts/docker-compose-envoy-http.yaml
+++ b/examples/docker-compose/quickstarts/docker-compose-envoy-http.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   edge-router:
     image: envoyproxy/envoy:v1.29.1

--- a/examples/docker-compose/quickstarts/docker-compose-proxy.yaml
+++ b/examples/docker-compose/quickstarts/docker-compose-proxy.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   heimdall:
     ports:

--- a/examples/docker-compose/quickstarts/docker-compose-traefik.yaml
+++ b/examples/docker-compose/quickstarts/docker-compose-traefik.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   proxy:
     image: traefik:3.0.0
@@ -11,7 +9,7 @@ services:
       --entryPoints.http.address=":9090" 
       --accesslog --api=true --api.insecure=true
     volumes:
-    - "/var/run/docker.sock:/var/run/docker.sock:ro"
+    - "${XDG_RUNTIME_DIR}/docker.sock:/var/run/docker.sock:ro"
     labels:
     - traefik.enable=true
     - traefik.http.routers.traefik_http.service=api@internal

--- a/examples/docker-compose/quickstarts/docker-compose.yaml
+++ b/examples/docker-compose/quickstarts/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   heimdall-init:
     image: finalgene/openssh

--- a/examples/kubernetes/metallb/configure.sh
+++ b/examples/kubernetes/metallb/configure.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-KIND_SUBNET=$(docker network inspect kind -f "{{(index .IPAM.Config 0).Subnet}}")
+KIND_SUBNET=$(docker network inspect kind -f "{{(index .IPAM.Config 1).Subnet}}")
 METALLB_IP_START=$(echo ${KIND_SUBNET} | sed "s@0.0/16@255.200@")
 METALLB_IP_END=$(echo ${KIND_SUBNET} | sed "s@0.0/16@255.250@")
 METALLB_IP_RANGE="${METALLB_IP_START}-${METALLB_IP_END}"


### PR DESCRIPTION
This PR introduces updates related to Docker Compose, such as replacing `docker-compose` with `docker compose` and removing the `version` property from the used `docker-compose.yaml` files, which has been deprecated by Docker.