### PR TITLE
docs: Heimdall image version set in documentation generated during release builds fixed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -430,7 +430,7 @@ jobs:
       - name: Prepare image version
         id: image-version
         run: |
-          export version=$(echo {{ github.ref_name }} |  sed 's/v//g')
+          export version=$(echo ${{ github.ref_name }} |  sed 's/v//g')
           echo "result=$version" >> $GITHUB_OUTPUT
       - name: Update used image tags to the released version
         uses: jacobtomlinson/gha-find-replace@2ff30f644d2e0078fc028beb9193f5ff0dcad39e # v3


### PR DESCRIPTION
## Related issue(s)

none

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).

## Description

Due to a typo, the version value set in generated documentation was `{{ github.ref_name }}` (look e.g. at step 6 in [Protect an Application](https://dadrus.github.io/heimdall/v0.17.2/docs/getting_started/protect_an_app/) section). The corresponding ci job step is fixed by this PR.