### PR TITLE
chore: Improve spelling & grammar in docs

### DIFF
--- a/docs/content/docs/concepts/provider.adoc
+++ b/docs/content/docs/concepts/provider.adoc
@@ -44,6 +44,6 @@ The following table gives an overview about existing providers
 
 | link:{{< relref "/docs/rules/providers.adoc#_kubernetes" >}}[Kubernetes]
 | Custom Resource
-| Loads rule sets made available to a kubernetes cluster as customer resources.
+| Loads rule sets made available to a kubernetes cluster as custom resources.
 
 |===

--- a/docs/content/docs/concepts/rules.adoc
+++ b/docs/content/docs/concepts/rules.adoc
@@ -12,20 +12,20 @@ description: Rules defines what should happen to particular requests and under w
 
 :toc:
 
-You can compare the relation between mechanisms and rules to a relation between a catalogue at a car dealer and a real car, when you get it. So, mechanisms is what you can see and select in a catalogue (though, in case of heimdall you have to define that catalogue first) to compile your car and the rule is your car with real components and behaviour. In that sense when you define a rule, you specify which mechanisms should it be built from and whether you would like some "tuning" to be applied to better suit your needs.
+You can compare the relation between mechanisms and rules to a relation between a catalogue at a car dealer and a real car, when you get it. So, mechanisms is what you can see and select in a catalogue (though, in case of heimdall you have to define that catalogue first) to compile your car and the rule is your car with real components and behavior. In that sense when you define a rule, you specify which mechanisms should it be built from and whether you would like some "tuning" to be applied to better suit your needs.
 
 == Rule Types
 
 Heimdall supports two types of rules:
 
 * The link:{{< relref "/docs/rules/regular_rule.adoc" >}}[upstream specific rule], also called the regular rule. You can define as many regular rules, as required. These rules are dynamic by nature and can come and go together with the upstream service defining these.
-* The link:{{< relref "/docs/rules/regular_rule.adoc" >}}[default rule], which, if defined, is used by the regular rules to inherit their behaviour and is also executed if no other rule matches.
+* The link:{{< relref "/docs/rules/regular_rule.adoc" >}}[default rule], which, if defined, is used by the regular rules to inherit their behavior and is also executed if no other rule matches.
 
 == Memory Footprint
 
 Even the first paragraphs compare mechanisms and the rules with a catalogue of car parts and a real car, things are a bit more complex in reality.
 
-To minimize the memory footprint, heimdall instanciates all defined mechanisms on start up. And since all mechanisms are stateless, following is happening at runtime, when the rule is loaded:
+To minimize the memory footprint, heimdall instantiates all defined mechanisms on start up. And since all mechanisms are stateless, the following is happening at runtime, when the rule is loaded:
 
 * If a rule, respectively its pipeline just references a mechanism without providing additional configuration, the already instantiated mechanism is used.
 * Otherwise, if the pipeline overrides any parts of the default mechanism configuration, a shallow copy of the referenced mechanism instance (created at start up) is created, and only those parts, which differ are replaced with new objects, representing the pipeline specific configuration.
@@ -76,7 +76,7 @@ The diagram below sketches the logic executed by heimdall for each and every inc
 . *Any rule matching request?* - This is the first step executed by heimdall in which it tries to find a link:{{< relref "#_matching_of_rules" >}}[matching rule]. If there is no matching rule, heimdall either falls back to the default rule if available, or the request is denied. Otherwise, the rule specific authentication & authorization pipeline is executed.
 . *Execute authentication & authorization pipeline* - when a rule is matched, the mechanisms defined in its authentication & authorization pipeline are executed.
 . *Forward request, respectively respond to the API gateway* - when the above steps succeed, heimdall, depending on the link:{{< relref "/docs/concepts/operating_modes.adoc" >}}[operating mode], responds with, respectively forwards whatever was defined in the pipeline (usually this is a set of HTTP headers). Otherwise
-. *Execute error pipeline* is executed if any of the mechanisms, defined in the authentiction & authorization pipeline fail. This again results in a response, this time however, based on the definition in the used error handler.
+. *Execute error pipeline* is executed if any of the mechanisms, defined in the authentication & authorization pipeline fail. This again results in a response, this time however, based on the definition in the used error handler.
 
 == Matching of Rules
 
