### PR TITLE
fix: Matching multiple hosts implements OR logic now

### DIFF
--- a/docs/content/docs/rules/regular_rule.adoc
+++ b/docs/content/docs/rules/regular_rule.adoc
@@ -36,7 +36,7 @@ The link:{{< relref "#_path_expression" >}}[Path Expression] describing the requ
 
 *** *`path_params`*: _PathParameterConditions_ (optional)
 +
-Additional conditions for the values captured by named wildcards in the path expression. Each entry supports the following properties:
+Additional conditions which must be met for the values captured by named wildcards in the path expression. All defined conditions must succeed for the request path to be considered a match. Each entry supports the following properties:
 
 **** *`name`*: _string_ (mandatory)
 +
@@ -59,7 +59,7 @@ Enables or disables backtracking when a request matches the path expressions but
 
 ** *`hosts`*: _HostMatcher array_ (optional)
 +
-Defines a set of hosts to match against the HTTP Host header. Each entry has the following properties:
+Defines a set of hosts to match against the HTTP Host header. These conditions are "OR" conditions, meaning that at least one must match for a successful match. Each entry has the following properties:
 
 *** *`type`*: _string_ (mandatory)
 +

--- a/internal/rules/repository_impl_test.go
+++ b/internal/rules/repository_impl_test.go
@@ -329,7 +329,7 @@ func TestRepositoryFindRule(t *testing.T) {
 				t.Helper()
 
 				rule1 := &ruleImpl{id: "test2", srcID: "baz", hash: []byte{1}}
-				rule1.routes = append(rule1.routes, &routeImpl{rule: rule1, path: "/baz/bar", matcher: compositeMatcher{}})
+				rule1.routes = append(rule1.routes, &routeImpl{rule: rule1, path: "/baz/bar", matcher: andMatcher{}})
 
 				err := repo.AddRuleSet("baz", []rule.Rule{rule1})
 				require.NoError(t, err)

--- a/internal/rules/route_matcher_test.go
+++ b/internal/rules/route_matcher_test.go
@@ -31,44 +31,37 @@ import (
 func TestCreateMethodMatcher(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
-		uc          string
+	for uc, tc := range map[string]struct {
 		configured  []string
 		expected    methodMatcher
 		shouldError bool
 	}{
-		{
-			uc:       "empty configuration",
+		"empty configuration": {
 			expected: methodMatcher{},
 		},
-		{
-			uc:          "empty method in list",
+		"empty method in list": {
 			configured:  []string{"FOO", ""},
 			shouldError: true,
 		},
-		{
-			uc:         "duplicates should be removed",
+		"duplicates should be removed": {
 			configured: []string{"BAR", "BAZ", "BAZ", "FOO", "FOO", "ZAB"},
 			expected:   methodMatcher{"BAR", "BAZ", "FOO", "ZAB"},
 		},
-		{
-			uc:         "only ALL configured",
+		"only ALL configured": {
 			configured: []string{"ALL"},
 			expected: methodMatcher{
 				http.MethodConnect, http.MethodDelete, http.MethodGet, http.MethodHead, http.MethodOptions,
 				http.MethodPatch, http.MethodPost, http.MethodPut, http.MethodTrace,
 			},
 		},
-		{
-			uc:         "ALL without POST and TRACE",
+		"ALL without POST and TRACE": {
 			configured: []string{"ALL", "!POST", "!TRACE"},
 			expected: methodMatcher{
 				http.MethodConnect, http.MethodDelete, http.MethodGet, http.MethodHead,
 				http.MethodOptions, http.MethodPatch, http.MethodPut,
 			},
 		},
-		{
-			uc:         "ALL with duplicates and without POST and TRACE",
+		"ALL with duplicates and without POST and TRACE": {
 			configured: []string{"ALL", "GET", "!POST", "!TRACE", "!TRACE"},
 			expected: methodMatcher{
 				http.MethodConnect, http.MethodDelete, http.MethodGet, http.MethodHead,
@@ -76,7 +69,7 @@ func TestCreateMethodMatcher(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.uc, func(t *testing.T) {
+		t.Run(uc, func(t *testing.T) {
 			// WHEN
 			res, err := createMethodMatcher(tc.configured)
 
@@ -93,38 +86,35 @@ func TestCreateMethodMatcher(t *testing.T) {
 func TestCreateHostMatcher(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
-		uc     string
+	for uc, tc := range map[string]struct {
 		conf   []config.HostMatcher
 		assert func(t *testing.T, matcher RouteMatcher, err error)
 	}{
-		{
-			uc: "empty configuration",
+		"empty configuration": {
 			assert: func(t *testing.T, matcher RouteMatcher, err error) {
 				t.Helper()
 
 				require.NoError(t, err)
-				assert.IsType(t, compositeMatcher{}, matcher)
+
+				assert.IsType(t, orMatcher{}, matcher)
 				assert.Empty(t, matcher)
 			},
 		},
-		{
-			uc:   "valid glob expression",
+		"valid glob expression": {
 			conf: []config.HostMatcher{{Value: "/**", Type: "glob"}},
 			assert: func(t *testing.T, matcher RouteMatcher, err error) {
 				t.Helper()
 
 				require.NoError(t, err)
-				assert.IsType(t, compositeMatcher{}, matcher)
+				assert.IsType(t, orMatcher{}, matcher)
 				assert.Len(t, matcher, 1)
 
-				hms := matcher.(compositeMatcher)
+				hms := matcher.(orMatcher)
 				assert.IsType(t, &hostMatcher{}, hms[0])
 				assert.IsType(t, &globMatcher{}, hms[0].(*hostMatcher).typedMatcher)
 			},
 		},
-		{
-			uc:   "invalid glob expression",
+		"invalid glob expression": {
 			conf: []config.HostMatcher{{Value: "!*][)(*", Type: "glob"}},
 			assert: func(t *testing.T, _ RouteMatcher, err error) {
 				t.Helper()
@@ -134,23 +124,21 @@ func TestCreateHostMatcher(t *testing.T) {
 				require.ErrorContains(t, err, "failed to compile host matching expression at index 0")
 			},
 		},
-		{
-			uc:   "valid regex expression",
+		"valid regex expression": {
 			conf: []config.HostMatcher{{Value: ".*", Type: "regex"}},
 			assert: func(t *testing.T, matcher RouteMatcher, err error) {
 				t.Helper()
 
 				require.NoError(t, err)
-				assert.IsType(t, compositeMatcher{}, matcher)
+				assert.IsType(t, orMatcher{}, matcher)
 				assert.Len(t, matcher, 1)
 
-				hms := matcher.(compositeMatcher)
+				hms := matcher.(orMatcher)
 				assert.IsType(t, &hostMatcher{}, hms[0])
 				assert.IsType(t, &regexpMatcher{}, hms[0].(*hostMatcher).typedMatcher)
 			},
 		},
-		{
-			uc:   "invalid regex expression",
+		"invalid regex expression": {
 			conf: []config.HostMatcher{{Value: "?>?<*??", Type: "regex"}},
 			assert: func(t *testing.T, _ RouteMatcher, err error) {
 				t.Helper()
@@ -160,23 +148,21 @@ func TestCreateHostMatcher(t *testing.T) {
 				require.ErrorContains(t, err, "failed to compile host matching expression at index 0")
 			},
 		},
-		{
-			uc:   "exact expression",
+		"exact expression": {
 			conf: []config.HostMatcher{{Value: "?>?<*??", Type: "exact"}},
 			assert: func(t *testing.T, matcher RouteMatcher, err error) {
 				t.Helper()
 
 				require.NoError(t, err)
-				assert.IsType(t, compositeMatcher{}, matcher)
+				assert.IsType(t, orMatcher{}, matcher)
 				assert.Len(t, matcher, 1)
 
-				hms := matcher.(compositeMatcher)
+				hms := matcher.(orMatcher)
 				assert.IsType(t, &hostMatcher{}, hms[0])
 				assert.IsType(t, &exactMatcher{}, hms[0].(*hostMatcher).typedMatcher)
 			},
 		},
-		{
-			uc:   "unsupported type",
+		"unsupported type": {
 			conf: []config.HostMatcher{{Value: "foo", Type: "bar"}},
 			assert: func(t *testing.T, _ RouteMatcher, err error) {
 				t.Helper()
@@ -186,8 +172,30 @@ func TestCreateHostMatcher(t *testing.T) {
 				require.ErrorContains(t, err, "unsupported host matching expression type 'bar' at index 0")
 			},
 		},
+		"multiple expressions": {
+			conf: []config.HostMatcher{
+				{Value: "foo", Type: "exact"},
+				{Value: ".*", Type: "regex"},
+				{Value: "/**", Type: "glob"},
+			},
+			assert: func(t *testing.T, matcher RouteMatcher, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				assert.IsType(t, orMatcher{}, matcher)
+				assert.Len(t, matcher, 3)
+
+				hms := matcher.(orMatcher)
+				assert.IsType(t, &hostMatcher{}, hms[0])
+				assert.IsType(t, &exactMatcher{}, hms[0].(*hostMatcher).typedMatcher)
+				assert.IsType(t, &hostMatcher{}, hms[1])
+				assert.IsType(t, &regexpMatcher{}, hms[1].(*hostMatcher).typedMatcher)
+				assert.IsType(t, &hostMatcher{}, hms[2])
+				assert.IsType(t, &globMatcher{}, hms[2].(*hostMatcher).typedMatcher)
+			},
+		},
 	} {
-		t.Run(tc.uc, func(t *testing.T) {
+		t.Run(uc, func(t *testing.T) {
 			hm, err := createHostMatcher(tc.conf)
 
 			tc.assert(t, hm, err)
@@ -198,38 +206,34 @@ func TestCreateHostMatcher(t *testing.T) {
 func TestCreatePathParamsMatcher(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
-		uc     string
+	for uc, tc := range map[string]struct {
 		conf   []config.ParameterMatcher
 		assert func(t *testing.T, matcher RouteMatcher, err error)
 	}{
-		{
-			uc: "empty configuration",
+		"empty configuration": {
 			assert: func(t *testing.T, matcher RouteMatcher, err error) {
 				t.Helper()
 
 				require.NoError(t, err)
-				assert.IsType(t, compositeMatcher{}, matcher)
+				assert.IsType(t, andMatcher{}, matcher)
 				assert.Empty(t, matcher)
 			},
 		},
-		{
-			uc:   "valid glob expression",
+		"valid glob expression": {
 			conf: []config.ParameterMatcher{{Name: "foo", Value: "/**", Type: "glob"}},
 			assert: func(t *testing.T, matcher RouteMatcher, err error) {
 				t.Helper()
 
 				require.NoError(t, err)
-				assert.IsType(t, compositeMatcher{}, matcher)
+				assert.IsType(t, andMatcher{}, matcher)
 				assert.Len(t, matcher, 1)
 
-				hms := matcher.(compositeMatcher)
+				hms := matcher.(andMatcher)
 				assert.IsType(t, &pathParamMatcher{}, hms[0])
 				assert.IsType(t, &globMatcher{}, hms[0].(*pathParamMatcher).typedMatcher)
 			},
 		},
-		{
-			uc:   "invalid glob expression",
+		"invalid glob expression": {
 			conf: []config.ParameterMatcher{{Name: "foo", Value: "!*][)(*", Type: "glob"}},
 			assert: func(t *testing.T, _ RouteMatcher, err error) {
 				t.Helper()
@@ -239,23 +243,21 @@ func TestCreatePathParamsMatcher(t *testing.T) {
 				require.ErrorContains(t, err, "failed to compile path params matching expression for parameter 'foo' at index 0")
 			},
 		},
-		{
-			uc:   "valid regex expression",
+		"valid regex expression": {
 			conf: []config.ParameterMatcher{{Name: "foo", Value: ".*", Type: "regex"}},
 			assert: func(t *testing.T, matcher RouteMatcher, err error) {
 				t.Helper()
 
 				require.NoError(t, err)
-				assert.IsType(t, compositeMatcher{}, matcher)
+				assert.IsType(t, andMatcher{}, matcher)
 				assert.Len(t, matcher, 1)
 
-				hms := matcher.(compositeMatcher)
+				hms := matcher.(andMatcher)
 				assert.IsType(t, &pathParamMatcher{}, hms[0])
 				assert.IsType(t, &regexpMatcher{}, hms[0].(*pathParamMatcher).typedMatcher)
 			},
 		},
-		{
-			uc:   "invalid regex expression",
+		"invalid regex expression": {
 			conf: []config.ParameterMatcher{{Name: "foo", Value: "?>?<*??", Type: "regex"}},
 			assert: func(t *testing.T, _ RouteMatcher, err error) {
 				t.Helper()
@@ -265,23 +267,21 @@ func TestCreatePathParamsMatcher(t *testing.T) {
 				require.ErrorContains(t, err, "failed to compile path params matching expression for parameter 'foo' at index 0")
 			},
 		},
-		{
-			uc:   "exact expression",
+		"exact expression": {
 			conf: []config.ParameterMatcher{{Name: "foo", Value: "?>?<*??", Type: "exact"}},
 			assert: func(t *testing.T, matcher RouteMatcher, err error) {
 				t.Helper()
 
 				require.NoError(t, err)
-				assert.IsType(t, compositeMatcher{}, matcher)
+				assert.IsType(t, andMatcher{}, matcher)
 				assert.Len(t, matcher, 1)
 
-				hms := matcher.(compositeMatcher)
+				hms := matcher.(andMatcher)
 				assert.IsType(t, &pathParamMatcher{}, hms[0])
 				assert.IsType(t, &exactMatcher{}, hms[0].(*pathParamMatcher).typedMatcher)
 			},
 		},
-		{
-			uc:   "unsupported type",
+		"unsupported type": {
 			conf: []config.ParameterMatcher{{Name: "foo", Value: "foo", Type: "bar"}},
 			assert: func(t *testing.T, _ RouteMatcher, err error) {
 				t.Helper()
@@ -292,7 +292,7 @@ func TestCreatePathParamsMatcher(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(tc.uc, func(t *testing.T) {
+		t.Run(uc, func(t *testing.T) {
 			pm, err := createPathParamsMatcher(tc.conf, config.EncodedSlashesOff)
 
 			tc.assert(t, pm, err)
@@ -303,17 +303,16 @@ func TestCreatePathParamsMatcher(t *testing.T) {
 func TestSchemeMatcherMatches(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
-		uc      string
+	for uc, tc := range map[string]struct {
 		matcher schemeMatcher
 		toMatch string
 		matches bool
 	}{
-		{uc: "matches any schemes", matcher: schemeMatcher(""), toMatch: "foo", matches: true},
-		{uc: "matches", matcher: schemeMatcher("http"), toMatch: "http", matches: true},
-		{uc: "does not match", matcher: schemeMatcher("http"), toMatch: "https"},
+		"matches any schemes": {matcher: schemeMatcher(""), toMatch: "foo", matches: true},
+		"matches":             {matcher: schemeMatcher("http"), toMatch: "http", matches: true},
+		"does not match":      {matcher: schemeMatcher("http"), toMatch: "https"},
 	} {
-		t.Run(tc.uc, func(t *testing.T) {
+		t.Run(uc, func(t *testing.T) {
 			err := tc.matcher.Matches(
 				&heimdall.Request{URL: &heimdall.URL{URL: url.URL{Scheme: tc.toMatch}}},
 				nil,
@@ -333,17 +332,16 @@ func TestSchemeMatcherMatches(t *testing.T) {
 func TestMethodMatcherMatches(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
-		uc      string
+	for uc, tc := range map[string]struct {
 		matcher methodMatcher
 		toMatch string
 		matches bool
 	}{
-		{uc: "matches any methods", matcher: methodMatcher{}, toMatch: "GET", matches: true},
-		{uc: "matches", matcher: methodMatcher{"GET"}, toMatch: "GET", matches: true},
-		{uc: "does not match", matcher: methodMatcher{"GET"}, toMatch: "POST"},
+		"matches any methods": {matcher: methodMatcher{}, toMatch: "GET", matches: true},
+		"matches":             {matcher: methodMatcher{"GET"}, toMatch: "GET", matches: true},
+		"does not match":      {matcher: methodMatcher{"GET"}, toMatch: "POST"},
 	} {
-		t.Run(tc.uc, func(t *testing.T) {
+		t.Run(uc, func(t *testing.T) {
 			err := tc.matcher.Matches(&heimdall.Request{Method: tc.toMatch}, nil, nil)
 
 			if tc.matches {
@@ -359,17 +357,42 @@ func TestMethodMatcherMatches(t *testing.T) {
 func TestHostMatcherMatches(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
-		uc      string
+	for uc, tc := range map[string]struct {
 		conf    []config.HostMatcher
 		toMatch string
 		matches bool
 	}{
-		{uc: "matches any host", conf: []config.HostMatcher{{Value: "**", Type: "glob"}}, toMatch: "foo.example.com", matches: true},
-		{uc: "matches", conf: []config.HostMatcher{{Value: "example.com", Type: "exact"}}, toMatch: "example.com", matches: true},
-		{uc: "does not match", conf: []config.HostMatcher{{Value: "^example.com", Type: "regex"}}, toMatch: "foo.example.com"},
+		"matches any host in requests": {
+			conf:    []config.HostMatcher{{Value: "**", Type: "glob"}},
+			toMatch: "foo.example.com",
+			matches: true,
+		},
+		"matches single exact value": {
+			conf:    []config.HostMatcher{{Value: "example.com", Type: "exact"}},
+			toMatch: "example.com",
+			matches: true,
+		},
+		"matches host from request if multiple matches are defined and one is appropriate": {
+			conf: []config.HostMatcher{
+				{Value: "foo.com", Type: "exact"},
+				{Value: "example.com", Type: "exact"},
+			},
+			toMatch: "example.com",
+			matches: true,
+		},
+		"does not match single regex based value": {
+			conf:    []config.HostMatcher{{Value: "^example.com", Type: "regex"}},
+			toMatch: "foo.example.com",
+		},
+		"does not match if multiple values are defined, but none of them are appropriate": {
+			conf: []config.HostMatcher{
+				{Value: "foo.com", Type: "exact"},
+				{Value: "bar.com", Type: "exact"},
+			},
+			toMatch: "example.com",
+		},
 	} {
-		t.Run(tc.uc, func(t *testing.T) {
+		t.Run(uc, func(t *testing.T) {
 			hm, err := createHostMatcher(tc.conf)
 			require.NoError(t, err)
 
@@ -388,91 +411,79 @@ func TestHostMatcherMatches(t *testing.T) {
 func TestPathParamsMatcherMatches(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
-		uc            string
+	for uc, tc := range map[string]struct {
 		conf          []config.ParameterMatcher
 		slashHandling config.EncodedSlashesHandling
-		toMatch       url.URL
+		toMatch       string
 		keys          []string
 		values        []string
 		matches       bool
 	}{
-		{
-			uc: "parameter not present in keys",
+		"parameter not present in keys": {
 			conf: []config.ParameterMatcher{
 				{Name: "foo", Type: "exact", Value: "bar"},
 			},
 			keys:   []string{"bar"},
 			values: []string{"baz"},
 		},
-		{
-			uc: "encoded slashes are not allowed",
+		"encoded slashes are not allowed": {
 			conf: []config.ParameterMatcher{
 				{Name: "foo", Type: "exact", Value: "bar%2Fbaz"},
 			},
 			slashHandling: config.EncodedSlashesOff,
 			keys:          []string{"foo"},
 			values:        []string{"bar%2Fbaz"},
-			toMatch: func() url.URL {
-				uri, err := url.Parse("http://example.com/bar%2Fbaz")
-				require.NoError(t, err)
-
-				return *uri
-			}(),
+			toMatch:       "http://example.com/bar%2Fbaz",
 		},
-		{
-			uc: "matches with path having allowed but not decoded encoded slashes",
+		"matches with path having allowed but not decoded encoded slashes": {
 			conf: []config.ParameterMatcher{
 				{Name: "foo", Type: "exact", Value: "bar%2Fbaz[id]"},
 			},
 			slashHandling: config.EncodedSlashesOnNoDecode,
 			keys:          []string{"foo"},
 			values:        []string{"bar%2Fbaz%5Bid%5D"},
-			toMatch: func() url.URL {
-				uri, err := url.Parse("http://example.com/bar%2Fbaz%5Bid%5D")
-				require.NoError(t, err)
-
-				return *uri
-			}(),
-			matches: true,
+			toMatch:       "http://example.com/bar%2Fbaz%5Bid%5D",
+			matches:       true,
 		},
-		{
-			uc: "matches with path having allowed decoded slashes",
+		"matches with path having allowed decoded slashes": {
 			conf: []config.ParameterMatcher{
 				{Name: "foo", Type: "exact", Value: "bar/baz[id]"},
 			},
 			slashHandling: config.EncodedSlashesOn,
 			keys:          []string{"foo"},
 			values:        []string{"bar%2Fbaz%5Bid%5D"},
-			toMatch: func() url.URL {
-				uri, err := url.Parse("http://example.com/foo%2Fbaz%5Bid%5D")
-				require.NoError(t, err)
-
-				return *uri
-			}(),
-			matches: true,
+			toMatch:       "http://example.com/foo%2Fbaz%5Bid%5D",
+			matches:       true,
 		},
-		{
-			uc: "doesn't match",
+		"does not match the request path if appropriate matcher is not defined as first element": {
+			conf: []config.ParameterMatcher{
+				{Name: "foo", Type: "exact", Value: "bar/foo"},
+				{Name: "foo", Type: "exact", Value: "bar/bar"},
+			},
+			slashHandling: config.EncodedSlashesOn,
+			keys:          []string{"foo"},
+			values:        []string{"bar/bar"},
+			toMatch:       "http://example.com/foo/bar",
+			matches:       false,
+		},
+		"doesn't match": {
 			conf: []config.ParameterMatcher{
 				{Name: "foo", Type: "exact", Value: "bar"},
 			},
 			slashHandling: config.EncodedSlashesOn,
 			keys:          []string{"foo"},
 			values:        []string{"baz"},
-			toMatch: func() url.URL {
-				uri, err := url.Parse("http://example.com/bar")
-				require.NoError(t, err)
-
-				return *uri
-			}(),
+			toMatch:       "http://example.com/bar",
 		},
 	} {
-		t.Run(tc.uc, func(t *testing.T) {
+		t.Run(uc, func(t *testing.T) {
 			hm, err := createPathParamsMatcher(tc.conf, tc.slashHandling)
 			require.NoError(t, err)
 
-			err = hm.Matches(&heimdall.Request{URL: &heimdall.URL{URL: tc.toMatch}}, tc.keys, tc.values)
+			uri, err := url.Parse(tc.toMatch)
+			require.NoError(t, err)
+
+			err = hm.Matches(&heimdall.Request{URL: &heimdall.URL{URL: *uri}}, tc.keys, tc.values)
 
 			if tc.matches {
 				require.NoError(t, err)
@@ -484,39 +495,79 @@ func TestPathParamsMatcherMatches(t *testing.T) {
 	}
 }
 
-func TestCompositeMatcherMatches(t *testing.T) {
+func TestAndMatcherMatches(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
-		uc      string
-		matcher compositeMatcher
+	for uc, tc := range map[string]struct {
+		matcher andMatcher
 		method  string
 		scheme  string
 		matches bool
 	}{
-		{
-			uc:      "matches anything",
-			matcher: compositeMatcher{},
+		"matches anything": {
+			matcher: andMatcher{},
 			method:  "GET",
 			scheme:  "foo",
 			matches: true,
 		},
-		{
-			uc:      "matches",
-			matcher: compositeMatcher{methodMatcher{"GET"}, schemeMatcher("https")},
+		"matches": {
+			matcher: andMatcher{methodMatcher{"GET"}, schemeMatcher("https")},
 			method:  "GET",
 			scheme:  "https",
 			matches: true,
 		},
-		{
-			uc:      "does not match",
-			matcher: compositeMatcher{methodMatcher{"POST"}},
+		"does not match": {
+			matcher: andMatcher{methodMatcher{"POST"}},
 			method:  "GET",
 			scheme:  "https",
 			matches: false,
 		},
 	} {
-		t.Run(tc.uc, func(t *testing.T) {
+		t.Run(uc, func(t *testing.T) {
+			err := tc.matcher.Matches(
+				&heimdall.Request{Method: tc.method, URL: &heimdall.URL{URL: url.URL{Scheme: tc.scheme}}},
+				nil,
+				nil,
+			)
+
+			if tc.matches {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestOrMatcherMatches(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		matcher orMatcher
+		method  string
+		scheme  string
+		matches bool
+	}{
+		"matches anything": {
+			matcher: orMatcher{},
+			method:  "GET",
+			scheme:  "foo",
+			matches: true,
+		},
+		"matches": {
+			matcher: orMatcher{methodMatcher{"GET"}, schemeMatcher("https")},
+			method:  "POST",
+			scheme:  "https",
+			matches: true,
+		},
+		"does not match": {
+			matcher: orMatcher{methodMatcher{"POST"}},
+			method:  "GET",
+			scheme:  "https",
+			matches: false,
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
 			err := tc.matcher.Matches(
 				&heimdall.Request{Method: tc.method, URL: &heimdall.URL{URL: url.URL{Scheme: tc.scheme}}},
 				nil,

--- a/internal/rules/rule_factory_impl.go
+++ b/internal/rules/rule_factory_impl.go
@@ -141,7 +141,7 @@ func (f *ruleFactory) CreateRule(version, srcID string, ruleConfig config2.Rule)
 			&routeImpl{
 				rule:    rul,
 				path:    rc.Path,
-				matcher: compositeMatcher{sm, mm, hm, ppm},
+				matcher: andMatcher{sm, mm, hm, ppm},
 			})
 	}
 


### PR DESCRIPTION
## Related issue(s)

closes #2232

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

Prior to this PR, the implemented logic used an AND approach when evaluating host expressions. This PR improves the documentation as well by clearly describing how the different conditions are combined.
