### PR TITLE
feat: Configurable limits for in-memory cache

### DIFF
--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -60,10 +60,10 @@ deployment:
     # E.g.:
     # limits:
     #   cpu: 100m
-    #   memory: 128Mi
+    #   memory: 256Mi
     # requests:
     #   cpu: 100m
-  #   memory: 128Mi
+  #   memory: 256Mi
 
   # Only used if autoscaling is disabled (see below)
   replicaCount: 2

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -57,13 +57,18 @@ deployment:
 
   # Remove the curly braces after 'resources:' if you want to specify resources
   resources: { }
-    # E.g.:
+    # Example configuration:
     # limits:
     #   cpu: 100m
     #   memory: 256Mi
     # requests:
     #   cpu: 100m
-  #   memory: 256Mi
+    #   memory: 256Mi
+    # Notes:
+    # - Memory settings depend on your cache backend configuration in heimdall.
+    # - By default, heimdall uses an in-memory cache limited to 128Mi.
+    # - If using Redis without client-side caching configured, the cache is also limited to 128Mi by default.
+    # - The heimdall process itself requires approximately 64Mi of memory.
 
   # Only used if autoscaling is disabled (see below)
   replicaCount: 2

--- a/docs/content/docs/operations/cache.adoc
+++ b/docs/content/docs/operations/cache.adoc
@@ -33,9 +33,7 @@ cache:
 
 == In-Memory Backend
 
-This backend manages the cached items in memory of heimdall's process.
-
-To configure it, you have to specify `in-memory` as type. No further configuration is supported. Here an example:
+This is the default caching backend used by heimdall. It manages the cached items in memory of heimdall's process. To explicitly configure it, specify `in-memory` as the type.
 
 [source, yaml]
 ----
@@ -43,7 +41,26 @@ cache:
   type: in-memory
 ----
 
