### PR TITLE
refactor!: `allow_fallback_on_error` property removed from authenticators

### DIFF
--- a/docs/content/docs/mechanisms/authenticators.adoc
+++ b/docs/content/docs/mechanisms/authenticators.adoc
@@ -68,10 +68,6 @@ The identifier of the subject to be verified.
 +
 The password of the subject to be verified.
 
-* *`allow_fallback_on_error`*: _boolean_ (optional, overridable)
-+
-**Deprecated:** As of v0.16.0, this property is ineffective and will be removed in v0.17.0. Refer to the authentication stage description in the link:{{< relref "/docs/concepts/pipelines/#_authentication_authorization_pipeline" >}}[Authentication & Authorization Pipline] for details on the current behavior.
-
 .Configuration of Basic Auth authenticator
 ====
 [source, yaml]
@@ -121,10 +117,6 @@ Where to extract the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_
 * *`cache_ttl`*: _link:{{< relref "/docs/configuration/types.adoc#_duration" >}}[Duration]_ (optional, overridable)
 +
 How long to cache the response. If not set, response caching if disabled. The cache key is calculated from the `identity_info_endpoint` configuration and the actual authentication data value.
-
-* *`allow_fallback_on_error`*: _boolean_ (optional, overridable)
-+
-**Deprecated:** As of v0.16.0, this property is ineffective and will be removed in v0.17.0. Refer to the authentication stage description in the link:{{< relref "/docs/concepts/pipelines/#_authentication_authorization_pipeline" >}}[Authentication & Authorization Pipline] for details on the current behavior.
 
 * *`session_lifespan`*: _link:{{< relref "/docs/configuration/types.adoc#_session_lifespan" >}}[Session Lifespan]_ (optional, not overridable)
 +
@@ -295,10 +287,6 @@ Where to extract the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_
 +
 How long to cache the response. If not set, caching of the introspection response is based on the available token expiration information. To disable caching, set it to `0s`. If you set the ttl to a custom value > 0, the expiration time (if available) of the token will be considered. The cache key is calculated from the `introspection_endpoint` configuration and the value of the access token.
 
-* *`allow_fallback_on_error`*: _boolean_ (optional, overridable)
-+
-**Deprecated:** As of v0.16.0, this property is ineffective and will be removed in v0.17.0. Refer to the authentication stage description in the link:{{< relref "/docs/concepts/pipelines/#_authentication_authorization_pipeline" >}}[Authentication & Authorization Pipline] for details on the current behavior.
-
 .Minimal possible configuration based on the Introspection endpoint
 ====
 [source, yaml]
@@ -396,10 +384,6 @@ Where to extract the subject id from the JWT, as well as which attributes to use
 * *`cache_ttl`*: _link:{{< relref "/docs/configuration/types.adoc#_duration" >}}[Duration]_ (optional, overridable)
 +
 How long to cache the key from the JWKS response, which was used for signature verification purposes. If not set, heimdall will cache this key for 10 minutes and not call JWKS endpoint again if the same `kid` is referenced in an JWT and same JWKS endpoint is used. The cache key is calculated from the `jwks_endpoint` configuration and the `kid` referenced in the JWT.
-
-* *`allow_fallback_on_error`*: _boolean_ (optional, overridable)
-+
-**Deprecated:** As of v0.16.0, this property is ineffective and will be removed in v0.17.0. Refer to the authentication stage description in the link:{{< relref "/docs/concepts/pipelines/#_authentication_authorization_pipeline" >}}[Authentication & Authorization Pipline] for details on the current behavior.
 
 * *`validate_jwk`*: _boolean_ (optional, not overridable)
 +

