### PR TITLE
docs: traefik helm chart version used in kubernetes examples updated to v37.1.1

### DIFF
--- a/examples/kubernetes/Justfile
+++ b/examples/kubernetes/Justfile
@@ -8,7 +8,7 @@ contour_version := '21.1.4'
 emissary_version := '8.12.2'
 haproxy_version := '0.14.9'
 envoy_gw_version := 'v1.0.1'
-traefik_version := '33.2.1'
+traefik_version := '37.1.1'
 metallb_version := '0.14.9'
 certmanager_version := '1.16.2'
 trustmanager_version := '0.14.0'
@@ -171,7 +171,7 @@ install-traefik global_mw="true":
 
   kubectl apply -f traefik/certificate.yaml
 
-  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
 
   helm upgrade --install traefik traefik/traefik \
       -n traefik \

--- a/examples/kubernetes/traefik/global-mw-helm-values.yaml
+++ b/examples/kubernetes/traefik/global-mw-helm-values.yaml
@@ -36,7 +36,8 @@ gateway:
       port: 8443
       hostname: echo-app.local
       protocol: HTTPS
-      namespacePolicy: All
+      namespacePolicy:
+        from: All
       mode: Terminate
       certificateRefs:
         - name: traefik-tls

--- a/examples/kubernetes/traefik/helm-values.yaml
+++ b/examples/kubernetes/traefik/helm-values.yaml
@@ -36,7 +36,8 @@ gateway:
       port: 8443
       hostname: echo-app.local
       protocol: HTTPS
-      namespacePolicy: All
+      namespacePolicy:
+        from: All
       mode: Terminate
       certificateRefs:
         - name: traefik-tls


### PR DESCRIPTION
## Related issue(s)

house keeping

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).

## Description

Using the most recent version of traefik in kubernetes examples.