-NOTE: By default, heimdall makes use of this backend.
+Additional optional configuration options via `config` allow control over the cache's memory usage (defaulting to 128MB if not specified) and the number of entries it can hold. The following properties are supported:
+
+* *`memory_limit`*: _link:{{< relref "/docs/configuration/types.adoc#_bytesize" >}}[ByteSize]_ (optional)
++
+The maximum amount of memory the cache is allowed to use. This limit helps prevent excessive memory consumption and may affect the number of entries stored. Defaults to 128MB.
+
+* *`entry_limit`*: _integer_ (optional)
++
+The maximum number of entries the cache can store. This limit ensures the cache doesn’t grow indefinitely and can be used in conjunction with `memory_limit` to manage cache size. If not specified, there is no limit on the number of entries.
+
+Here is an example configuration that sets the memory limit to 256MB and the entry limit to 10000:
+
+[source, yaml]
+----
+cache:
+  type: in-memory
+  config:
+    memory_limit: 256MB
+    entry_limit: 10000
+----
 
 
 == Redis Backends

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/dadrus/heimdall
 go 1.24.1
 
 require (
+	github.com/DmitriyVTitov/size v1.5.0
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/alicebob/miniredis/v2 v2.34.0
 	github.com/ccoveille/go-safecast v1.6.1
@@ -31,7 +32,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf
 	github.com/instana/go-otel-exporter v1.0.0
-	github.com/jellydator/ttlcache/v3 v3.3.0
+	github.com/jellydator/ttlcache/v3 v3.3.1-0.20250207140243-aefc35918359
 	github.com/johannesboyne/gofakes3 v0.0.0-20250106100439-5c39aecd6999
 	github.com/justinas/alice v1.2.0
 	github.com/knadh/koanf/maps v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/Azure/go-autorest/autorest/to v0.4.0/go.mod h1:fE8iZBn7LQR7zH/9XU2NcP
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DmitriyVTitov/size v1.5.0 h1:/PzqxYrOyOUX1BXj6J9OuVRVGe+66VL4D9FlUaW515g=
+github.com/DmitriyVTitov/size v1.5.0/go.mod h1:le6rNI4CoLQV1b9gzp1+3d7hMAD/uu2QcJ+aYbNgiU0=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=
@@ -255,8 +257,8 @@ github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf h1:FtEj8sfIcaaB
 github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf/go.mod h1:yrqSXGoD/4EKfF26AOGzscPOgTTJcyAwM2rpixWT+t4=
 github.com/instana/go-otel-exporter v1.0.0 h1:s7PPvvB8xcSRNaXpgjYpBQWnFZRAqGGJZPkQ/j6RNjU=
 github.com/instana/go-otel-exporter v1.0.0/go.mod h1:chO0kaNOIV+bhh+eYRBiSShhuOHMV6HHQYgVo/7xxAs=
-github.com/jellydator/ttlcache/v3 v3.3.0 h1:BdoC9cE81qXfrxeb9eoJi9dWrdhSuwXMAnHTbnBm4Wc=
-github.com/jellydator/ttlcache/v3 v3.3.0/go.mod h1:bj2/e0l4jRnQdrnSTaGTsh4GSXvMjQcy41i7th0GVGw=
+github.com/jellydator/ttlcache/v3 v3.3.1-0.20250207140243-aefc35918359 h1:uzTOUCYbGERlXB3wX2/u9AsMeXnZCd8yLl2DMAY1Wxs=
+github.com/jellydator/ttlcache/v3 v3.3.1-0.20250207140243-aefc35918359/go.mod h1:aqa3CYl8S7MwpMXtFH3uNIEEfOjcn1MUNO+bQIGbFAQ=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/internal/cache/memory/cache.go
+++ b/internal/cache/memory/cache.go
@@ -19,7 +19,6 @@ package memory
 import (
 	"context"
 	"errors"
-	"github.com/dadrus/heimdall/internal/x"
 	"time"
 
 	"github.com/inhies/go-bytesize"
@@ -27,6 +26,7 @@ import (
 
 	"github.com/dadrus/heimdall/internal/app"
 	"github.com/dadrus/heimdall/internal/cache"
+	"github.com/dadrus/heimdall/internal/x"
 )
 
 const defaultCacheMemorySize = 128 * bytesize.MB

--- a/internal/cache/memory/cache.go
+++ b/internal/cache/memory/cache.go
@@ -19,13 +19,17 @@ package memory
 import (
 	"context"
 	"errors"
+	"github.com/dadrus/heimdall/internal/x"
 	"time"
 
+	"github.com/inhies/go-bytesize"
 	"github.com/jellydator/ttlcache/v3"
 
 	"github.com/dadrus/heimdall/internal/app"
 	"github.com/dadrus/heimdall/internal/cache"
 )
+
+const defaultCacheMemorySize = 128 * bytesize.MB
 
 var ErrNoCacheEntry = errors.New("no cache entry")
 
@@ -34,8 +38,44 @@ func init() { // nolint: gochecknoinits
 	cache.Register("in-memory", cache.FactoryFunc(NewCache))
 }
 
-func NewCache(_ app.Context, _ map[string]any) (cache.Cache, error) {
-	return &Cache{c: ttlcache.New[string, []byte](ttlcache.WithDisableTouchOnHit[string, []byte]())}, nil
+func NewCache(_ app.Context, conf map[string]any) (cache.Cache, error) {
+	type Config struct {
+		MaxEntries uint64             `mapstructure:"max_entries"`
+		MaxMemory  *bytesize.ByteSize `mapstructure:"max_memory"`
+	}
+
+	var cfg Config
+
+	if len(conf) != 0 {
+		err := decodeConfig(conf, &cfg)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	maxMemory := x.IfThenElseExec(cfg.MaxMemory == nil,
+		func() uint64 { return uint64(defaultCacheMemorySize) },
+		func() uint64 { return uint64(*cfg.MaxMemory) },
+	)
+
+	return &Cache{
+		c: ttlcache.New[string, []byte](
+			ttlcache.WithDisableTouchOnHit[string, []byte](),
+			ttlcache.WithCapacity[string, []byte](cfg.MaxEntries),
+			ttlcache.WithMaxCost[string, []byte](maxMemory,
+				func(item *ttlcache.Item[string, []byte]) uint64 {
+					// An empty cache takes up 374 bytes.
+					// Each entry incurs overhead: 16 bytes for the string (key) metadata and 24 bytes
+					// for the []byte (value) metadata. The cache also maintains internal structures,
+					// averaging about 144 bytes per entry. Combined, this results in an overhead of
+					// approximately 184 bytes, excluding the empty cache size.
+					const ttlCacheOverheadPerEntry = 184
+
+					return uint64(len(item.Key()) + len(item.Value()) + ttlCacheOverheadPerEntry) //nolint:gosec
+				},
+			),
+		),
+	}, nil
 }
 
 type Cache struct {

--- a/internal/cache/memory/cache_test.go
+++ b/internal/cache/memory/cache_test.go
@@ -46,15 +46,15 @@ func TestNewCache(t *testing.T) {
 			err:    heimdall.ErrConfiguration,
 		},
 		"max memory is configured": {
-			config: []byte(`max_memory: 10MB`),
+			config: []byte(`memory_limit: 10MB`),
 		},
 		"max entries is configured": {
-			config: []byte(`max_entries: 10`),
+			config: []byte(`entry_limit: 10`),
 		},
 		"both, max entries and max memory are configured": {
 			config: []byte(`
-max_entries: 10
-max_memory: 100MB
+entry_limit: 10
+memory_limit: 100MB
 `),
 		},
 	} {
@@ -178,10 +178,10 @@ func TestMemoryCacheExpiration(t *testing.T) {
 	assert.LessOrEqual(t, hits, 4)
 }
 
-func TestMaxMemoryUsage(t *testing.T) {
+func TestMemoryLimit(t *testing.T) {
 	t.Parallel()
 
-	cch, err := NewCache(nil, map[string]any{"max_memory": "2MB"})
+	cch, err := NewCache(nil, map[string]any{"memory_limit": "2MB"})
 	require.NoError(t, err)
 
 	err = cch.Start(t.Context())
@@ -201,10 +201,10 @@ func TestMaxMemoryUsage(t *testing.T) {
 	assert.LessOrEqual(t, finalSize, int(2*bytesize.MB))
 }
 
-func TestMaxEntriesUsage(t *testing.T) {
+func TestEntryLimit(t *testing.T) {
 	t.Parallel()
 
-	cch, err := NewCache(nil, map[string]any{"max_entries": 10})
+	cch, err := NewCache(nil, map[string]any{"entry_limit": 10})
 	require.NoError(t, err)
 
 	err = cch.Start(t.Context())

--- a/internal/cache/memory/config_decoder.go
+++ b/internal/cache/memory/config_decoder.go
@@ -1,0 +1,47 @@
+// Copyright 2024 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package memory
+
+import (
+	"github.com/go-viper/mapstructure/v2"
+
+	"github.com/dadrus/heimdall/internal/config"
+	"github.com/dadrus/heimdall/internal/heimdall"
+	"github.com/dadrus/heimdall/internal/x/errorchain"
+)
+
+func decodeConfig(input any, output any) error {
+	dec, err := mapstructure.NewDecoder(
+		&mapstructure.DecoderConfig{
+			DecodeHook: mapstructure.ComposeDecodeHookFunc(
+				config.StringToByteSizeHookFunc(),
+			),
+			Result:      output,
+			ErrorUnused: true,
+		})
+	if err != nil {
+		return errorchain.NewWithMessagef(heimdall.ErrConfiguration,
+			"failed decoding in-memory cache config").CausedBy(err)
+	}
+
+	if err = dec.Decode(input); err != nil {
+		return errorchain.NewWithMessagef(heimdall.ErrConfiguration,
+			"failed decoding in-memory cache config").CausedBy(err)
+	}
+
+	return nil
+}

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -89,6 +89,27 @@
       "properties": {
         "type": {
           "const": "in-memory"
+        },
+        "config": {
+          "description": "In-Memory cache configuration",
+          "type": "object",
+          "properties": {
+            "max_memory": {
+              "description": "The maximum memory size a cache is allowed to use",
+              "type": "string",
+              "default": "128MB",
+              "pattern": "^[0-9]+(B|KB|MB|GB)$",
+              "examples": [
+                "1GB",
+                "256MB",
+                "128KB"
+              ]
+            },
+            "max_entries": {
+              "description": "The maximum number of entries a cache is permitted to store",
+              "type": "integer"
+            }
+          }
         }
       }
     },

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -94,8 +94,8 @@
           "description": "In-Memory cache configuration",
           "type": "object",
           "properties": {
-            "max_memory": {
-              "description": "The maximum memory size a cache is allowed to use",
+            "memory_limit": {
+              "description": "The maximum amount of memory the cache is allowed to use. This limit helps prevent excessive memory consumption and may affect the number of entries stored.",
               "type": "string",
               "default": "128MB",
               "pattern": "^[0-9]+(B|KB|MB|GB)$",
@@ -105,8 +105,8 @@
                 "128KB"
               ]
             },
-            "max_entries": {
-              "description": "The maximum number of entries a cache is permitted to store",
+            "entry_limit": {
+              "description": "The maximum number of entries the cache can store. This limit ensures the cache doesn’t grow indefinitely and can be used in conjunction with `memoryLimit` to manage cache size.",
               "type": "integer"
             }
           }


### PR DESCRIPTION
## Related issue(s)

closes #1250 

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

This PR limits the in-memory cache of heimdall by default to 128MB to prevent excessive memory consumption, and introduces optional configuration options to allow fine-tuning. The snippet below shows the new configuration options:

```yaml
cache:
  type: in-memory
  config: # <- this is new
    memory_limit: 256MB # defaults to 128MB if not set
    entry_limit: 10000 # unbound if not set
```
