### PR TITLE
fix: Verbose errors always contain high level detail message

### DIFF
--- a/internal/handler/middleware/http/errorhandler/error_handler_test.go
+++ b/internal/handler/middleware/http/errorhandler/error_handler_test.go
@@ -68,7 +68,7 @@ func TestHandlerHandle(t *testing.T) {
 			err:     errorchain.New(heimdall.ErrAuthorization),
 			expCode: http.StatusForbidden,
 			accept:  "text/plain",
-			expBody: "authorization error",
+			expBody: "authorization error: authorization error",
 		},
 		"communication timeout error default": {
 			handler: New(),

--- a/internal/handler/middleware/http/errorhandler/formatter.go
+++ b/internal/handler/middleware/http/errorhandler/formatter.go
@@ -54,6 +54,11 @@ func format(req *http.Request, body error) (contenttype.MediaType, []byte, error
 	case "plain":
 		fallthrough
 	default:
+		stringer, ok := body.(fmt.Stringer)
+		if ok {
+			return supportedMediaTypes[2], []byte(stringer.String()), nil
+		}
+
 		return supportedMediaTypes[2], []byte(body.Error()), nil
 	}
 }

--- a/internal/x/errorchain/error_chain.go
+++ b/internal/x/errorchain/error_chain.go
@@ -195,7 +195,7 @@ func (ec *ErrorChain) firstMessage() string {
 			return current.msg
 		}
 
-		if chained, ok := current.err.(*ErrorChain); ok {
+		if chained, ok := current.err.(*ErrorChain); ok { //nolint: errorlint
 			msg := chained.firstMessage()
 			if msg != chained.Error() {
 				return msg

--- a/internal/x/errorchain/error_chain_test.go
+++ b/internal/x/errorchain/error_chain_test.go
@@ -255,7 +255,6 @@ func TestErrorChainString(t *testing.T) {
 		t.Run(uc, func(t *testing.T) {
 			// GIVEN
 			// data from the test case
-
 			value := tc.err.String()
 
 			// THEN
@@ -314,7 +313,6 @@ func TestErrorChainJSONMarshal(t *testing.T) {
 		t.Run(uc, func(t *testing.T) {
 			// GIVEN
 			// data from the test case
-
 			res, err := json.Marshal(tc.err)
 
 			// THEN
@@ -374,7 +372,6 @@ func TestErrorChainXMLMarshal(t *testing.T) {
 		t.Run(uc, func(t *testing.T) {
 			// GIVEN
 			// data from the test case
-
 			res, err := xml.Marshal(tc.err)
 
 			// THEN


### PR DESCRIPTION
## Related issue(s)

closes #2804 

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

Making sure, verbose error responses always contain a high level detail message