### PR TITLE
fix: Helm Chart updated to disable autoscaling by default and to check resource request configuration in HPA template

### DIFF
--- a/charts/heimdall/README.adoc
+++ b/charts/heimdall/README.adoc
@@ -8,7 +8,7 @@ This chart helps you to deploy heimdall in your Kubernetes cluster using Helm.
 
 == Prerequisites
 
-* A Kubernetes version >= 1.27
+* A Kubernetes version >= 1.29
 * https://helm.sh/docs/intro/install/[Helm] 3.10+
 * https://git-scm.com/downloads[Git] (optional)
 

--- a/charts/heimdall/README.adoc
+++ b/charts/heimdall/README.adoc
@@ -277,18 +277,34 @@ capabilities:
 
 a|`deployment.resources`
 
-Enables you to specify the resources for the deployment, like limits, etc
+Specifies resource requests and limits for the deployment.
+
+**Note:** Memory usage depends on the cache backend and its configuration. By default, heimdall uses an in-memory cache limited to 128Mi. With Redis (with client-side caching), the limit is also 128Mi. The heimdall process itself requires ~64Mi.
+
+Example:
+```yaml
+deployment:
+  resources:
+    limits:
+      cpu: 125m
+      memory: 256Mi
+    requests:
+      cpu: 125m
+      memory: 256Mi
+```
 a| `{}` (empty map)
 
 a| `deployment.replicaCount`
 
-If HPA is disabled, allows specifying the amount of desired replicas
-a| `2`
+Allows specifying the amount of desired replicas (only used if HPA is disabled)
+a| `1`
 
 a| `deployment.autoscaling.enabled`
 
 Enables or disables HPA based on CPU and memory utilization
-a| `true`
+
+If enabled, `deployment.resources.requests` must be configured.
+a| `false`
 
 a| `deployment.autoscaling.minReplicas`
 
@@ -303,11 +319,15 @@ a| `10`
 a| `deployment.autoscaling.targetCPUUtilizationPercentage`
 
 Target CPU utilization in % to scale up
+
+Requires `deployment.resources.requests.cpu` to be configured
 a| `80`
 
 a| `deployment.autoscaling.targetMemoryUtilizationPercentage`
 
 Target Memory utilization in % to scale up
+
+Requires `deployment.resources.requests.memory` to be configured
 a| `80`
 
 a| `deployment.nodeSelector`

--- a/charts/heimdall/templates/hpa.yaml
+++ b/charts/heimdall/templates/hpa.yaml
@@ -18,6 +18,12 @@
 {{- if and (not .Values.deployment.autoscaling.targetCPUUtilizationPercentage) (not .Values.deployment.autoscaling.targetMemoryUtilizationPercentage) }}
   {{- fail "autoscaling is enabled, but usage of both, the cpu and the memory metrics is disabled" }}
 {{- end }}
