### PR TITLE
refactor!: Default main port set to 4456

### DIFF
--- a/DockerHub-README.md
+++ b/DockerHub-README.md
@@ -37,23 +37,23 @@ default_rule:
 Start heimdall:
 
 ```bash
-docker run -t -p 4455:4455 -v $PWD:/heimdall/conf \
+docker run -t -p 4456:4456 -v $PWD:/heimdall/conf \
   dadrus/heimdall:latest serve decision -c /heimdall/conf/heimdall.yaml
 ```
 
 Call the decision service endpoint to emulate behavior of an API-Gateway:
 
 ```bash
-curl -v 127.0.0.1:4455/foobar
+curl -v 127.0.0.1:4456/foobar
 ```
 
 You should now see similar output to the following snippet:
 
 ```bash
-*   Trying 127.0.0.1:4455...
-* Connected to 127.0.0.1 (127.0.0.1) port 4455 (#0)
+*   Trying 127.0.0.1:4456...
+* Connected to 127.0.0.1 (127.0.0.1) port 4456 (#0)
 > GET /foobar HTTP/1.1
-> Host: 127.0.0.1:4455
+> Host: 127.0.0.1:4456
 > User-Agent: curl/7.74.0
 > Accept: */*
 >
@@ -142,7 +142,7 @@ services:
       # Mount your rule file:
       - ./rule.yaml:/heimdall/conf/rule.yaml:ro
     ports:
-      - 4455:4455
+      - 4456:4456
     command: -c /heimdall/conf/config.yaml serve proxy
   
   upstream:
@@ -158,16 +158,16 @@ docker compose up
 Call the proxy service endpoint to emulate behavior of a client application:
 
 ```bash
-curl -v 127.0.0.1:4455/foobar
+curl -v 127.0.0.1:4456/foobar
 ```
 
 You should now see similar output to the following snippet:
 
 ```bash
