### PR TITLE
feat: Helm Chart as OCI image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -242,6 +242,13 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      packages: write
+      id-token: write
+    needs:
+      - release-container-image
+    outputs:
+      digest: ${{ steps.publish-ghcr.outputs.digest }}
+      image_name: ${{ steps.publish-ghcr.outputs.image_name }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
@@ -267,6 +274,50 @@ jobs:
           linting: off
           chart_version: ${{ steps.prepare.outputs.chart_version }}
           app_version: ${{ steps.prepare.outputs.app_version }}
+      - name: Publish Chart to GHCR
+        id: publish-ghcr
+        uses: ./.github/actions/helm-chart-oci-publisher
+        with:
+          name: ${{ github.event.repository.name }}
+          repository: ${{ github.repository }}/chart
+          chart_version: ${{ steps.prepare.outputs.chart_version }}
+          app_version: ${{ steps.prepare.outputs.app_version }}
+          registry: ghcr.io
+          registry_username: ${{ github.actor }}
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a # v3.8.1
+        with:
+          cosign-release: "${{ env.COSIGN_VERSION }}"
+      - name: Login to GitHub
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Sign the Helm chart in GHCR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          cosign sign --yes ${{ steps.publish-ghcr.outputs.image_name }}@${{ steps.publish-ghcr.outputs.digest }}
+
+  create-ghcr-helm-provenance:
+    needs:
+      - release-helm-chart
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    # Note: this _must_ be referenced by tag. See: https://github.com/slsa-framework/slsa-verifier/issues/12
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.1.0
+    with:
+      image: ${{ needs.release-helm-chart.outputs.image_name }}
+      digest: ${{ needs.release-helm-chart.outputs.digest }}
+    secrets:
+      registry-username: ${{ github.actor }}
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
+
 
   verify-provenance:
     needs:
@@ -275,6 +326,7 @@ jobs:
       - create-binaries-provenance
       - create-dockerhub-image-provenance
       - create-ghcr-image-provenance
+      - create-ghcr-helm-provenance
     runs-on: ubuntu-24.04
     permissions: read-all
     steps:
@@ -321,6 +373,10 @@ jobs:
       - name: Verify image released to GitHub
         run: |
           IMAGE=ghcr.io/${{ github.repository }}:${{ steps.version.outputs.result }}@${{ needs.release-container-image.outputs.ghcr_image_digest }}
+          slsa-verifier verify-image "${IMAGE}" --source-uri github.com/${{ github.repository }} --source-tag ${{ github.ref_name }}
+      - name: Verify helm chart released to GitHub
+        run: |
+          IMAGE=${{ needs.release-helm-chart.outputs.image_name }}@${{ needs.release-helm-chart.outputs.digest }}
           slsa-verifier verify-image "${IMAGE}" --source-uri github.com/${{ github.repository }} --source-tag ${{ github.ref_name }}
 
   release-documentation:

--- a/charts/heimdall/README.adoc
+++ b/charts/heimdall/README.adoc
@@ -9,14 +9,12 @@ This chart helps you to deploy heimdall in your Kubernetes cluster using Helm.
 == Prerequisites
 
 * A Kubernetes version >= 1.27
-* https://helm.sh/docs/intro/install/[Helm] 3.0+
+* https://helm.sh/docs/intro/install/[Helm] 3.10+
 * https://git-scm.com/downloads[Git] (optional)
 
 == Getting the Chart Sources
 
 This step is required if you want installing the chart using its sources. Additionally, the step may also be required for managing the custom resource definitions (CRDs), which heimdall requires, or for upgrading/deleting the CRDs.
-
-To install the chart with the release name `my-release` (`my-release` is the name that you choose):
 
 1. Clone the heimdall repo:
 +
@@ -30,16 +28,6 @@ git clone https://github.com/dadrus/heimdall
 [source,bash]
 ----
 cd heimdall
-----
-
-== Adding the Helm Repository
-
-This step is required if you're installing the chart via the helm repository.
-
-[source,bash]
-----
-$ helm repo add dadrus https://dadrus.github.io/heimdall/charts
-$ helm repo update
 ----
 
 == Installing the Chart
@@ -56,6 +44,14 @@ By default, heimdall requires a custom resource definition (CRD) installed in th
 
 === Installing via Helm Repository
 
+Add the Helm repository hosted on GitHub Pages.
+
+[source,bash]
+----
+$ helm repo add dadrus https://dadrus.github.io/heimdall/charts
+$ helm repo update
+----
+
 To install the chart with the release name "my-release" ("my-release" is the name that you choose) and configure heimdall to operate in decision mode:
 
 [source,bash]
@@ -70,7 +66,16 @@ If you need proxy mode, install it with:
 $ helm install my-release -f heimdall.yaml --set operationMode=proxy dadrus/heimdall
 ----
 
-In both cases you have to integrate it with your ingress controller. For decision mode that means setting corresponding annotations on Ingress resources to let the traffic first be verified by heimdall before it is forwarded to the upstream services by the Ingress Controller.
+=== Installing via OCI Image
+
+The chart is also published as an OCI image to GHCR, offering an alternative with enhanced security. The OCI image is signed and includes SLSA provenance, which can be verified for authenticity and integrity as described in https://dadrus.github.io/heimdall/dev/docs/operations/security/#_verification_of_heimdall_artifacts[Verification of Heimdall Artifacts].
+
+To install with the release name "my-release" ("my-release" is the name that you choose) and configure heimdall to operate in decision mode:
+
+[source,bash]
+----
+helm install my-release -f heimdall.yaml oci://ghcr.io/dadrus/heimdall/chart
+----
 
 === Installing Using Chart Sources
 
@@ -90,9 +95,9 @@ $ helm install my-release -f heimdall.yaml --set operationMode=proxy ./charts/he
 
 === Post-Install Steps
 
-==== Integration with Ingress
+==== Integration with Ingress/Gateway API
 
-After having installed heimdall, you have to integrate it with your ingress controller. For decision mode that means setting corresponding annotations on Ingress resources to let the traffic first be verified by heimdall before it is forwarded to the upstream services by the Ingress Controller.
+No matter which installation approach you choose, if Heimdall is running in decision mode, you need to connect it to your ingress controller or Gateway API implementation afterward. This ensures traffic is validated by Heimdall prior to being routed to upstream services. Check the existing https://dadrus.github.io/heimdall/dev/guides/[Guides] for more information.
 
 ==== Metrics Collection
 
@@ -156,6 +161,13 @@ To upgrade the release "my-release" using Helm Repository:
 [source,bash]
 ----
 $ helm upgrade my-release dadrus/heimdall
+----
+
+To upgrade the release "my-release" using the OCI image:
+
+[source,bash]
+----
+$ helm upgrade my-release oci://ghcr.io/dadrus/heimdall/chart
 ----
 
 == Uninstalling the Chart

--- a/docs/content/docs/operations/security.adoc
+++ b/docs/content/docs/operations/security.adoc
@@ -104,18 +104,25 @@ NOTE: As of today secret reloading is only supported for link:{{< relref "/docs/
 
 == Verification of Heimdall Artifacts
 
-Heimdall binaries and container images are signed using https://docs.sigstore.dev/docs/signing/quickstart/[Cosign] and the https://docs.sigstore.dev/docs/signing/overview/[keyless signing feature]. Additionally, SLSA provenance is generated for released binaries and container images, providing a higher level of assurance about the build process in accordance with https://slsa.dev/spec/v1.0/levels#build-l3-hardened-builds[SLSA Level 3] requirements.
+Heimdall releases include three types of artifacts: archived binaries, container images, and Helm Charts (as OCI images). Each is signed using https://docs.sigstore.dev/docs/signing/quickstart/[Cosign] with its https://docs.sigstore.dev/docs/signing/overview/[keyless signing feature]. Additionally, SLSA provenance is generated for all released artifacts, providing a higher level of assurance about the build process in accordance with https://slsa.dev/spec/v1.0/levels#build-l3-hardened-builds[SLSA Level 3] requirements. This chapter explains how to verify the signatures and provenance for each artifact type.
+
+NOTE: The Helm Chart is also released to gh-pages, but this version is neither signed nor accompanied by provenance.
 
 === Prerequisites
 
-* Install https://docs.sigstore.dev/docs/system_config/installation/[Cosign]
-* Install https://github.com/slsa-framework/slsa-verifier#installation[slsa-verifier]
+To verify the artifacts, install the following tools:
+
+* https://docs.sigstore.dev/docs/system_config/installation/[Cosign]
+* https://github.com/slsa-framework/slsa-verifier#installation[slsa-verifier]
+* https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md[crane] (for Helm chart OCI image verification)
+
+These tools are required for verifying signatures and provenance across all artifact types.
 
 === Container Image Verification
 
 ==== Signature Verification with Cosign
 
-The signatures are stored in a repository named `dadrus/heimdall-signatures`. To verify the released container image using Cosign, execute the following command:
+Signatures for container images are stored in `dadrus/heimdall-signatures`. To verify a released container image, run:
 
 [source, bash]
 ----
@@ -125,9 +132,9 @@ cosign verify dadrus/heimdall:<tag> \
   --certificate-oidc-issuer=https://token.actions.githubusercontent.com | jq
 ----
 
-NOTE: If you pull heimdall images from ghcr.io, reference the `ghcr.io` registry while specifying the repository names. So `dadrus/heimdall-signatures` becomes `ghcr.io/dadrus/heimdall-signatures` and `dadrus/heimdall:<tag>` becomes `ghcr.io/dadrus/heimdall:<tag>`.
+NOTE: For images from GHCR, use `ghcr.io/dadrus/heimdall-signatures` and `ghcr.io/dadrus/heimdall:<tag>`. For `dev` tagged images, adjust `--certificate-identity-regexp` to `https://github.com/dadrus/heimdall/.github/workflows/ci.yaml*`.
 
-In successful verification case, cosign will print similar output to the one shown below and exit with `0`.
+On success, Cosign outputs JSON (similar to the example below) and exits with `0`.
 
 [source, json]
 ----
@@ -170,30 +177,72 @@ In successful verification case, cosign will print similar output to the one sho
 ]
 ----
 
-For released images, the `Subject` value ends with `@refs/tags/<release version>`, as indicated in the snippet above. The `dev` tagged images can be verified similarly, but the `--certificate-identity-regexp` flag needs to be set to `https://github.com/dadrus/heimdall/.github/workflows/ci.yaml*`, since these images are built and signed by a different workflow.
+For released images, the `Subject` value ends with `@refs/tags/<release version>`, as indicated in the snippet above.
 
 ==== Provenance Verification with slsa-verifier
 
-To verify the SLSA provenance of the container image using `slsa-verifier`, execute the following commands:
+To verify the SLSA provenance of a container image, first obtain its digest:
 
 [source, bash]
 ----
 IMAGE=$(docker inspect dadrus/heimdall:<tag> | jq -r '.[0].RepoDigests[0]')
 # instead of docker, you can also use podman, crane, or similar tools
+----
+
+Then verify:
+
+[source, bash]
+----
 slsa-verifier verify-image "${IMAGE}" \
   --source-uri github.com/dadrus/heimdall \
   --source-tag v<tag>
 ----
 
-NOTE: If you pull heimdall image from ghcr.io, use `ghcr.io/dadrus/heimdall:<tag>` as reference to get the image digest.
+NOTE: Use `ghcr.io/dadrus/heimdall:<tag>` for GHCR images.
+
+On success, `slsa-verifier` prints a success message and exits with `0`.
+
+=== Helm Chart Verification
+
+==== Signature Verification with Cosign
+
+To verify the Helm Chart OCI image signature, run:
+
+[source, bash]
+----
+cosign verify ghcr.io/dadrus/heimdall/chart/heimdall:<tag> \
+  --certificate-identity-regexp=https://github.com/dadrus/heimdall/.github/workflows/release.yaml* \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com | jq
+----
+
+Replace `<tag>` with the chart version (e.g., `0.15.0`). On success, Cosign outputs JSON similar to the container image example and exits with `0`.
+
+==== Provenance Verification with slsa-verifier
+
+To verify the Helm Chart’s provenance, obtain its digest:
+
+[source, bash]
+----
+IMAGE=ghcr.io/dadrus/heimdall/chart/heimdall:<tag>
+DIGEST=$(crane digest "${IMAGE}")
+----
+
+Then verify:
+
+[source, bash]
+----
+slsa-verifier verify-image "${IMAGE}@${DIGEST}" \
+  --source-uri github.com/dadrus/heimdall \
+  --source-tag <heimdall release version>
+----
+
+Replace `<tag>` with the chart version (e.g., `0.15.0`), and use `--source-tag` matching the GitHub release. Please note that the `<tag>` of the chart image does not correspond to the heimdall release version. On success, `slsa-verifier` prints a success message and exits with `0`.
 
 === Release Binary Verification
 
 ==== Signature Verification with Cosign
 
-The detached signatures and certificates for all released archives are published together with the corresponding platform-specific archive. The names of the signature files adhere to the `<archive>.sig` naming pattern, and the names of the certificate files adhere to the `<archive>.pem` naming pattern, with `<archive>` being the archive for a platform-specific build.
-
-To verify the signature of the archive, hence its contents including the platform-specific heimdall binary, execute the following command:
+Detached signatures and certificates for all released archives are published alongside each platform-specific archive (e.g., `<archive>.sig` and `<archive>.pem`). To verify the signature of an archive, including its platform-specific heimdall binary, run:
 
 [source, bash]
 ----
@@ -204,18 +253,11 @@ cosign verify-blob /path/to/the/downloaded/<archive> \
   --certificate /path/to/the/downloaded/<archive>.pem
 ----
 
-In successful verification case, cosign will print the following output and exit with `0`.
-
-[source, bash]
-----
-Verified OK
-----
+On successful verification, Cosign outputs `Verified OK` and exits with `0`.
 
 ==== Provenance Verification with slsa-verifier
 
-The SLSA provenance for each release archive is published alongside the archive and follows the `heimdall_<release version>.intoto.jsonl` naming pattern. This file contains the provenance information generated during the SLSA Level 3 compliant build process.
-
-To verify the provenance of the archive, execute the following command:
+SLSA provenance is published as `heimdall_<release version>.intoto.jsonl` for all released archives. To verify the provenance for a particular archive, run:
 
 [source, bash]
 ----
@@ -226,7 +268,9 @@ slsa-verifier verify-artifact \
   /path/to/the/downloaded/<archive>
 ----
 
-In a successful verification case, `slsa-verifier` will print a success message and exit with `0`. Replace `<release version>` with the specific version tag of the release (e.g., `v0.16.0`) that corresponds to the archive.
+Replace `<release version>` with the specific version tag of the release (e.g., `v0.16.0`) that corresponds to the archive.
+
+On success, `slsa-verifier` prints a success message and exits with `0`.
 
 == Software Bill of Material (SBOM)
 
@@ -245,7 +289,7 @@ cosign verify-attestation dadrus/heimdall:<tag> \
   --type=cyclonedx
 ----
 
-NOTE: If you pull heimdall images from ghcr.io, reference the `ghcr.io` registry while specifying the repository names. So `dadrus/heimdall-sbom` becomes `ghcr.io/dadrus/heimdall-sbom` and `dadrus/heimdall:<tag>` becomes `ghcr.io/dadrus/heimdall:<tag>`.
+NOTE: If you pull heimdall images from GHCR, reference the `ghcr.io` registry while specifying the repository names. So `dadrus/heimdall-sbom` becomes `ghcr.io/dadrus/heimdall-sbom` and `dadrus/heimdall:<tag>` becomes `ghcr.io/dadrus/heimdall:<tag>`.
 
 In successful verification case, cosign will print similar output to the one shown below and exit with `0`.
 


### PR DESCRIPTION
## Related issue(s)

closes #2291

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

This PR modifies the release workflow to publish the Helm Chart as an OCI image alongside its existing gh-pages distribution. It also implements signing of the chart image using Cosign and generates SLSA provenance for it.
