### PR TITLE
feat: Better error responses for the serve subcommands

### DIFF
--- a/cmd/serve/decision.go
+++ b/cmd/serve/decision.go
@@ -31,11 +31,12 @@ const serveDecisionFlagEnvoyGRPC = "envoy-grpc"
 // NewDecisionCommand represents the "serve decision" command.
 func NewDecisionCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "decision",
-		Short:        "Starts heimdall in Decision operation mode",
-		Example:      "heimdall serve decision",
-		SilenceUsage: true,
+		Use:           "decision",
+		Short:         "Starts heimdall in Decision operation mode",
+		Example:       "heimdall serve decision",
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true
 			useEnvoyExtAuth, _ := cmd.Flags().GetBool(serveDecisionFlagEnvoyGRPC)
 
 			app, err := createApp(
@@ -55,7 +56,7 @@ func NewDecisionCommand() *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().Bool(serveDecisionFlagEnvoyGRPC, false,
+	cmd.Flags().Bool(serveDecisionFlagEnvoyGRPC, false,
 		"If specified, decision mode is started for integration with envoy extauth gRPC service")
 
 	return cmd

--- a/cmd/serve/proxy.go
+++ b/cmd/serve/proxy.go
@@ -27,11 +27,13 @@ import (
 // NewProxyCommand represents the proxy command.
 func NewProxyCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:          "proxy",
-		Short:        "Starts heimdall in Reverse Proxy operation mode",
-		Example:      "heimdall serve proxy",
-		SilenceUsage: true,
+		Use:           "proxy",
+		Short:         "Starts heimdall in Reverse Proxy operation mode",
+		Example:       "heimdall serve proxy",
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.SilenceUsage = true
+
 			app, err := createApp(
 				cmd,
 				fx.Options(


### PR DESCRIPTION
## Related issue(s)

None

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have added tests that prove the correctness of my implementation.

## Description

Usage is now printed for `serve decision` and `serve proxy` commands if the required arguments are not provided.

---
BEGIN_COMMIT_OVERRIDE
feat: Better error responses for the `serve` subcommands (#2814) 
END_COMMIT_OVERRIDE