-*   Trying 127.0.0.1:4455...
-* Connected to 127.0.0.1 (127.0.0.1) port 4455 (#0)
+*   Trying 127.0.0.1:4456...
+* Connected to 127.0.0.1 (127.0.0.1) port 4456 (#0)
 > GET /foobar HTTP/1.1
-> Host: 127.0.0.1:4455
+> Host: 127.0.0.1:4456
 > User-Agent: curl/7.74.0
 > Accept: */*
 >

--- a/charts/heimdall/README.adoc
+++ b/charts/heimdall/README.adoc
@@ -348,7 +348,7 @@ a| `{}` (empty map)
 a| `service.main.port`
 
 The main port exposed by the k8s Service created for heimdall.
-a| `4455`
+a| `4456`
 
 a| `service.main.name`
 

--- a/charts/heimdall/tests/configmap_test.yaml
+++ b/charts/heimdall/tests/configmap_test.yaml
@@ -58,7 +58,7 @@ tests:
           value:
             |-
             serve:
-              port: 4455
+              port: 4456
             management:
               port: 4457
             profiling:
@@ -174,7 +174,7 @@ tests:
                 read: 4KB
                 write: 10KB
               host: 127.0.0.1
-              port: 4455
+              port: 4456
               respond:
                 verbose: true
                 with:

--- a/charts/heimdall/tests/container_test.yaml
+++ b/charts/heimdall/tests/container_test.yaml
@@ -241,7 +241,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports
           value:
-            - containerPort: 4455
+            - containerPort: 4456
               name: http-main
               protocol: TCP
             - containerPort: 4457
@@ -256,7 +256,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports
           value:
-            - containerPort: 4455
+            - containerPort: 4456
               name: http-main
               protocol: TCP
             - containerPort: 4457
@@ -272,7 +272,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports
           value:
-            - containerPort: 4455
+            - containerPort: 4456
               name: http-main
               protocol: TCP
             - containerPort: 4457
@@ -292,7 +292,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports
           value:
-            - containerPort: 4455
+            - containerPort: 4456
               name: http-main
               protocol: TCP
             - containerPort: 4457
@@ -310,7 +310,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports
           value:
-            - containerPort: 4455
+            - containerPort: 4456
               name: http-main
               protocol: TCP
             - containerPort: 4457
@@ -329,7 +329,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports
           value:
-            - containerPort: 4455
+            - containerPort: 4456
               name: http-main
               protocol: TCP
             - containerPort: 4457
@@ -350,7 +350,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports
           value:
-            - containerPort: 4455
+            - containerPort: 4456
               name: http-main
               protocol: TCP
             - containerPort: 4457
@@ -374,7 +374,7 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports
           value:
-            - containerPort: 4455
+            - containerPort: 4456
               name: http-main
               protocol: TCP
             - containerPort: 4457

--- a/charts/heimdall/tests/service_test.yaml
+++ b/charts/heimdall/tests/service_test.yaml
@@ -124,7 +124,7 @@ tests:
               protocol: TCP
               targetPort: http-management
             - name: main
-              port: 4455
+              port: 4456
               protocol: TCP
               targetPort: http-main
 
@@ -140,7 +140,7 @@ tests:
               protocol: TCP
               targetPort: http-management
             - name: main
-              port: 4455
+              port: 4456
               protocol: TCP
               targetPort: http-main
 
@@ -157,7 +157,7 @@ tests:
               protocol: TCP
               targetPort: http-management
             - name: main
-              port: 4455
+              port: 4456
               protocol: TCP
               targetPort: http-main
 
@@ -173,7 +173,7 @@ tests:
               protocol: TCP
               targetPort: http-management
             - name: main
-              port: 4455
+              port: 4456
               protocol: TCP
               targetPort: http-main
 
@@ -192,7 +192,7 @@ tests:
               protocol: TCP
               targetPort: http-management
             - name: main
-              port: 4455
+              port: 4456
               protocol: TCP
               targetPort: http-main
             - name: admission-controller

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -104,7 +104,7 @@ service:
   # Main service
   main:
     # Service port
-    port: 4455
+    port: 4456
     # Service port name
     name: main
   # Management service
@@ -159,7 +159,7 @@ extraArgs: []
 # heimdall config defaults
 # DO NOT OVERRIDE the values here. Use heimdall config yaml file instead!
 serve:
-  port: 4455
+  port: 4456
 management:
   port: 4457
 profiling:

--- a/docs/content/docs/concepts/operating_modes.adoc
+++ b/docs/content/docs/concepts/operating_modes.adoc
@@ -64,7 +64,7 @@ Imagine following request hits heimdall (sent to it by an API gateway)
 [source, bash]
 ----
 GET /my-service/api HTTP/1.1
-Host: heimdall:4455
+Host: heimdall:4456
 X-Forwarded-Host: my-backend-service
 
 Some payload
@@ -138,7 +138,7 @@ Imagine following request hits heimdall
 [source, bash]
 ----
 GET /my-service/api HTTP/1.1
-Host: heimdall:4455
+Host: heimdall:4456
 
 Some payload
 ----

--- a/docs/content/docs/getting_started/protect_an_app.adoc
+++ b/docs/content/docs/getting_started/protect_an_app.adoc
@@ -248,7 +248,7 @@ services:
   heimdall: # <1>
     image: dadrus/heimdall:dev
     ports:
-    - "9090:4455"
+    - "9090:4456"
     volumes:
     - ./heimdall-config.yaml:/etc/heimdall/config.yaml:ro
     - ./upstream-rules.yaml:/etc/heimdall/rules.yaml:ro
@@ -299,7 +299,7 @@ services:
     - traefik.enable=true
     - traefik.http.routers.traefik_http.service=api@internal
     - traefik.http.routers.traefik_http.entrypoints=http
-    - traefik.http.middlewares.heimdall.forwardauth.address=http://heimdall:4455  # <2>
+    - traefik.http.middlewares.heimdall.forwardauth.address=http://heimdall:4456  # <2>
     - traefik.http.middlewares.heimdall.forwardauth.authResponseHeaders=Authorization
 
   heimdall:  # <3>

--- a/docs/content/docs/operations/security.adoc
+++ b/docs/content/docs/operations/security.adoc
@@ -75,7 +75,7 @@ heimdall container image is shipped without any certificates by intention to ens
 E.g.
 [source, bash]
 ----
-docker run -t -p 4455:4455 \
+docker run -t -p 4456:4456 \
   -v $PWD:/heimdall/conf \
   -v /etc/ssl/certs/ca-certificates.crt:/etc/ssl/certs/ca-certificates.crt:ro \
    dadrus/heimdall:dev serve decision \

--- a/docs/content/docs/services/main.adoc
+++ b/docs/content/docs/services/main.adoc
@@ -12,7 +12,7 @@ description: This is heimdall's main service responsible for driving the actual 
 
 :toc:
 
-To make use of this service you have to start heimdall with either `heimdall serve proxy` or `heimdall serve decision`. By default, heimdall listens on `0.0.0.0:4455` endpoint for incoming requests and also configures useful defaults. You can, and should however adjust the configuration for your needs.
+To make use of this service you have to start heimdall with either `heimdall serve proxy` or `heimdall serve decision`. By default, heimdall listens on `0.0.0.0:4456` endpoint for incoming requests and also configures useful defaults. You can, and should however adjust the configuration for your needs.
 
 == Configuration
 
@@ -24,7 +24,7 @@ By making use of this property, you can specify the TCP/IP address on which heim
 
 * *`port`*: _integer_ (optional)
 +
-By making use of this property, you can specify the TCP port that heimdall should listen on. Defaults to `4455`.
+By making use of this property, you can specify the TCP port that heimdall should listen on. Defaults to `4456`.
 
 * *`timeout`*: _Timeout_ (optional)
 +

--- a/docs/content/guides/authn/oidc_first_party_auth.adoc
+++ b/docs/content/guides/authn/oidc_first_party_auth.adoc
@@ -230,7 +230,7 @@ services:
   heimdall: # <1>
     image: dadrus/heimdall:dev
     ports:
-      - "9090:4455"
+      - "9090:4456"
     command: serve proxy --c /etc/heimdall/config.yaml --insecure
     volumes:
       - ./heimdall-config.yaml:/etc/heimdall/config.yaml:ro

--- a/docs/content/guides/authz/openfga.adoc
+++ b/docs/content/guides/authz/openfga.adoc
@@ -45,7 +45,7 @@ services:
     image: dadrus/heimdall:dev
     container_name: heimdall
     ports:
-    - "9090:4455"
+    - "9090:4456"
     volumes:
     - ./heimdall-config.yaml:/etc/heimdall/config.yaml:ro
     - ./rules:/etc/heimdall/rules:ro

--- a/docs/content/guides/proxies/caddy.adoc
+++ b/docs/content/guides/proxies/caddy.adoc
@@ -36,7 +36,7 @@ NOTE: Proper configuration of `trusted_proxies` is mandatory when using this opt
 :9090 {
     reverse_proxy upstream:8081
 
-    forward_auth https://heimdall:4455 { <1>
+    forward_auth https://heimdall:4456 { <1>
         uri          / <2>
         copy_headers Authorization <3>
     }
@@ -57,7 +57,7 @@ With this method, `X-Forwarded-*` headers are not used, relying solely on the st
 :9090 {
     reverse_proxy upstream:8081
 
-    forward_auth https://heimdall:4455 { <1>
+    forward_auth https://heimdall:4456 { <1>
         uri          {http.request.uri} <2>
         method       {http.request.method} <3>
         header_down  Host {http.request.hostport} <4>

--- a/docs/content/guides/proxies/contour.adoc
+++ b/docs/content/guides/proxies/contour.adoc
@@ -83,7 +83,7 @@ spec:
   protocol: h2
   services:
     - name: heimdall
-      port: 4455
+      port: 4456
 ----
 +
 The `ExtensionService` resource definition tells Contour to program Envoy with an upstream cluster directing traffic to heimdall. That way, as also described in the link:{{< relref "envoy.adoc" >}}[Envoy Integration Guide], Envoy will delegate authentication and authorization to heimdall. If heimdall answers with a `200 OK` HTTP code, Envoy grants access and forwards the original request to the upstream service. Otherwise, the response from heimdall is treated as an error and is returned to the client.

--- a/docs/content/guides/proxies/envoy.adoc
+++ b/docs/content/guides/proxies/envoy.adoc
@@ -56,7 +56,7 @@ clusters:
                 address:
                   socket_address:
                     address: heimdall
-                    port_value: 4455
+                    port_value: 4456
   # other cluster entries
 ----
 <1> The name of our cluster
@@ -79,7 +79,7 @@ http_filters:
       transport_api_version: V3 # <2>
       http_service:
         server_uri: # <3>
-          uri: heimdall:4455
+          uri: heimdall:4456
           cluster: ext-authz
           timeout: 0.25s
         authorization_request:
@@ -175,7 +175,7 @@ static_resources:
                     transport_api_version: V3
                     http_service:
                       server_uri:
-                        uri: heimdall:4455
+                        uri: heimdall:4456
                         cluster: ext-authz
                         timeout: 0.25s
                       authorization_request:
@@ -212,7 +212,7 @@ static_resources:
                   address:
                     socket_address:
                       address: heimdall
-                      port_value: 4455
+                      port_value: 4456
     - name: services
       connect_timeout: 5s
       type: strict_dns

--- a/docs/content/guides/proxies/envoy_gateway.adoc
+++ b/docs/content/guides/proxies/envoy_gateway.adoc
@@ -54,7 +54,7 @@ spec:
     grpc:
       backendRef: # <4>
         name: heimdall
-        port: 4455
+        port: 4456
         namespace: heimdall
 ----
 <1> The name of the `SecurityPolicy`. You can change it to any other value if you like.
@@ -82,7 +82,7 @@ spec:
     grpc:
       backendRef: # <4>
         name: heimdall
-        port: 4455
+        port: 4456
         namespace: heimdall
 ----
 <1> The name of the `SecurityPolicy`. You can change it to any other value if you like.
@@ -107,7 +107,7 @@ spec:
     kind: Service
     namespace: heimdall
     name: heimdall
-    sectionName: "4455"
+    sectionName: "4456"
   tls: # <3>
     caCertRefs:
       - name: demo-ca # <4>

--- a/docs/content/guides/proxies/istio.adoc
+++ b/docs/content/guides/proxies/istio.adoc
@@ -57,7 +57,7 @@ data:
     - name: heimdall-ext-auth # <1>
       envoyExtAuthzGrpc: # <2>
         service: heimdall.heimdall.svc.cluster.local # <3>
-        port: "4455"
+        port: "4456"
 ----
 <1> `heimdall-ext-auth` is the name of our extension provider, which will be referenced later in the https://istio.io/latest/docs/reference/config/security/authorization-policy/[`AuthorizationPolicy`] configuration.
 <2> We're using a gRPC based implementation here. However, since Istio does not automatically configure Envoy to use HTTP/2 for gRPC calls, it requires an additional https://istio.io/latest/docs/reference/config/networking/envoy-filter/[`EnvoyFilter`] resource. This appears to be a bug in Istio's implementation.
@@ -77,7 +77,7 @@ data:
     - name: heimdall-ext-auth
       envoyExtAuthzHttp:
         service: heimdall.heimdall.svc.cluster.local
-        port: "4455"
+        port: "4456"
         includeRequestHeadersInCheck: [ "authorization", "cookie", "accept", "x-forwarded-for", "x-forwarded-proto", "x-forwarded-host" ] # <1>
         headersToUpstreamOnAllow: [ "authorization" ] # <2>
 ----
@@ -102,7 +102,7 @@ spec:
       match: # <3>
         context: GATEWAY
         cluster:
-          name: outbound|4455||heimdall.heimdall.svc.cluster.local
+          name: outbound|4456||heimdall.heimdall.svc.cluster.local
       patch:
         operation: MERGE
         value:

--- a/docs/content/guides/proxies/nginx.adoc
+++ b/docs/content/guides/proxies/nginx.adoc
@@ -75,7 +75,7 @@ location = /_auth {  <4>
   internal;
   access_log               off;
   proxy_method             $request_method; <5>
-  proxy_pass               https://heimdall:4455$request_uri; <6>
+  proxy_pass               https://heimdall:4456$request_uri; <6>
   proxy_pass_request_body  off; <7>
   proxy_set_header         Content-Length   "";
   proxy_set_header         Host $http_host; <8>
@@ -106,7 +106,7 @@ NOTE: Proper configuration of `trusted_proxies` is mandatory if using this optio
 
 location = /_auth {
   internal;
-  proxy_pass               https://heimdall:4455;  <1>
+  proxy_pass               https://heimdall:4456;  <1>
   proxy_pass_request_body  off;
   proxy_set_header         Content-Length         "";
   proxy_set_header         X-Forwarded-Method     $request_method;  <2>

--- a/docs/content/guides/proxies/traefik.adoc
+++ b/docs/content/guides/proxies/traefik.adoc
@@ -47,7 +47,7 @@ http:
   middlewares:
     heimdall: # <2>
       forwardAuth: # <3>
-        address: "https://heimdall:4455" # <4>
+        address: "https://heimdall:4456" # <4>
         authResponseHeaders:
         - Authorization # <5>
 
@@ -73,7 +73,7 @@ metadata: # <1>
   namespace: heimdall
 spec:
   forwardAuth: # <2>
-    address: "https://heimdall.heimdall.svc.cluster.local:4455" # <3>
+    address: "https://heimdall.heimdall.svc.cluster.local:4456" # <3>
     authResponseHeaders: # <4>
       - Authorization
 ----
@@ -125,7 +125,7 @@ services:
     # other config options
     labels:
     # other labels
-    - traefik.http.middlewares.heimdall.forwardauth.address=https://heimdall:4455 # <3>
+    - traefik.http.middlewares.heimdall.forwardauth.address=https://heimdall:4456 # <3>
     - traefik.http.middlewares.heimdall.forwardauth.authResponseHeaders=Authorization # <4>
 
   heimdall:

--- a/examples/docker-compose/quickstarts/Caddyfile
+++ b/examples/docker-compose/quickstarts/Caddyfile
@@ -6,13 +6,13 @@
 	reverse_proxy upstream:8081
 
     # this configuration requires a secure trusted_proxies configuration in heimdall
-	forward_auth http://heimdall:4455 {
+	forward_auth http://heimdall:4456 {
     	uri          /
     	copy_headers Authorization
     }
 
     # alternative configuration without the need to configure trusted_proxies
-    #forward_auth http://heimdall:4455 {
+    #forward_auth http://heimdall:4456 {
     #    uri          /
     #    method       {method}
     #    header_down  Host {http.request.hostport}

--- a/examples/docker-compose/quickstarts/docker-compose-proxy.yaml
+++ b/examples/docker-compose/quickstarts/docker-compose-proxy.yaml
@@ -1,5 +1,5 @@
 services:
   heimdall:
     ports:
-    - "9090:4455"
+    - "9090:4456"
     command: serve proxy -c /etc/heimdall/config.yaml --insecure

--- a/examples/docker-compose/quickstarts/docker-compose-traefik.yaml
+++ b/examples/docker-compose/quickstarts/docker-compose-traefik.yaml
@@ -14,7 +14,7 @@ services:
     - traefik.enable=true
     - traefik.http.routers.traefik_http.service=api@internal
     - traefik.http.routers.traefik_http.entrypoints=http
-    - traefik.http.middlewares.heimdall.forwardauth.address=http://heimdall:4455
+    - traefik.http.middlewares.heimdall.forwardauth.address=http://heimdall:4456
     - traefik.http.middlewares.heimdall.forwardauth.authResponseHeaders=Authorization
 
   heimdall:

--- a/examples/docker-compose/quickstarts/envoy-config-grpc.yaml
+++ b/examples/docker-compose/quickstarts/envoy-config-grpc.yaml
@@ -48,7 +48,7 @@ static_resources:
                   address:
                     socket_address:
                       address: heimdall
-                      port_value: 4455
+                      port_value: 4456
     - name: services
       connect_timeout: 5s
       type: strict_dns

--- a/examples/docker-compose/quickstarts/envoy-config-http.yaml
+++ b/examples/docker-compose/quickstarts/envoy-config-http.yaml
@@ -18,7 +18,7 @@ static_resources:
                     transport_api_version: V3
                     http_service:
                       server_uri:
-                        uri: heimdall:4455
+                        uri: heimdall:4456
                         cluster: ext-authz
                         timeout: 0.25s
                       authorization_request:
@@ -55,7 +55,7 @@ static_resources:
                   address:
                     socket_address:
                       address: heimdall
-                      port_value: 4455
+                      port_value: 4456
     - name: services
       connect_timeout: 5s
       type: strict_dns

--- a/examples/kubernetes/haproxy/helm-values.yaml
+++ b/examples/kubernetes/haproxy/helm-values.yaml
@@ -5,7 +5,7 @@ controller:
 # Uncomment the below lines for a global configuration.metrics:
 # See also https://github.com/jcmoraisjr/haproxy-ingress/issues/1105
 #  config:
-#    auth-url: "https://heimdall.heimdall.svc.cluster.local:4455"
+#    auth-url: "https://heimdall.heimdall.svc.cluster.local:4456"
 #    auth-headers-succeed: "authorization"
 #    headers: |
 #      X-Forwarded-Uri: %[baseq]

--- a/examples/kubernetes/istio/envoy-filter.yaml
+++ b/examples/kubernetes/istio/envoy-filter.yaml
@@ -12,7 +12,7 @@ spec:
       match:
         context: GATEWAY
         cluster:
-          name: outbound|4455||heimdall.heimdall.svc.cluster.local
+          name: outbound|4456||heimdall.heimdall.svc.cluster.local
       patch:
         operation: MERGE
         value:

--- a/examples/kubernetes/istio/istio-values.yaml
+++ b/examples/kubernetes/istio/istio-values.yaml
@@ -20,10 +20,10 @@ meshConfig:
       # Istio doesn't configure HTTP 2 for GRPC communication. EnvoyFilter is required
       envoyExtAuthzGrpc:
         service: heimdall.heimdall.svc.cluster.local
-        port: "4455"
+        port: "4456"
       # alternatively, one can use the config from below. In that case EnvoyFilter is not needed
       #envoyExtAuthzHttp:
       #  service: heimdall.heimdall.svc.cluster.local
-      #  port: "4455"
+      #  port: "4456"
       #  includeRequestHeadersInCheck: [ "authorization", "cookie", "accept", "x-forwarded-for", "x-forwarded-proto", "x-forwarded-host" ]
       #  headersToUpstreamOnAllow: [ "authorization" ]

--- a/examples/kubernetes/nginx/global-helm-values.yaml
+++ b/examples/kubernetes/nginx/global-helm-values.yaml
@@ -1,6 +1,6 @@
 controller:
   config:
-    global-auth-url: https://heimdall.heimdall.svc.cluster.local:4455
+    global-auth-url: https://heimdall.heimdall.svc.cluster.local:4456
     global-auth-response-headers: "Authorization"
     global-auth-snippet: |
       proxy_set_header         X-Forwarded-Method     $request_method;

--- a/examples/kubernetes/quickstarts/demo-app/overlays/haproxy/ingress.yaml
+++ b/examples/kubernetes/quickstarts/demo-app/overlays/haproxy/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: echo-app
   # Comment the following annotations if you configure external auth globally
   annotations:
-    haproxy-ingress.github.io/auth-url: "https://heimdall.heimdall.svc.cluster.local:4455"
+    haproxy-ingress.github.io/auth-url: "https://heimdall.heimdall.svc.cluster.local:4456"
     haproxy-ingress.github.io/auth-headers-succeed: "authorization"
     haproxy-ingress.github.io/headers: |
       X-Forwarded-Uri: %[pathq]

--- a/examples/kubernetes/quickstarts/demo-app/overlays/nginx-route-based/ingress.yaml
+++ b/examples/kubernetes/quickstarts/demo-app/overlays/nginx-route-based/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/name: echo-app
   annotations:
-    nginx.ingress.kubernetes.io/auth-url: "https://heimdall.heimdall.svc.cluster.local:4455"
+    nginx.ingress.kubernetes.io/auth-url: "https://heimdall.heimdall.svc.cluster.local:4456"
     nginx.ingress.kubernetes.io/auth-response-headers: "Authorization"
     nginx.ingress.kubernetes.io/auth-snippet: |
       proxy_set_header         X-Forwarded-Method     $request_method;

--- a/examples/kubernetes/quickstarts/heimdall/backend-tls-policy.yaml
+++ b/examples/kubernetes/quickstarts/heimdall/backend-tls-policy.yaml
@@ -9,7 +9,7 @@ spec:
     kind: Service
     namespace: heimdall
     name: heimdall
-    sectionName: "4455"
+    sectionName: "4456"
   tls:
     caCertRefs:
       - name: cacerts

--- a/examples/kubernetes/quickstarts/heimdall/contour-extension-service.yaml
+++ b/examples/kubernetes/quickstarts/heimdall/contour-extension-service.yaml
@@ -7,4 +7,4 @@ spec:
   protocol: h2
   services:
     - name: heimdall
-      port: 4455
+      port: 4456

--- a/examples/kubernetes/quickstarts/heimdall/emissary-auth-service.yaml
+++ b/examples/kubernetes/quickstarts/heimdall/emissary-auth-service.yaml
@@ -4,6 +4,6 @@ metadata:
   name: heimdall
   namespace: heimdall
 spec:
-  auth_service: "https://heimdall.heimdall.svc.cluster.local:4455"
+  auth_service: "https://heimdall.heimdall.svc.cluster.local:4456"
   proto: grpc
   protocol_version: v3

--- a/examples/kubernetes/quickstarts/heimdall/envoygw-security-policy.yaml
+++ b/examples/kubernetes/quickstarts/heimdall/envoygw-security-policy.yaml
@@ -13,7 +13,7 @@ spec:
     grpc:
       backendRef:
         name: heimdall
-        port: 4455
+        port: 4456
         namespace: heimdall
 ---
 

--- a/examples/kubernetes/quickstarts/heimdall/heimdall-middleware.yaml
+++ b/examples/kubernetes/quickstarts/heimdall/heimdall-middleware.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: heimdall
 spec:
   forwardAuth:
-    address: "https://heimdall.heimdall.svc.cluster.local:4455"
+    address: "https://heimdall.heimdall.svc.cluster.local:4456"
     tls:
       caSecret: heimdall-tls
     authResponseHeaders:

--- a/internal/config/default_configuration.go
+++ b/internal/config/default_configuration.go
@@ -31,7 +31,7 @@ const (
 	defaultMaxIdleConnections        = 100
 	defaultMaxIdleConnectionsPerHost = 100
 
-	defaultServePort             = 4455
+	defaultServePort             = 4456
 	defaultManagementServicePort = 4457
 	defaultProfilingServicePort  = 10251
 


### PR DESCRIPTION
This PR updates the default main port to 4456, reverting to the value used for the decision service prior to #2089. Although the referenced PR introduces a breaking change, this adjustment reduces its impact on setups running heimdall in decision operation mode, which appears to be the most common use case across projects. For those using heimdall in proxy mode, the desired port can be set via the available configuration option, as shown below. 

```yaml
# heimdall config file
serve:
  port: 4455
```

If a Helm chart is used for deployment in proxy mode, the previous behavior - using port 4455 for the exposed service - can be restored, as also demonstrated below.

```yaml
# your helm chart value file

service:
  main:
    port: 4455
```