--- a/internal/rules/mechanisms/authenticators/basic_auth_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/basic_auth_authenticator.go
@@ -76,21 +76,14 @@ func newBasicAuthAuthenticator(
 		Msg("Creating authenticator")
 
 	type Config struct {
-		UserID               string `mapstructure:"user_id"                 validate:"required"`
-		Password             string `mapstructure:"password"                validate:"required"`
-		AllowFallbackOnError bool   `mapstructure:"allow_fallback_on_error"`
+		UserID   string `mapstructure:"user_id"  validate:"required"`
+		Password string `mapstructure:"password" validate:"required"`
 	}
 
 	var conf Config
 	if err := decodeConfig(app, rawConfig, &conf); err != nil {
 		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
 			"failed decoding config for basic_auth authenticator '%s'", name).CausedBy(err)
-	}
-
-	if conf.AllowFallbackOnError {
-		logger.Warn().
-			Str("_name", name).
-			Msg("Usage of allow_fallback_on_error on authenticator is deprecated and has no effect")
 	}
 
 	auth := basicAuthAuthenticator{
@@ -177,21 +170,14 @@ func (a *basicAuthAuthenticator) WithConfig(stepID string, rawConfig map[string]
 	}
 
 	type Config struct {
-		UserID               string `mapstructure:"user_id"`
-		Password             string `mapstructure:"password"`
-		AllowFallbackOnError *bool  `mapstructure:"allow_fallback_on_error"`
+		UserID   string `mapstructure:"user_id"`
+		Password string `mapstructure:"password"`
 	}
 
 	var conf Config
 	if err := decodeConfig(a.app, rawConfig, &conf); err != nil {
 		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
 			"failed decoding config for basic auth authenticator '%s'", a.name).CausedBy(err)
-	}
-
-	if conf.AllowFallbackOnError != nil {
-		logger := a.app.Logger()
-		logger.Warn().Str("_id", a.id).
-			Msg("Usage of allow_fallback_on_error is deprecated and has no effect")
 	}
 
 	return &basicAuthAuthenticator{

--- a/internal/rules/mechanisms/authenticators/basic_auth_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/basic_auth_authenticator_test.go
@@ -41,7 +41,7 @@ func TestCreateBasicAuthAuthenticator(t *testing.T) {
 		config []byte
 		assert func(t *testing.T, err error, auth *basicAuthAuthenticator)
 	}{
-		"valid configuration without set fallback": {
+		"valid configuration": {
 			config: []byte(`
 user_id: foo
 password: bar`),
@@ -60,34 +60,7 @@ password: bar`),
 
 				assert.Equal(t, userID, auth.userID)
 				assert.Equal(t, password, auth.password)
-				assert.Equal(t, "valid configuration without set fallback", auth.ID())
-				assert.Equal(t, auth.ID(), auth.Name())
-				assert.Empty(t, auth.emptyAttributes)
-				assert.NotNil(t, auth.emptyAttributes)
-			},
-		},
-		"valid configuration without fallback set to true": {
-			config: []byte(`
-user_id: foo
-password: bar
-allow_fallback_on_error: true
-`),
-			assert: func(t *testing.T, err error, auth *basicAuthAuthenticator) {
-				t.Helper()
-
-				require.NoError(t, err)
-
-				md := sha256.New()
-				md.Write([]byte("foo"))
-				userID := hex.EncodeToString(md.Sum(nil))
-
-				md.Reset()
-				md.Write([]byte("bar"))
-				password := hex.EncodeToString(md.Sum(nil))
-
-				assert.Equal(t, userID, auth.userID)
-				assert.Equal(t, password, auth.password)
-				assert.Equal(t, "valid configuration without fallback set to true", auth.ID())
+				assert.Equal(t, "valid configuration", auth.ID())
 				assert.Equal(t, auth.ID(), auth.Name())
 				assert.Empty(t, auth.emptyAttributes)
 				assert.NotNil(t, auth.emptyAttributes)

--- a/internal/rules/mechanisms/authenticators/generic_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/generic_authenticator.go
@@ -86,20 +86,12 @@ func newGenericAuthenticator(app app.Context, name string, rawConfig map[string]
 		Payload               template.Template                   `mapstructure:"payload"`
 		SessionLifespanConfig *SessionLifespanConfig              `mapstructure:"session_lifespan"`
 		CacheTTL              *time.Duration                      `mapstructure:"cache_ttl"`
-		AllowFallbackOnError  bool                                `mapstructure:"allow_fallback_on_error"`
 	}
 
 	var conf Config
 	if err := decodeConfig(app, rawConfig, &conf); err != nil {
 		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
 			"failed decoding config for generic authenticator '%s'", name).CausedBy(err)
-	}
-
-	if conf.AllowFallbackOnError {
-		logger.Warn().
-			Str("_type", AuthenticatorGeneric).
-			Str("_name", name).
-			Msg("Usage of allow_fallback_on_error on authenticator is deprecated and has no effect")
 	}
 
 	if strings.HasPrefix(conf.Endpoint.URL, "http://") {
@@ -172,22 +164,13 @@ func (a *genericAuthenticator) WithConfig(stepID string, rawConfig map[string]an
 	}
 
 	type Config struct {
-		CacheTTL             *time.Duration `mapstructure:"cache_ttl"`
-		AllowFallbackOnError *bool          `mapstructure:"allow_fallback_on_error"`
+		CacheTTL *time.Duration `mapstructure:"cache_ttl"`
 	}
 
 	var conf Config
 	if err := decodeConfig(a.app, rawConfig, &conf); err != nil {
 		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
 			"failed decoding config for generic authenticator '%s'", a.name).CausedBy(err)
-	}
-
-	if conf.AllowFallbackOnError != nil {
-		logger := a.app.Logger()
-		logger.Warn().
-			Str("_type", AuthenticatorGeneric).
-			Str("_name", a.name).
-			Msg("Usage of allow_fallback_on_error on authenticator is deprecated and has no effect")
 	}
 
 	return &genericAuthenticator{

--- a/internal/rules/mechanisms/authenticators/generic_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/generic_authenticator_test.go
@@ -325,15 +325,13 @@ forward_cookies:
 payload: |
   foo=bar
 subject:
-  id: some_template
-allow_fallback_on_error: true`),
+  id: some_template`),
 			assert: func(t *testing.T, err error, prototype *genericAuthenticator,
 				configured *genericAuthenticator,
 			) {
 				t.Helper()
 
 				require.NoError(t, err)
-
 				assert.Equal(t, prototype, configured)
 			},
 		},

--- a/internal/rules/mechanisms/authenticators/jwt_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator.go
@@ -91,28 +91,20 @@ func newJwtAuthenticator(
 		Msg("Creating authenticator")
 
 	type Config struct {
-		JWKSEndpoint         *endpoint.Endpoint                  `mapstructure:"jwks_endpoint"        validate:"required_without=MetadataEndpoint,excluded_with=MetadataEndpoint"` //nolint:lll,tagalign
-		MetadataEndpoint     *oauth2.MetadataEndpoint            `mapstructure:"metadata_endpoint"    validate:"required_without=JWKSEndpoint,excluded_with=JWKSEndpoint"`         //nolint:lll,tagalign
-		Assertions           oauth2.Expectation                  `mapstructure:"assertions"           validate:"required_with=JWKSEndpoint"`                                       //nolint:lll,tagalign
-		SubjectInfo          SubjectInfo                         `mapstructure:"subject"              validate:"-"`                                                                //nolint:lll,tagalign
-		AuthDataSource       extractors.CompositeExtractStrategy `mapstructure:"jwt_source"`
-		CacheTTL             *time.Duration                      `mapstructure:"cache_ttl"`
-		AllowFallbackOnError bool                                `mapstructure:"allow_fallback_on_error"`
-		ValidateJWK          *bool                               `mapstructure:"validate_jwk"`
-		TrustStore           truststore.TrustStore               `mapstructure:"trust_store"`
+		JWKSEndpoint     *endpoint.Endpoint                  `mapstructure:"jwks_endpoint"        validate:"required_without=MetadataEndpoint,excluded_with=MetadataEndpoint"` //nolint:lll,tagalign
+		MetadataEndpoint *oauth2.MetadataEndpoint            `mapstructure:"metadata_endpoint"    validate:"required_without=JWKSEndpoint,excluded_with=JWKSEndpoint"`         //nolint:lll,tagalign
+		Assertions       oauth2.Expectation                  `mapstructure:"assertions"           validate:"required_with=JWKSEndpoint"`                                       //nolint:lll,tagalign
+		SubjectInfo      SubjectInfo                         `mapstructure:"subject"              validate:"-"`                                                                //nolint:lll,tagalign
+		AuthDataSource   extractors.CompositeExtractStrategy `mapstructure:"jwt_source"`
+		CacheTTL         *time.Duration                      `mapstructure:"cache_ttl"`
+		ValidateJWK      *bool                               `mapstructure:"validate_jwk"`
+		TrustStore       truststore.TrustStore               `mapstructure:"trust_store"`
 	}
 
 	var conf Config
 	if err := decodeConfig(app, rawConfig, &conf); err != nil {
 		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
 			"failed decoding config for jwt authenticator '%s'", name).CausedBy(err)
-	}
-
-	if conf.AllowFallbackOnError {
-		logger.Warn().
-			Str("_type", AuthenticatorJWT).
-			Str("_name", name).
-			Msg("Usage of allow_fallback_on_error on authenticator is deprecated and has no effect")
 	}
 
 	if conf.JWKSEndpoint != nil {
@@ -257,23 +249,14 @@ func (a *jwtAuthenticator) WithConfig(stepID string, rawConfig map[string]any) (
 	}
 
 	type Config struct {
-		Assertions           oauth2.Expectation `mapstructure:"assertions"              validate:"-"`
-		CacheTTL             *time.Duration     `mapstructure:"cache_ttl"`
-		AllowFallbackOnError *bool              `mapstructure:"allow_fallback_on_error"`
+		Assertions oauth2.Expectation `mapstructure:"assertions" validate:"-"`
+		CacheTTL   *time.Duration     `mapstructure:"cache_ttl"`
 	}
 
 	var conf Config
 	if err := decodeConfig(a.app, rawConfig, &conf); err != nil {
 		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
 			"failed decoding config for jwt authenticator '%s'", a.name).CausedBy(err)
-	}
-
-	if conf.AllowFallbackOnError != nil {
-		logger := a.app.Logger()
-		logger.Warn().
-			Str("_type", AuthenticatorJWT).
-			Str("_name", a.name).
-			Msg("Usage of allow_fallback_on_error on authenticator is deprecated and has no effect")
 	}
 
 	return &jwtAuthenticator{

--- a/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
@@ -317,7 +317,6 @@ assertions:
     - ES256
 subject:
   id: some_claim
-allow_fallback_on_error: true
 validate_jwk: false
 trust_store: ` + trustStorePath),
 			assert: func(t *testing.T, err error, auth *jwtAuthenticator) {

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
@@ -91,20 +91,12 @@ func newOAuth2IntrospectionAuthenticator(
 		SubjectInfo           SubjectInfo                         `mapstructure:"subject"                 validate:"-"`                                                                          //nolint:lll,tagalign
 		AuthDataSource        extractors.CompositeExtractStrategy `mapstructure:"token_source"`
 		CacheTTL              *time.Duration                      `mapstructure:"cache_ttl"`
-		AllowFallbackOnError  bool                                `mapstructure:"allow_fallback_on_error"`
 	}
 
 	var conf Config
 	if err := decodeConfig(app, rawConfig, &conf); err != nil {
 		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
 			"failed decoding config for oauth2_introspection authenticator '%s'", name).CausedBy(err)
-	}
-
-	if conf.AllowFallbackOnError {
-		logger.Warn().
-			Str("_type", AuthenticatorOAuth2Introspection).
-			Str("_name", name).
-			Msg("Usage of allow_fallback_on_error on authenticator is deprecated and has no effect")
 	}
 
 	if conf.IntrospectionEndpoint != nil && strings.HasPrefix(conf.IntrospectionEndpoint.URL, "http://") {
@@ -232,23 +224,14 @@ func (a *oauth2IntrospectionAuthenticator) WithConfig(stepID string, rawConfig m
 	}
 
 	type Config struct {
-		Assertions           oauth2.Expectation `mapstructure:"assertions"`
-		CacheTTL             *time.Duration     `mapstructure:"cache_ttl"`
-		AllowFallbackOnError *bool              `mapstructure:"allow_fallback_on_error"`
+		Assertions oauth2.Expectation `mapstructure:"assertions"`
+		CacheTTL   *time.Duration     `mapstructure:"cache_ttl"`
 	}
 
 	var conf Config
 	if err := decodeConfig(a.app, rawConfig, &conf); err != nil {
 		return nil, errorchain.NewWithMessagef(heimdall.ErrConfiguration,
 			"failed decoding config for oauth2_introspection authenticator '%s'", a.name).CausedBy(err)
-	}
-
-	if conf.AllowFallbackOnError != nil {
-		logger := a.app.Logger()
-		logger.Warn().
-			Str("_type", AuthenticatorOAuth2Introspection).
-			Str("_name", a.name).
-			Msg("Usage of allow_fallback_on_error on authenticator is deprecated and has no effect")
 	}
 
 	return &oauth2IntrospectionAuthenticator{

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
@@ -197,7 +197,6 @@ assertions:
 subject:
   id: some_claim
 cache_ttl: 5s
-allow_fallback_on_error: true
 `),
 			assert: func(t *testing.T, err error, auth *oauth2IntrospectionAuthenticator) {
 				t.Helper()

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -1346,12 +1346,6 @@
                 "30s"
               ]
             },
-            "allow_fallback_on_error": {
-              "type": "boolean",
-              "description": "Whether the pipeline should fallback to a next authenticator if this one fails validating the given credentials",
-              "default": false,
-              "deprecationMessage": "This property is deprecated. Fallback is now determined solely by the order of authenticators in the pipeline."
-            },
             "session_lifespan": {
               "$ref": "#/definitions/sessionLifespanConfiguration"
             }
@@ -1413,12 +1407,6 @@
                 "1m",
                 "30s"
               ]
-            },
-            "allow_fallback_on_error": {
-              "type": "boolean",
-              "description": "Whether the pipeline should fallback to a next authenticator if this one fails validating the given credentials",
-              "default": false,
-              "deprecationMessage": "This property is deprecated. Fallback is now determined solely by the order of authenticators in the pipeline."
             }
           }
         }
@@ -1479,12 +1467,6 @@
                 "30s"
               ]
             },
-            "allow_fallback_on_error": {
-              "type": "boolean",
-              "description": "Whether the pipeline should fallback to a next authenticator if this one fails validating the given credentials",
-              "default": false,
-              "deprecationMessage": "This property is deprecated. Fallback is now determined solely by the order of authenticators in the pipeline."
-            },
             "validate_jwk": {
               "type": "boolean",
               "description": "Whether the certificate chain (if present) in the JWK should be validated",
@@ -1527,12 +1509,6 @@
             "password": {
               "description": "The password for the client_id for the authentication scheme",
               "type": "string"
-            },
-            "allow_fallback_on_error": {
-              "type": "boolean",
-              "description": "Whether the pipeline should fallback to a next authenticator if this one fails validating the given credentials",
-              "default": false,
-              "deprecationMessage": "This property is deprecated. Fallback is now determined solely by the order of authenticators in the pipeline."
             }
           }
         }


### PR DESCRIPTION
## Related issue(s)

closes #2661 

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

As stated in the PR title, it removes support for the `allow_fallback_on_error` property, which has anyway had no effect since v0.16.0 of heimdall.