### PR TITLE
chore: `map` contextualizer update

### DIFF
--- a/cmd/validate/test_data/config-valid.yaml
+++ b/cmd/validate/test_data/config-valid.yaml
@@ -227,6 +227,13 @@ mechanisms:
             bla: bla
         payload: foo
         continue_pipeline_on_error: true
+    - id: mapping
+      type: map
+      config:
+        items:
+          my_endpoint: "https://some-other.service/users/{{ .Values.user_id }}"
+        values:
+          user_id: "{{ .Subject.ID }}"
     - id: profile_data_contextualizer
       type: generic
       config:

--- a/cmd/validate/test_data/ruleset-valid.yaml
+++ b/cmd/validate/test_data/ruleset-valid.yaml
@@ -32,6 +32,10 @@ rules:
             - profile
     - authenticator: introspection_authenticator1
     - contextualizer: subscription_contextualizer
+    - contextualizer: mapping
+      config:
+        values:
+          user_id: foo
     - authorizer: allow_all_authorizer
     - finalizer: jwt
       config:

--- a/docs/content/docs/mechanisms/contextualizers.adoc
+++ b/docs/content/docs/mechanisms/contextualizers.adoc
@@ -116,10 +116,6 @@ Configuration using the `config` property is mandatory. Following properties are
 +
 Every entry in the items map is a map of templates. Every key will be present in the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_outputs" >}}[`Outputs`] object.
 
-* *`continue_pipeline_on_error`*: _boolean_ (optional, overridable)
-+
-If set to `true`, allows the pipeline to continue with the execution of the next mechanisms. So the error, if thrown, is ignored. Defaults to `false`, which means the execution of the authentication & authorization pipeline is stopped and the execution of the error pipeline is started.
-
 * *`values`* _map of strings_ (optional, overridable)
 +
 A key value map, which is made accessible to the template rendering engine as link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_values" >}}[`Values`] object to render parts of the URL and/or the payload. The actual values in that map can be templated as well with access to the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_subject" >}}[`Subject`], the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_outputs" >}}[`Outputs`] and link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_request" >}}[`Request`] objects.

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -363,6 +363,13 @@ mechanisms:
             bla: bla
         payload: http://foo
         continue_pipeline_on_error: true
+    - id: mapping
+      type: map
+      config:
+        items:
+          my_endpoint: "https://some-other.service/users/{{ .Values.user_id }}"
+        values:
+          user_id: "{{ .Subject.ID }}"
     - id: profile_data_contextualizer
       type: generic
       config:

--- a/internal/rules/mechanisms/contextualizers/map_contextualizer_test.go
+++ b/internal/rules/mechanisms/contextualizers/map_contextualizer_test.go
@@ -205,30 +205,6 @@ values:
 				assert.False(t, configured.ContinueOnError())
 			},
 		},
-		"with continueOnError reconfigured": {
-			prototypeConfig: []byte(`
-items:
-  url: "{{ .Values.foo }}"
-values: 
-  foo: http://foo.bar
-`),
-			config: []byte(`
-continue_pipeline_on_error: true
-`),
-			assert: func(t *testing.T, err error, prototype *mapContextualizer, configured *mapContextualizer) {
-				t.Helper()
-
-				require.NoError(t, err)
-
-				assert.NotEqual(t, prototype, configured)
-				assert.Equal(t, prototype.items, configured.items)
-				assert.Equal(t, prototype.id, configured.id)
-				assert.NotEqual(t, prototype.continueOnError, configured.continueOnError)
-				assert.Equal(t, "contextualizer", configured.ID())
-				assert.False(t, prototype.ContinueOnError())
-				assert.True(t, configured.ContinueOnError())
-			},
-		},
 	} {
 		t.Run(uc, func(t *testing.T) {
 			pc, err := testsupport.DecodeTestConfig(tc.prototypeConfig)

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -1673,7 +1673,7 @@
           "const": "generic"
         },
         "id": {
-          "description": "The unique id of the contextualizers to be used in the rule definition",
+          "description": "The unique id of the contextualizer to be used in the rule definition",
           "type": "string"
         },
         "config": {
@@ -1729,6 +1729,48 @@
               "minLength": 0,
               "uniqueItems": true,
               "default": []
+            }
+          }
+        }
+      }
+    },
+    "contextualizerMap": {
+      "description": "Map Contextualizer",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "id",
+        "config"
+      ],
+      "properties": {
+        "type": {
+          "const": "map"
+        },
+        "id": {
+          "description": "The unique id of the contextualizer to be used in the rule definition",
+          "type": "string"
+        },
+        "config": {
+          "description": "Map Contextualizer Configuration",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "items"
+          ],
+          "properties": {
+            "items": {
+              "description": "Key-Value map with templated entries. Referenced template variables will be resolved from the values property defined below.",
+              "type": "object",
+              "minLength": 1,
+              "uniqueItems": true
+            },
+            "values": {
+              "description": "Key-Value map with entries required for templating",
+              "type": "object",
+              "minLength": 0,
+              "uniqueItems": true,
+              "default": {}
             }
           }
         }
@@ -2151,8 +2193,7 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "authenticators",
-        "finalizers"
+        "authenticators"
       ],
       "properties": {
         "error_handlers": {
@@ -2229,7 +2270,14 @@
           "additionalItems": false,
           "uniqueItems": true,
           "items": {
-            "$ref": "#/definitions/contextualizerGeneric"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/contextualizerGeneric"
+              },
+              {
+                "$ref": "#/definitions/contextualizerMap"
+              }
+            ]
           }
         },
         "finalizers": {


### PR DESCRIPTION
## Related issue(s)

relates to #2537

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

This PR introduces updates related to the work done in #2537:

* The JSON schema has been updated to define the new contextualizer. Without this change, the new functionality could not be used, as attempts to configure the `map` contextualizer would result in schema validation errors.
* The `continue_on_error` property has been removed, as errors raised by this contextualizer can only be related to misconfiguration, which should prevent the pipeline from continuing.