+{{- if and .Values.deployment.autoscaling.targetCPUUtilizationPercentage (not (dig "requests" "cpu" "" .Values.deployment.resources)) }}
+  {{- fail "autoscaling is configured to use cpu metrics, but no cpu resource requests are configured" }}
+{{- end }}
+{{- if and .Values.deployment.autoscaling.targetMemoryUtilizationPercentage (not (dig "requests" "memory" "" .Values.deployment.resources)) }}
+  {{- fail "autoscaling is configured to use memory metrics, but no memory resource requests are configured" }}
+{{- end }}
 {{- $data := dict "Release" .Release "Values" .Values "Chart" .Chart }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler

--- a/charts/heimdall/tests/deployment_test.yaml
+++ b/charts/heimdall/tests/deployment_test.yaml
@@ -160,16 +160,14 @@ tests:
             foo: bar
             helm.sh/chart: heimdall-2.0.0
 
-  - it: should configure 2 replicas if autoscaling is disabled
+  - it: should configure 1 replica by default
     template: deployment.yaml
-    set:
-      deployment.autoscaling.enabled: false
     asserts:
       - equal:
           path: spec.replicas
-          value: 2
+          value: 1
 
-  - it: should not configure replicas if autoscaling is enabled (default)
+  - it: should not configure replicas if autoscaling is enabled
     template: deployment.yaml
     set:
       deployment.autoscaling.enabled: true

--- a/charts/heimdall/tests/hpa_test.yaml
+++ b/charts/heimdall/tests/hpa_test.yaml
@@ -2,21 +2,44 @@ suite: test suite for horizontal pod autoscaler
 templates:
   - hpa.yaml
 tests:
-  - it: should be configured by default
-    asserts:
-      - isKind:
-          of: HorizontalPodAutoscaler
-      - isAPIVersion:
-          of: autoscaling/v2
-
-  - it: can be disabled
-    set:
-      deployment.autoscaling.enabled: false
+  - it: should not be configured by default
     asserts:
       - hasDocuments:
           count: 0
 
+
+  - it: should error when enabled, but both, cpu and memory metrics are disabled
+    set:
+      deployment.autoscaling.enabled: true
+      deployment.autoscaling.targetCPUUtilizationPercentage: 0
+      deployment.autoscaling.targetMemoryUtilizationPercentage: 0
+    asserts:
+      - failedTemplate:
+          errorMessage: autoscaling is enabled, but usage of both, the cpu and the memory metrics is disabled
+
+  - it: should error when cpu metrics are enabled, but no cpu resource requests are configured
+    set:
+      deployment.autoscaling.enabled: true
+      deployment.autoscaling.targetCPUUtilizationPercentage: 50
+      deployment.autoscaling.targetMemoryUtilizationPercentage: 0
+    asserts:
+      - failedTemplate:
+          errorMessage: autoscaling is configured to use cpu metrics, but no cpu resource requests are configured
+
+  - it: should error when memory metrics are enabled, but no memory resource requests are configured
+    set:
+      deployment.autoscaling.enabled: true
+      deployment.autoscaling.targetCPUUtilizationPercentage: 0
+      deployment.autoscaling.targetMemoryUtilizationPercentage: 50
+    asserts:
+      - failedTemplate:
+          errorMessage: autoscaling is configured to use memory metrics, but no memory resource requests are configured
+
   - it: name should be set with default name
+    set:
+      deployment.autoscaling.enabled: true
+      deployment.resources.requests.cpu: 100m
+      deployment.resources.requests.memory: 196Mi
     asserts:
       - equal:
           path: metadata.name
@@ -27,6 +50,9 @@ tests:
       name: test-release
     set:
       nameOverride: foo
+      deployment.autoscaling.enabled: true
+      deployment.resources.requests.cpu: 100m
+      deployment.resources.requests.memory: 196Mi
     asserts:
       - equal:
           path: metadata.name
@@ -35,12 +61,20 @@ tests:
   - it: namespace should be set
     release:
       namespace: test-namespace
+    set:
+      deployment.autoscaling.enabled: true
+      deployment.resources.requests.cpu: 100m
+      deployment.resources.requests.memory: 196Mi
     asserts:
       - equal:
           path: metadata.namespace
           value: test-namespace
 
   - it: should set default labels with default values
+    set:
+      deployment.autoscaling.enabled: true
+      deployment.resources.requests.cpu: 100m
+      deployment.resources.requests.memory: 196Mi
     asserts:
       - isSubset:
           path: metadata.labels
@@ -61,6 +95,9 @@ tests:
       name: test-release
     set:
       nameOverride: foo
+      deployment.autoscaling.enabled: true
+      deployment.resources.requests.cpu: 100m
+      deployment.resources.requests.memory: 196Mi
     asserts:
       - equal:
           path: metadata.labels
@@ -72,6 +109,10 @@ tests:
             helm.sh/chart: heimdall-2.0.0
 
   - it: should have no annotations
+    set:
+      deployment.autoscaling.enabled: true
+      deployment.resources.requests.cpu: 100m
+      deployment.resources.requests.memory: 196Mi
     asserts:
       - notExists:
           path: metadata.annotations
@@ -79,6 +120,10 @@ tests:
   - it: should reference expected deployment
     release:
       name: test-release
+    set:
+      deployment.autoscaling.enabled: true
+      deployment.resources.requests.cpu: 100m
+      deployment.resources.requests.memory: 196Mi
     asserts:
       - equal:
           path: spec.scaleTargetRef
@@ -88,6 +133,10 @@ tests:
             name: test-release-heimdall
 
   - it: should set min and max replicas by default
+    set:
+      deployment.autoscaling.enabled: true
+      deployment.resources.requests.cpu: 100m
+      deployment.resources.requests.memory: 196Mi
     asserts:
       - equal:
           path: spec.minReplicas
@@ -98,17 +147,24 @@ tests:
 
   - it: min and max replicas can be configured
     set:
-      deployment.autoscaling.minReplicas: 1
+      deployment.autoscaling.enabled: true
+      deployment.autoscaling.minReplicas: 2
       deployment.autoscaling.maxReplicas: 4
+      deployment.resources.requests.cpu: 100m
+      deployment.resources.requests.memory: 196Mi
     asserts:
       - equal:
           path: spec.minReplicas
-          value: 1
+          value: 2
       - equal:
           path: spec.maxReplicas
           value: 4
 
   - it: should configure cpu and memory metrics by default with default average utilization
+    set:
+      deployment.autoscaling.enabled: true
+      deployment.resources.requests.cpu: 100m
+      deployment.resources.requests.memory: 196Mi
     asserts:
       - equal:
           path: spec.metrics
@@ -128,10 +184,11 @@ tests:
 
   - it: should configure cpu and memory metrics with specified average utilization
     set:
-      deployment:
-        autoscaling:
-          targetCPUUtilizationPercentage: 40
-          targetMemoryUtilizationPercentage: 50
+      deployment.autoscaling.enabled: true
+      deployment.autoscaling.targetCPUUtilizationPercentage: 40
+      deployment.autoscaling.targetMemoryUtilizationPercentage: 50
+      deployment.resources.requests.cpu: 100m
+      deployment.resources.requests.memory: 196Mi
     asserts:
       - equal:
           path: spec.metrics
@@ -151,9 +208,9 @@ tests:
 
   - it: cpu metrics can be disabled
     set:
-      deployment:
-        autoscaling:
-          targetCPUUtilizationPercentage: 0
+      deployment.autoscaling.enabled: true
+      deployment.autoscaling.targetCPUUtilizationPercentage: 0
+      deployment.resources.requests.memory: 196Mi
     asserts:
       - equal:
           path: spec.metrics
@@ -167,9 +224,9 @@ tests:
 
   - it: memory metrics can be disabled
     set:
-      deployment:
-        autoscaling:
-          targetMemoryUtilizationPercentage: 0
+      deployment.autoscaling.enabled: true
+      deployment.autoscaling.targetMemoryUtilizationPercentage: 0
+      deployment.resources.requests.cpu: 100m
     asserts:
       - equal:
           path: spec.metrics
@@ -180,13 +237,3 @@ tests:
                   averageUtilization: 80
                   type: Utilization
               type: Resource
-
-  - it: should error when both, cpu and memory metrics are disabled
-    set:
-      deployment:
-        autoscaling:
-          targetCPUUtilizationPercentage: 0
-          targetMemoryUtilizationPercentage: 0
-    asserts:
-      - failedTemplate:
-          errorMessage: autoscaling is enabled, but usage of both, the cpu and the memory metrics is disabled

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -71,12 +71,12 @@ deployment:
     # - The heimdall process itself requires approximately 64Mi of memory.
 
   # Only used if autoscaling is disabled (see below)
-  replicaCount: 2
+  replicaCount: 1
 
   # Configures HorizontalPodAutoscaler
   autoscaling:
     enabled: false
-    minReplicas: 1
+    minReplicas: 2
     maxReplicas: 10
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80

--- a/charts/heimdall/values.yaml
+++ b/charts/heimdall/values.yaml
@@ -75,8 +75,8 @@ deployment:
 
   # Configures HorizontalPodAutoscaler
   autoscaling:
-    enabled: true
-    minReplicas: 2
+    enabled: false
+    minReplicas: 1
     maxReplicas: 10
     targetCPUUtilizationPercentage: 80
     targetMemoryUtilizationPercentage: 80

--- a/docs/content/docs/getting_started/installation.adoc
+++ b/docs/content/docs/getting_started/installation.adoc
@@ -105,11 +105,13 @@ heimdall version 0.15.10
 
 == Helm Chart
 
-Heimdall can be installed via a Helm chart with a few simple steps, depending on if you are deploying for the first time, or upgrading from an existing installation.
+Heimdall can be installed using a Helm chart in just a few steps - whether you're deploying it for the first time or upgrading an existing installation. The chart is available via a Helm chart repository hosted on GitHub or as an OCI image published to GHCR. For detailed instructions, refer to the https://github.com/dadrus/heimdall/tree/main/charts/heimdall[chart documentation].
+
+NOTE: Autoscaling (HPA) is disabled by default to avoid misconfigured setups. If you enable it, be sure to define resource requests and limits appropriate for your production environment.
 
 === Prerequisites
 
-* A Kubernetes version >= 1.27
+* A Kubernetes version >= 1.29
 * https://helm.sh/docs/intro/install/[Helm] 3.0+
 
 === Adding the Helm Repository

--- a/docs/content/docs/operations/cache.adoc
+++ b/docs/content/docs/operations/cache.adoc
@@ -144,7 +144,7 @@ Data flush delay. When greater than zero, pauses pipeline write loop for some ti
 
 * *`tls`*: _link:{{< relref "/docs/configuration/types.adoc#_tls" >}}[TLS]_ (optional)
 +
-TLS settings. By default, the communication to Redis happens over TLS. This requires however a properly configured link:{{< relref "/docs/operations/security.adoc#_tls_trust_store" >}}[trust store], as otherwise heimdall won't trust the certificates used by the Redis services. In addition to the referenced configuration options, you can also make use of the following properties:
+TLS settings. By default, the communication to Redis happens over TLS. This requires however a properly configured link:{{< relref "/docs/operations/security.adoc#_trust_store" >}}[trust store], as otherwise heimdall won't trust the certificates used by the Redis services. In addition to the referenced configuration options, you can also make use of the following properties:
 
 ** *`disabled`*: _boolean_ (optional)
 +

--- a/docs/content/docs/operations/security.adoc
+++ b/docs/content/docs/operations/security.adoc
@@ -28,7 +28,7 @@ The following configurations and behaviors are enforced by default:
 
 [NOTE]
 ====
-For development purposes, all of the above settings can be disabled at once by starting heimdall with the `--insecure` flag.
+For development purposes, all the above settings can be disabled at once by starting heimdall with the `--insecure` flag.
 
 If any of the above enforcement settings are disabled and an insecure configuration is used, warnings will be logged.
 ====
@@ -57,9 +57,9 @@ The link:{{< relref "/guides/proxies/_index.adoc" >}}[API Gateways & Proxies Gui
 
 Logs, metrics and profiling information is very valuable for operating heimdall. These are however also very valuable for any adversary. For this reason, the corresponding services, exposing such information are by default, if enabled, listening only on the loopback (`127.0.0.1`) interface. If you have to configure them to listen to other interfaces, e.g. because you operate heimdall in a container, make sure, you don't expose them publicly.
 
-== TLS Trust Store
+== Trust Store
 
-As documented in link:{{< relref "/docs/concepts/pipelines.adoc" >}}[Concepts] section, the execution of heimdall's pipeline typically includes communication to other systems. The endpoints of the corresponding systems should be TLS protected. This is however actually out of scope for heimdall. What is in scope, is the verification of the used TLS server certificate if TLS is used. This happens by making use of the operating system-wide trust store, containing the certificates of Root and Intermediate CAs (trust anchors) shipped with the OS. That means, you should
+As documented in link:{{< relref "/docs/concepts/pipelines.adoc" >}}[Concepts] section, the execution of heimdall's pipeline typically includes communication to other systems. The endpoints of the corresponding systems should be TLS protected. This is, however, actually out of scope for heimdall. What is in scope is the verification of the used TLS server certificate if TLS is used or other certificates. This happens by making use of the operating system-wide trust store, containing the certificates of Root and Intermediate CAs (trust anchors) shipped with the OS. That means, you should
 
 1. ensure this trust store contains the certificates of the Root CAs of your PKI hierarchy and
 2. ensure the endpoints, heimdall communicates with over TLS, provide not only their own certificates, but also the intermediate certificates and cross certificates not included within the OS trust store

--- a/docs/content/guides/proxies/istio.adoc
+++ b/docs/content/guides/proxies/istio.adoc
@@ -19,7 +19,7 @@ https://istio.io/[Istio] is an open-source service mesh that extends Kubernetesâ
 * Deployed Istio (See https://istio.io/latest/docs/setup/install/[here] for installation options)
 * heimdall installed and operated in link:{{< relref "/docs/concepts/operating_modes.adoc#_decision_mode" >}}[Decision Operation Mode].
 +
-NOTE: To allow heimdall communicating with services running in the mesh, add the certificate of the CA used by Istio to heimdall's link:{{< relref "/docs/operations/security.adoc#_tls_trust_store" >}}[trust store].
+NOTE: To allow heimdall communicating with services running in the mesh, add the certificate of the CA used by Istio to heimdall's link:{{< relref "/docs/operations/security.adoc#_trust_store" >}}[trust store].
 
 == Integration Options
 


### PR DESCRIPTION
## Related issue(s)

closes #2442

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

This PR addresses a usability and configuration issue with the Helm chart's default behavior. 

The chart enabled autoscaling by default but does not configure default resource requests, which led to silent failures in the HPA. The HPA would appear active, but pods would not scale, and errors like those shown in the referenced ticket were not visible unless actively checked.

To avoid misleading behavior, this PR introduced the following changes:

* Autoscaling is now disabled by default to avoid broken out-of-the-box behavior
* A conditional check has been added to the HPA template to ensure it only renders if resource requests required by a particular metric are explicitly defined and raises an error otherwise
* Chart README has been updated to document this behavior and guide users on enabling autoscaling correctly.
* Installation section in the docs has been updated as well.

With that in place, the updated functionality puts control in the hands of the user to configure autoscaling explicitly and still supports experimentation with minimal configuration.