### PR TITLE
fix: TLS errors during mechanism execution always result in pipeline failure

### DIFF
--- a/internal/rules/composite_subject_creator.go
+++ b/internal/rules/composite_subject_creator.go
@@ -17,13 +17,14 @@
 package rules
 
 import (
-	"github.com/dadrus/heimdall/internal/x/errorchain"
-	"github.com/rs/zerolog"
 	"strings"
+
+	"github.com/rs/zerolog"
 
 	"github.com/dadrus/heimdall/internal/accesscontext"
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/subject"
+	"github.com/dadrus/heimdall/internal/x/errorchain"
 )
 
 type compositeSubjectCreator []subjectCreator

--- a/internal/rules/composite_subject_creator_test.go
+++ b/internal/rules/composite_subject_creator_test.go
@@ -55,7 +55,7 @@ func TestCompositeSubjectCreatorExecution(t *testing.T) {
 			},
 		},
 		"no fallback due to tls error": {
-			subjectCreator: func(t *testing.T, ctx heimdall.RequestContext, sub *subject.Subject) compositeSubjectCreator {
+			subjectCreator: func(t *testing.T, ctx heimdall.RequestContext, _ *subject.Subject) compositeSubjectCreator {
 				t.Helper()
 
 				auth1 := rulemocks.NewSubjectCreatorMock(t)

--- a/internal/rules/composite_subject_handler.go
+++ b/internal/rules/composite_subject_handler.go
@@ -17,12 +17,13 @@
 package rules
 
 import (
-	"github.com/dadrus/heimdall/internal/x/errorchain"
-	"github.com/rs/zerolog"
 	"strings"
+
+	"github.com/rs/zerolog"
 
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/subject"
+	"github.com/dadrus/heimdall/internal/x/errorchain"
 )
 
 type compositeSubjectHandler []subjectHandler

--- a/internal/rules/composite_subject_handler_test.go
+++ b/internal/rules/composite_subject_handler_test.go
@@ -119,7 +119,7 @@ func TestCompositeSubjectHandlerExecution(t *testing.T) {
 		},
 		"tls related error stops pipeline execution": {
 			configureMocks: func(t *testing.T, ctx heimdall.RequestContext, first *rulemocks.SubjectHandlerMock,
-				second *rulemocks.SubjectHandlerMock, sub *subject.Subject,
+				_ *rulemocks.SubjectHandlerMock, sub *subject.Subject,
 			) {
 				t.Helper()
 


### PR DESCRIPTION
## Related issue(s)

fixes #2575

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

As the title says, TLS errors raised during the execution of any mechanism will now always cause the pipeline to fail, triggering the execution of the error handler pipeline.
