### PR TITLE
docs: Clarifications that CORS related functionality is only supported if heimdall is operated as proxy

### DIFF
--- a/docs/content/docs/configuration/types.adoc
+++ b/docs/content/docs/configuration/types.adoc
@@ -491,6 +491,8 @@ So with `10B` you can define the byte size of 10 bytes and with `2MB` you can sa
 
 == CORS
 
+NOTE: This functionality is only supported if heimdall is operated in proxy mode. In decision operation mode, this configuration is ignored.
+
 https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[CORS] (Cross-Origin Resource Sharing) headers can be added and configured by making use of this type. This functionality allows for advanced security features to quickly be set. If CORS headers are set, then heimdall does not pass preflight requests to its decision pipeline, instead the response will be generated and sent back to the client directly. Following properties are supported:
 
 * *`allowed_origins`*: _string array_ (optional)

--- a/docs/content/docs/services/main.adoc
+++ b/docs/content/docs/services/main.adoc
@@ -74,7 +74,7 @@ Controls the maximum number of idle (keep-alive) connections per host. Defaults 
 
 * *`cors`*: _link:{{< relref "/docs/configuration/types.adoc#_cors" >}}[CORS]_ (optional)
 +
-https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[CORS] (Cross-Origin Resource Sharing) headers can be added and configured by making use of this option. This functionality allows for advanced security features to quickly be set. If CORS headers are set, then heimdall does not pass preflight requests neither to its pipeline, nor to the upstream service. Instead, the response will be generated and sent back to the client directly.
+If heimdall is operated in proxy mode, https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS[CORS] (Cross-Origin Resource Sharing) headers can be added and configured by making use of this option. This functionality allows for advanced security features to quickly be set. If CORS headers are set, then heimdall does not pass preflight requests neither to its pipeline, nor to the upstream service. Instead, the response will be generated and sent back to the client directly.
 
 * *`tls`*: _link:{{< relref "/docs/configuration/types.adoc#_tls" >}}[TLS]_ (optional)
 +


### PR DESCRIPTION
## Related issue(s)

None - has been discovered by @roinou and communicated in Discord: https://discord.com/channels/1100447190796742698/1391768188026491000/1392094572682940447

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have updated the documentation.

## Description

This PR extends the documentation to clarify that CORS related functionality is only available if heimdall is operated as proxy. CORS related configuration is not used in decision operation mode.