### PR TITLE
docs: OTEL disabled in Kubernetes examples (used bitnami images are not available anymore)

### DIFF
--- a/examples/kubernetes/Justfile
+++ b/examples/kubernetes/Justfile
@@ -312,12 +312,12 @@ install-heimdall router=default_router:
       kubectl apply -f quickstarts/heimdall/istio-authorization-policy.yaml
   fi
 
-  kubectl apply -f quickstarts/heimdall/pod_monitor.yaml
+  #kubectl apply -f quickstarts/heimdall/pod_monitor.yaml
 
 create-cluster:
   kind create cluster --config kind/kind.yaml --name {{cluster_name}}
 
-setup-cluster: create-cluster setup-charts install-lb install-cert-manager install-minio-operator install-observability-stack
+setup-cluster: create-cluster setup-charts install-lb install-cert-manager # install-minio-operator install-observability-stack
 
 install-ngnix-demo: setup-cluster (install-nginx-ingress-controller "false") (install-heimdall "nginx") (install-echo-service "nginx-route-based")
 

--- a/examples/kubernetes/istio/istio-values.yaml
+++ b/examples/kubernetes/istio/istio-values.yaml
@@ -9,10 +9,10 @@ global:
 meshConfig:
   defaultConfig:
     discoveryAddress: istiod.istio-system.svc:15012
-  defaultProviders:
-    metrics:
-      - prometheus
-  enablePrometheusMerge: true
+#  defaultProviders:
+#    metrics:
+#      - prometheus
+#  enablePrometheusMerge: true
   rootNamespace: istio-system
   trustDomain: cluster.local
   extensionProviders:

--- a/examples/kubernetes/nginx/global-helm-values.yaml
+++ b/examples/kubernetes/nginx/global-helm-values.yaml
@@ -7,20 +7,20 @@ controller:
       proxy_set_header         X-Forwarded-Proto      $scheme;
       proxy_set_header         X-Forwarded-Host       $http_host;
       proxy_set_header         X-Forwarded-Uri        $request_uri;
-    enable-opentelemetry: "true"
-    opentelemetry-config: "/etc/nginx/opentelemetry.toml"
-    opentelemetry-operation-name: "HTTP $request_method $service_name $uri"
-    opentelemetry-trust-incoming-span: "true"
-    otlp-collector-host: "alloy.monitoring"
-    otlp-collector-port: "4317"
-    otel-max-queuesize: "2048"
-    otel-schedule-delay-millis: "5000"
-    otel-max-export-batch-size: "512"
-    otel-service-name: "nginx-ingress" # Opentelemetry resource name
-    otel-sampler: "AlwaysOn" # Also: AlwaysOff, TraceIdRatioBased
-    otel-sampler-ratio: "1.0"
+#   enable-opentelemetry: "true"
+#   opentelemetry-config: "/etc/nginx/opentelemetry.toml"
+#   opentelemetry-operation-name: "HTTP $request_method $service_name $uri"
+#   opentelemetry-trust-incoming-span: "true"
+#   otlp-collector-host: "alloy.monitoring"
+#   otlp-collector-port: "4317"
+#   otel-max-queuesize: "2048"
+#   otel-schedule-delay-millis: "5000"
+#   otel-max-export-batch-size: "512"
+#   otel-service-name: "nginx-ingress" # Opentelemetry resource name
+#   otel-sampler: "AlwaysOn" # Also: AlwaysOff, TraceIdRatioBased
+#   otel-sampler-ratio: "1.0"
 
-  metrics:
-    enabled: true
-    serviceMonitor:
-      enabled: true
+#  metrics:
+#    enabled: true
+#    serviceMonitor:
+#      enabled: true

--- a/examples/kubernetes/nginx/helm-values.yaml
+++ b/examples/kubernetes/nginx/helm-values.yaml
@@ -3,20 +3,20 @@ controller:
 
   config:
     annotations-risk-level: "Critical"
