### PR TITLE
fix: `X-Forwarded-For`, `-Proto`, `-Host` and `Forwarded` are always send to the upstream in proxy mode

### DIFF
--- a/internal/handler/proxy/request_context.go
+++ b/internal/handler/proxy/request_context.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -129,58 +130,76 @@ func (r *requestContext) rewriteRequest(targetURL *url.URL) func(req *httputil.P
 		proxyReq.Out.Header.Del("X-Forwarded-Uri")
 		proxyReq.Out.Header.Del("X-Forwarded-Path")
 
-		// delete those headers which are set by heimdall first
-		// we do this to prevent spoofing
-		uh := r.UpstreamHeaders()
-		for name := range uh {
-			proxyReq.Out.Header.Del(name)
-		}
+		r.addUpstreamHeader(proxyReq.Out)
+		r.addUpstreamCookies(proxyReq.Out)
+		r.rewriteForwardedHeader(proxyReq.In, proxyReq.Out)
+	}
+}
 
-		// add them now
-		for name, values := range uh {
-			for _, value := range values {
-				proxyReq.Out.Header.Add(name, value)
+func (r *requestContext) rewriteForwardedHeader(in, out *http.Request) {
+	// set headers, which might be relevant for the upstream, if these are present in the original request
+	// and have not been dropped
+	forwardedHost := in.Header.Get("X-Forwarded-Host")
+	forwardedProto := in.Header.Get("X-Forwarded-Proto")
+	forwardedFor := in.Header.Get("X-Forwarded-For")
+	forwarded := in.Header.Get("Forwarded")
+	proto := x.IfThenElse(in.TLS != nil, "https", "http")
+	clientIP := httpx.IPFromHostPort(r.req.RemoteAddr)
+
+	out.Header.Set("X-Forwarded-For", x.IfThenElseExec(len(forwardedFor) == 0,
+		func() string { return clientIP },
+		func() string { return fmt.Sprintf("%s, %s", forwardedFor, clientIP) }))
+
+	out.Header.Set("X-Forwarded-Proto",
+		x.IfThenElse(len(forwardedProto) == 0, proto, forwardedProto))
+
+	out.Header.Set("X-Forwarded-Host",
+		x.IfThenElse(len(forwardedHost) == 0, in.Host, forwardedHost))
+
+	out.Header.Set("Forwarded", x.IfThenElseExec(len(forwarded) == 0,
+		func() string {
+			if strings.Contains(clientIP, ":") {
+				// IPv6 must be quoted
+				clientIP = "\"[" + clientIP + "]\""
 			}
+
+			return fmt.Sprintf("for=%s;host=%s;proto=%s",
+				clientIP, in.Host, proto)
+		},
+		func() string {
+			if strings.Contains(clientIP, ":") {
+				// IPv6 must be quoted
+				clientIP = "\"[" + clientIP + "]\""
+			}
+
+			return fmt.Sprintf("%s, for=%s;host=%s;proto=%s",
+				forwarded, clientIP, in.Host, proto)
+		}))
+}
+
+func (r *requestContext) addUpstreamCookies(req *http.Request) {
+	for k, v := range r.UpstreamCookies() {
+		req.AddCookie(&http.Cookie{Name: k, Value: v})
+	}
+}
+
+func (r *requestContext) addUpstreamHeader(req *http.Request) {
+	// delete those headers which are set by heimdall first
+	// we do this to prevent spoofing
+	uh := r.UpstreamHeaders()
+	for name := range uh {
+		req.Header.Del(name)
+	}
+
+	// add them now
+	for name, values := range uh {
+		for _, value := range values {
+			req.Header.Add(name, value)
 		}
+	}
 
-		if host := uh.Get("Host"); len(host) != 0 {
-			proxyReq.Out.Host = host
-			proxyReq.Out.Header.Del("Host")
-		}
-
-		for k, v := range r.UpstreamCookies() {
-			proxyReq.Out.AddCookie(&http.Cookie{Name: k, Value: v})
-		}
-
-		// set headers, which might be relevant for the upstream, if these are present in the original request
-		// and have not been dropped
-		forwardedHost := proxyReq.In.Header.Get("X-Forwarded-Host")
-		forwardedProto := proxyReq.In.Header.Get("X-Forwarded-Proto")
-		forwardedFor := proxyReq.In.Header.Get("X-Forwarded-For")
-		forwarded := proxyReq.In.Header.Get("Forwarded")
-		proto := x.IfThenElse(proxyReq.In.TLS != nil, "https", "http")
-		clientIP := httpx.IPFromHostPort(r.req.RemoteAddr)
-
-		if len(forwardedFor) != 0 || len(forwardedProto) != 0 || len(forwardedHost) != 0 {
-			proxyReq.Out.Header.Set("X-Forwarded-For", x.IfThenElseExec(len(forwardedFor) == 0,
-				func() string { return clientIP },
-				func() string { return fmt.Sprintf("%s, %s", forwardedFor, clientIP) }))
-
-			proxyReq.Out.Header.Set("X-Forwarded-Proto",
-				x.IfThenElse(len(forwardedProto) == 0, proto, forwardedProto))
-
-			proxyReq.Out.Header.Set("X-Forwarded-Host",
-				x.IfThenElse(len(forwardedHost) == 0, proxyReq.In.Host, forwardedHost))
-		} else {
-			proxyReq.Out.Header.Set("Forwarded", x.IfThenElseExec(len(forwarded) == 0,
-				func() string {
-					return fmt.Sprintf("for=%s;host=%s;proto=%s",
-						clientIP, proxyReq.In.Host, proto)
-				},
-				func() string {
-					return fmt.Sprintf("%s, for=%s;host=%s;proto=%s",
-						forwarded, clientIP, proxyReq.In.Host, proto)
-				}))
-		}
+	if host := uh.Get("Host"); len(host) != 0 {
+		req.Host = host
+		req.Header.Del("Host")
 	}
 }


### PR DESCRIPTION
## Related issue(s)

fixes #2243

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

Fix for the referenced issue.  

Additionally, this PR corrects the handling of the `for` directive in the `Forwarded` header when the value is an IPv6 address, as specified in [RFC 7239](https://datatracker.ietf.org/doc/html/rfc7239). Previously, the value was neither quoted nor enclosed in `[` and `]`.