@@ -137,7 +137,7 @@ try {
 
 with `findMatchingRule` returning a specific instance of a class implementing our `Rule` interface matching the request.
 
-Since there is some default behaviour in place, like error handling, if the error pipeline is empty, and some stages of the authentication & authorization pipeline is optional, internally, there is some kind of base rule in place, all other rules inherit from. So something like shown in the snippet below.
+Since there is some default behavior in place, like error handling, if the error pipeline is empty, and some stages of the authentication & authorization pipeline is optional, internally, there is some kind of base rule in place, all other rules inherit from. So something like shown in the snippet below.
 
 [source, java]
 ----
@@ -191,4 +191,3 @@ public class SpecificRule extends DefaultRule {
 ----
 
 NOTE: You cannot override a single mechanism of a particular stage. As soon as you define a single mechanism in a pipeline, belonging to the one or the other stage, the entire stage is overridden.
-

--- a/docs/content/docs/configuration/types.adoc
+++ b/docs/content/docs/configuration/types.adoc
@@ -417,7 +417,7 @@ The scopes required for the access token.
 
 * *`cache_ttl`*: _link:{{< relref "#_duration" >}}[Duration]_ (optional)
 +
-How long to cache the token received from the token endpoint. Defaults to the token expiration information from the token endpoint (the value of the `expires_in` field) if present. If the token expiration inforation is not present and `cache_ttl` is not configured, the received token is not cached. If the token expiration information is present in the response and `cache_ttl` is configured the shorter value is taken. If caching is enabled, the token is cached until 5 seconds before its expiration. To disable caching, set it to `0s`. The cache key calculation is based on the values of `token_url`, `client_id`, `client_secret` and the `scopes` properties.
+How long to cache the token received from the token endpoint. Defaults to the token expiration information from the token endpoint (the value of the `expires_in` field) if present. If the token expiration information is not present and `cache_ttl` is not configured, the received token is not cached. If the token expiration information is present in the response and `cache_ttl` is configured the shorter value is taken. If caching is enabled, the token is cached until 5 seconds before its expiration. To disable caching, set it to `0s`. The cache key calculation is based on the values of `token_url`, `client_id`, `client_secret` and the `scopes` properties.
 
 * *`header`*: _object_ (optional, overridable)
 +

--- a/docs/content/docs/getting_started/protect_an_app.adoc
+++ b/docs/content/docs/getting_started/protect_an_app.adoc
@@ -26,7 +26,7 @@ For authentication, we'll use JWTs containing the respective roles. Authorizatio
 In both setups, we'll create minimal but complete environments using Docker Compose with:
 
 * https://doc.traefik.io/traefik/[Traefik] as the edge proxy,
-* https://hub.docker.com/r/containous/whoami/[containous/whoami] (a service that echoes back everything it receives), mimicking our service exposing the endpoints described above,
+* https://hub.docker.com/r/traefik/whoami/[traefik/whoami] (a service that echoes back everything it receives), mimicking our service exposing the endpoints described above,
 * an https://nginx.org/en/[NGINX] server serving the public key for verifying the JWTs (mimicking the JWKS endpoint typically exposed by an OIDC provider),
 * https://www.openpolicyagent.org/[OPA], which evaluates the authorization policy,
 * heimdall, orchestrating everything to enforce the above requirements.
@@ -256,7 +256,7 @@ services:
     command: serve proxy -c /etc/heimdall/config.yaml --insecure
 
   upstream: # <2>
-    image: containous/whoami:latest
+    image: traefik/whoami:latest
     command:
     - --port=8081
 
@@ -311,7 +311,7 @@ services:
     command: serve decision -c /etc/heimdall/config.yaml --insecure
 
   upstream:  # <4>
-    image: containous/whoami:latest
+    image: traefik/whoami:latest
     command:
     - --port=8081
     labels:

--- a/docs/content/docs/mechanisms/authorizers.adoc
+++ b/docs/content/docs/mechanisms/authorizers.adoc
@@ -12,7 +12,7 @@ description: Authorizers ensure that only those subjects, which are eligible can
 
 :toc:
 
-Some of the authorizers may support or require additional configuration. The corresponding properties are annotated with `mandatory`, respectively `optional` to denote configuration requirement, as well as with `overridable`, `not overriddable` and `partially overridable` to indicate whether the property can be overridden in a rule pipeline.
+Some of the authorizers may support or require additional configuration. The corresponding properties are annotated with `mandatory`, respectively `optional` to denote configuration requirement, as well as with `overridable`, `not overridable` and `partially overridable` to indicate whether the property can be overridden in a rule pipeline.
 
 == Allow
 

--- a/docs/content/docs/mechanisms/contextualizers.adoc
+++ b/docs/content/docs/mechanisms/contextualizers.adoc
@@ -12,7 +12,7 @@ description: Contextualizers allow you enriching the information about the reque
 
 :toc:
 
-Some of the contextualizers may support or require additional configuration. The corresponding properties are annotated with `mandatory`, respectively `optional` to denote configuration requirement, as well as with `overridable`, `not overriddable` and `partially overridable` to indicate whether the property can be overridden in a rule pipeline.
+Some of the contextualizers may support or require additional configuration. The corresponding properties are annotated with `mandatory`, respectively `optional` to denote configuration requirement, as well as with `overridable`, `not overridable` and `partially overridable` to indicate whether the property can be overridden in a rule pipeline.
 
 == Generic
 
@@ -88,7 +88,7 @@ config:
     }
 ----
 
-Since the `values` property is not defined but used in the payload, it must be specified in a rule making use of this contextualzer, e.g. in the following way:
+Since the `values` property is not defined but used in the payload, it must be specified in a rule making use of this contextualizer, e.g. in the following way:
 
 [source, yaml]
 ----

--- a/docs/content/docs/mechanisms/error_handlers.adoc
+++ b/docs/content/docs/mechanisms/error_handlers.adoc
@@ -12,7 +12,7 @@ description: Error handlers kick in when any of the stages of the regular rule p
 
 :toc:
 
-Some of the error handlers may support or require additional configuration. The corresponding properties are annotated with `mandatory`, respectively `optional` to denote configuration requirement, as well as with `overridable`, `not overriddable` and `partially overridable` to indicate whether the property can be overridden in a rule pipeline.
+Some of the error handlers may support or require additional configuration. The corresponding properties are annotated with `mandatory`, respectively `optional` to denote configuration requirement, as well as with `overridable`, `not overridable` and `partially overridable` to indicate whether the property can be overridden in a rule pipeline.
 
 == Default
 

--- a/docs/content/docs/mechanisms/evaluation_objects.adoc
+++ b/docs/content/docs/mechanisms/evaluation_objects.adoc
@@ -253,7 +253,7 @@ To ease the usage, all https://masterminds.github.io/sprig/[sprig] functions, ex
 
 * `urlenc` - Encodes a given string using url encoding. Is handy if you need to generate request body or query parameters e.g. for communication with further systems.
 
-* `atIndex` - Implements python-like access to arrays and takes as a single argument the index to access the element in the array at. With index being a positive values it works exactly the same way, as with the usage of the build-in index function to access array elements. With negative index value, one can access the array elements from the tail of the array. -1 is the index of the last element, -2 the index of the element before the last one, etc.
+* `atIndex` - Implements python-like access to arrays and takes as a single argument the index to access the element in the array at. With index being a positive values it works exactly the same way, as with the usage of the built-in index function to access array elements. With negative index value, one can access the array elements from the tail of the array. -1 is the index of the last element, -2 the index of the element before the last one, etc.
 +
 Example: `{{ atIndex 2 [1,2,3,4,5] }}` evaluates to `3` (behaves the same way as the `index` function) and `{{ atIndex -2 [1,2,3,4,5] }}` evaluates to `4`.
 
@@ -337,7 +337,7 @@ You can find further examples as part of mechanism descriptions, supporting temp
 
 Expressions can be used to execute conditional logic. As of today only https://github.com/google/cel-spec[CEL] is supported as expression language. All standard, as well as https://pkg.go.dev/github.com/google/cel-go/ext#pkg-functions[extension] functions are available. Which of the link:{{<  relref "#_objects" >}}[evaluation objects] are available to the expression depends on the mechanism.
 
-In addition to the build-in, respectively extension methods and functions, as well as the methods available on the evaluation objects, following functions are available as well:
+In addition to the built-in extension methods and functions, as well as the methods available on the evaluation objects, the following functions are available as well:
 
 * `split` - this function works on strings and expects a separator as a single argument. The result is a string array.
 +

--- a/docs/content/docs/mechanisms/finalizers.adoc
+++ b/docs/content/docs/mechanisms/finalizers.adoc
@@ -12,7 +12,7 @@ description: Finalizers are the last steps executed in a rule pipeline and can e
 
 :toc:
 
-Some finalizers may support or require additional configuration. The corresponding properties are annotated with `mandatory`, respectively `optional` to denote configuration requirement, as well as with `overridable`, `not overriddable` and `partially overridable` to indicate whether the property can be overridden in a rule pipeline.
+Some finalizers may support or require additional configuration. The corresponding properties are annotated with `mandatory`, respectively `optional` to denote configuration requirement, as well as with `overridable`, `not overridable` and `partially overridable` to indicate whether the property can be overridden in a rule pipeline.
 
 == Noop
 
@@ -182,7 +182,7 @@ The scopes required for the access token.
 
 * *`cache_ttl`*: _link:{{< relref "/docs/configuration/types.adoc#_duration" >}}[Duration]_ (optional, overridable)
 +
-How long to cache the token received from the token endpoint. Defaults to the token expiration information from the token endpoint (the value of the `expires_in` field) if present. If the token expiration inforation is not present and `cache_ttl` is not configured, the received token is not cached. If the token expiration information is present in the response and `cache_ttl` is configured the shorter value is taken. If caching is enabled, the token is cached until 5 seconds before its expiration. To disable caching, set it to `0s`. The cache key calculation is based on the entire `oauth2_client_credentials` configuration without considering the `header` property.
+How long to cache the token received from the token endpoint. Defaults to the token expiration information from the token endpoint (the value of the `expires_in` field) if present. If the token expiration information is not present and `cache_ttl` is not configured, the received token is not cached. If the token expiration information is present in the response and `cache_ttl` is configured the shorter value is taken. If caching is enabled, the token is cached until 5 seconds before its expiration. To disable caching, set it to `0s`. The cache key calculation is based on the entire `oauth2_client_credentials` configuration without considering the `header` property.
 
 * *`header`*: _object_ (optional, overridable)
 +

--- a/docs/content/docs/operations/cache.adoc
+++ b/docs/content/docs/operations/cache.adoc
@@ -87,7 +87,7 @@ The password to be used
 
 * *`client_cache`*: _ClientCache_ (optional)
 +
-Configurs the client cache to reduce roundtrip time. Following settings are possible:
+Configures the client cache to reduce roundtrip time. Following settings are possible:
 
 ** *`disabled`*: _boolean_ (optional)
 +

--- a/docs/content/docs/operations/configuration.adoc
+++ b/docs/content/docs/operations/configuration.adoc
@@ -153,7 +153,7 @@ and using environment variables with
 [source,bash]
 ----
 HEIMDALLCFG_SERVE_TRUSTED__PROXIES_0=192.168.1.0/24
-HEIMDALLCFG_SERVE_TRUSTED__PROXIES_0=192.168.2.0/24
+HEIMDALLCFG_SERVE_TRUSTED__PROXIES_1=192.168.2.0/24
 ----
 +
 For structured configuration, like the definition of the authenticators in the example above
@@ -190,5 +190,3 @@ and using the environment variables with
 ----
 HEIMDALLCFG_TRACING_SPAN__PROCESSOR=simple
 ----
-
-

--- a/docs/content/docs/operations/observability.adoc
+++ b/docs/content/docs/operations/observability.adoc
@@ -26,7 +26,7 @@ With `text` and `gelf` being the available formats. `text` is the default format
 +
 WARNING: Usage of `text` (default) format is not recommended for production deployments as it requires more computational resources and is hence slow.
 +
-.Configuring logging to emit logs using GELD format.
+.Configuring logging to emit logs using GELF format.
 ====
 [source, yaml]
 ----
@@ -217,7 +217,7 @@ Otherwise, if you configure it to use `gelf` format, the output will look as fol
 
 == Tracing
 
-Heimdall makes use of https://opentelemetry.io/[OpenTelemetry] for distributed tracing to support recording of paths taken by requests and supports all environment variables including the defined values according to https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/[OpenTelemetry Environment Variables] and https://opentelemetry.io/docs/concepts/sdk-configuration/[OpenTelemetry SDK Configuration] specifications. In addition to these environment variables, heimdall defines some additional options, which are described below and can be used to tune the behaviour.
+Heimdall makes use of https://opentelemetry.io/[OpenTelemetry] for distributed tracing to support recording of paths taken by requests and supports all environment variables including the defined values according to https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/[OpenTelemetry Environment Variables] and https://opentelemetry.io/docs/concepts/sdk-configuration/[OpenTelemetry SDK Configuration] specifications. In addition to these environment variables, heimdall defines some additional options, which are described below and can be used to tune the behavior.
 
 === Configuration
 
@@ -271,7 +271,7 @@ Since not every service in a multi-service system may set or understand the abov
 
 All of these are supported by heimdall. In addition, following propagators can be configured as well:
 
-* `datadog` - https://www.datadoghq.com/product/apm/[Datadog APM Trace Header] propagator.footnote:[Datadog supports the OTLP protokoll. For that reason, there is no exporter available.]
+* `datadog` - https://www.datadoghq.com/product/apm/[Datadog APM Trace Header] propagator.footnote:[Datadog supports the OTLP protocol. For that reason, there is no exporter available.]
 
 Configured propagators are used for inbound, as well as for outbound traffic.
 

--- a/docs/content/guides/authn/oidc_first_party_auth.adoc
+++ b/docs/content/guides/authn/oidc_first_party_auth.adoc
@@ -27,7 +27,7 @@ There are also some further endpoints, which you'll learn about during the setup
 
 Technically, the setup includes:
 
-* https://hub.docker.com/r/containous/whoami/[containous/whoami] - A service that echoes back everything it receives, simulating our main service with endpoints mentioned above.
+* https://hub.docker.com/r/traefik/whoami/[traefik/whoami] - A service that echoes back everything it receives, simulating our main service with endpoints mentioned above.
 * https://www.keycloak.org/[Keycloak] - Our identity provider.
 * https://oauth2-proxy.github.io/oauth2-proxy/[OAuth2-Proxy] - Handles the Authorization Code Grant flow for the actual user login.
 * heimdall - Manages everything to enforce the requirements outlined above.
@@ -239,7 +239,7 @@ services:
       - ./signer.pem:/etc/heimdall/signer.pem:ro
 
   upstream: # <2>
-    image: containous/whoami:latest
+    image: traefik/whoami:latest
     command: --port=8081
 
   oauth2-proxy: # <3>

--- a/docs/content/guides/authz/openfga.adoc
+++ b/docs/content/guides/authz/openfga.adoc
@@ -53,7 +53,7 @@ services:
     command: serve proxy -c /etc/heimdall/config.yaml --insecure
 
   upstream: # <2>
-    image: containous/whoami:latest
+    image: traefik/whoami:latest
     container_name: upstream
     command:
     - --port=8081

--- a/docs/content/guides/proxies/contour.adoc
+++ b/docs/content/guides/proxies/contour.adoc
@@ -95,7 +95,7 @@ A global configuration allows you to setup a single external authorization confi
 [source, yaml]
 ----
 globalExtAuth:
-  extensionService: <namespace in which heimdall is installed>/<name of the extention service>
+  extensionService: <namespace in which heimdall is installed>/<name of the extension service>
   failOpen: false
   responseTimeout: 1s
 ----

--- a/docs/content/guides/proxies/envoy_gateway.adoc
+++ b/docs/content/guides/proxies/envoy_gateway.adoc
@@ -29,7 +29,7 @@ Technically, the integration happens the same way as with link:{{< relref "/guid
 
 In both cases, the filter calls an external gRPC or HTTP service (here heimdall) to check whether an incoming HTTP request is authorized or not. If heimdall responses with `2xx` the request is forwarded to the upstream service, otherwise the response from heimdall is returned to the caller.
 
-In case of Envoy Gateway the abovesaid configuration happens via a https://gateway.envoyproxy.io/contributions/design/security-policy/[`SecurityPolicy`] custom resource, that can be linked to a https://gateway-api.sigs.k8s.io/api-types/gateway[`Gateway`], https://gateway-api.sigs.k8s.io/api-types/httproute[`HTTPRoute`], or a https://gateway-api.sigs.k8s.io/api-types/grpcroute[`GRPCRoute`] resource.
+In the case of Envoy Gateway the configuration described above happens via a https://gateway.envoyproxy.io/contributions/design/security-policy/[`SecurityPolicy`] custom resource, that can be linked to a https://gateway-api.sigs.k8s.io/api-types/gateway[`Gateway`], https://gateway-api.sigs.k8s.io/api-types/httproute[`HTTPRoute`], or a https://gateway-api.sigs.k8s.io/api-types/grpcroute[`GRPCRoute`] resource.
 
 NOTE: As of today, there is a limitation in the implementation of the Envoy Gateway - it does not allow cross-namespace reference of external auth services (see also https://github.com/envoyproxy/gateway/issues/3322[envoyproxy/gateway#3322]). That means, the https://gateway-api.sigs.k8s.io/api-types/httproute[`HTTPRoute`], the https://gateway-api.sigs.k8s.io/api-types/gateway[`Gateway`] resource and heimdall must be deployed in the same namespace.
 

--- a/docs/content/guides/proxies/istio.adoc
+++ b/docs/content/guides/proxies/istio.adoc
@@ -176,7 +176,7 @@ With this configuration completed, you can proceed to deploy the necessary gatew
 
 Simply create the Ingress https://istio.io/latest/docs/reference/config/networking/gateway/[`Gateway`] resource and define the https://istio.io/latest/docs/reference/config/networking/virtual-service/[`VirtualService`] resources for your services according to your requirements. No further configuration is necessary.
 
-== Kubenetes Gateway API
+== Kubernetes Gateway API
 
 As of this writing, Istio's implementation of the Gateway API appears incomplete. It lacks the necessary `Role` and `RoleBinding` to access the `Secret` containing additional CA certificates. Without these, the Envoy instances cannot access the secret, preventing them from trusting heimdall's certificate. To resolve this, apply the following resources in the namespace where the https://kubernetes.io/docs/concepts/services-networking/gateway/#api-kind-gateway[`Gateway`] will be installed:
 [source, yaml]

--- a/docs/content/guides/proxies/traefik.adoc
+++ b/docs/content/guides/proxies/traefik.adoc
@@ -146,7 +146,7 @@ services:
 
 == Traefik as Ingress Controller
 
-If you have Traefik as Ingress Controller in your Kubernetes cluster, you can simply integrate heimdall globally as descibed in link:{{< relref "#_global_configuration" >}}[Global Configuration] chapter above and make use of the standard https://kubernetes.io/docs/concepts/services-networking/ingress/[Ingress resource].
+If you have Traefik as Ingress Controller in your Kubernetes cluster, you can simply integrate heimdall globally as described in link:{{< relref "#_global_configuration" >}}[Global Configuration] chapter above and make use of the standard https://kubernetes.io/docs/concepts/services-networking/ingress/[Ingress resource].
 
 If you are using traefik's proprietary https://doc.traefik.io/traefik/routing/providers/kubernetes-crd/#kind-ingressroute[`IngressRoute`] custom resource instead of kubernetes standard https://kubernetes.io/docs/concepts/services-networking/ingress/[`Ingress`] one, you can also reference the https://doc.traefik.io/traefik/routing/providers/kubernetes-crd/#kind-middleware[`Middleware`] resource locally. This option is shown in the snippet below.
 
@@ -181,9 +181,8 @@ NOTE: By default, `IngressRoute` resources are not allowed to reference resource
 
 == Traefik as Gateway API implementation
 
-If you have Traefik as https://gateway-api.sigs.k8s.io/[Gateway API] implementation in your Kubernetes cluster, you can simply integrate heimdall globally as descibed in link:{{< relref "#_kubernetes_deployment" >}}[Global Configuration] chapter above and make use of the standard https://gateway-api.sigs.k8s.io/api-types/httproute[`HTTPRoute`] resource.
+If you have Traefik as https://gateway-api.sigs.k8s.io/[Gateway API] implementation in your Kubernetes cluster, you can simply integrate heimdall globally as described in link:{{< relref "#_kubernetes_deployment" >}}[Global Configuration] chapter above and make use of the standard https://gateway-api.sigs.k8s.io/api-types/httproute[`HTTPRoute`] resource.
 
 == Additional Resources
 
 A fully working example with Traefik is shown in the link:{{< relref "/docs/getting_started/protect_an_app.adoc" >}}[Protect an Application] quickstart and is also available on https://github.com/dadrus/heimdall/tree/main/examples[GitHub].
-


### PR DESCRIPTION
## Checklist

- [x] I agree to follow this project's [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Security Policy](../SECURITY.md).

## Description

These are mostly spelling fixes. The following changes are also noteworthy:

- Change Docker org for "whoami" per deprecation notice at <https://hub.docker.com/r/containous/whoami/>
- `HEIMDALLCFG_SERVE_TRUSTED__PROXIES_0`: the same environmental variable name was defined twice, which doesn't make sense. I'm *assuming* the second one should be _1 but I didn't test it. Interestingly, this was `_0` even prior to a recent fix to this line that moved the escaped `_`, but the _0 was kept. But there is no way to configure the same environmental variable to two different values, so I assume it must be wrong!

My editor (vim) adds trailing newlines (which is typical in *nix). I noticed it was inconsistent whether or not the existing files had these or not, so I didn't make any special effort to avoid this.