-    enable-opentelemetry: "true"
-    opentelemetry-config: "/etc/nginx/opentelemetry.toml"
-    opentelemetry-operation-name: "HTTP $request_method $service_name $uri"
-    opentelemetry-trust-incoming-span: "true"
-    otlp-collector-host: "alloy.monitoring"
-    otlp-collector-port: "4317"
-    otel-max-queuesize: "2048"
-    otel-schedule-delay-millis: "5000"
-    otel-max-export-batch-size: "512"
-    otel-service-name: "nginx-ingress" # Opentelemetry resource name
-    otel-sampler: "AlwaysOn" # Also: AlwaysOff, TraceIdRatioBased
-    otel-sampler-ratio: "1.0"
+#   enable-opentelemetry: "true"
+#   opentelemetry-config: "/etc/nginx/opentelemetry.toml"
+#   opentelemetry-operation-name: "HTTP $request_method $service_name $uri"
+#   opentelemetry-trust-incoming-span: "true"
+#   otlp-collector-host: "alloy.monitoring"
+#   otlp-collector-port: "4317"
+#   otel-max-queuesize: "2048"
+#   otel-schedule-delay-millis: "5000"
+#   otel-max-export-batch-size: "512"
+#   otel-service-name: "nginx-ingress" # Opentelemetry resource name
+#   otel-sampler: "AlwaysOn" # Also: AlwaysOff, TraceIdRatioBased
+#   otel-sampler-ratio: "1.0"
 
-  metrics:
-    enabled: true
-    serviceMonitor:
-      enabled: true
+#  metrics:
+#    enabled: true
+#    serviceMonitor:
+#      enabled: true

--- a/examples/kubernetes/quickstarts/heimdall/config.yaml
+++ b/examples/kubernetes/quickstarts/heimdall/config.yaml
@@ -3,7 +3,13 @@ log:
   level: trace
 
 profiling:
-  enabled: true
+  enabled: false
+
+metrics:
+  enabled: false
+
+tracing:
+  enabled: false
 
 serve:
   tls:

--- a/examples/kubernetes/quickstarts/heimdall/helm-values.yaml
+++ b/examples/kubernetes/quickstarts/heimdall/helm-values.yaml
@@ -30,9 +30,6 @@ admissionController:
   annotations:
     cert-manager.io/inject-ca-from: heimdall/heimdall-tls
 
-profiling:
-  enabled: true
-
 env:
   OTEL_METRICS_EXPORTER: "prometheus"
   OTEL_EXPORTER_PROMETHEUS_HOST: "0.0.0.0"

--- a/examples/kubernetes/traefik/global-mw-helm-values.yaml
+++ b/examples/kubernetes/traefik/global-mw-helm-values.yaml
@@ -4,18 +4,18 @@ logs:
   access:
     enabled: true
 
-tracing:
-  otlp:
-    enabled: true
-    grpc:
-      enabled: true
-      endpoint: alloy.monitoring:4317
-      insecure: true
+#tracing:
+#  otlp:
+#    enabled: true
+#    grpc:
+#      enabled: true
+#      endpoint: alloy.monitoring:4317
+#      insecure: true
 
-metrics:
-  prometheus:
-    serviceMonitor:
-      enabled: true
+#metrics:
+#  prometheus:
+#    serviceMonitor:
+#      enabled: true
 
 experimental:
   kubernetesGateway:

--- a/examples/kubernetes/traefik/helm-values.yaml
+++ b/examples/kubernetes/traefik/helm-values.yaml
@@ -4,18 +4,18 @@ logs:
   access:
     enabled: true
 
-tracing:
-  otlp:
-    enabled: true
-    grpc:
-      enabled: true
-      endpoint: alloy.monitoring:4317
-      insecure: true
+#tracing:
+#  otlp:
+#    enabled: true
+#    grpc:
+#      enabled: true
+#      endpoint: alloy.monitoring:4317
+#      insecure: true
 
-metrics:
-  prometheus:
-    serviceMonitor:
-      enabled: true
+#metrics:
+#  prometheus:
+#    serviceMonitor:
+#      enabled: true
 
 experimental:
   kubernetesGateway:


### PR DESCRIPTION
## Related issue(s)

None

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have updated the documentation.

## Description

The OTEL stack used in kubernetes examples is partially based on bitnami images, which a not publicly available anymore. To make the examples working again, this PR disables OTEL for now. Another PR will come which updates the setup with new working images and related configuration