### PR TITLE
fix: Configured keystores must contain at least one key entry

### DIFF
--- a/internal/keystore/key_store.go
+++ b/internal/keystore/key_store.go
@@ -151,15 +151,15 @@ func createKeyStore(blocks []*pem.Block, password string) (keyStore, error) {
 		}
 	}
 
+	return verifyAndBuildKeyStore(entries, certs)
+}
+
+func verifyAndBuildKeyStore(entries []*Entry, certs []*x509.Certificate) (keyStore, error) {
 	if len(entries) == 0 {
 		return nil, errorchain.NewWithMessage(heimdall.ErrConfiguration,
 			"no key material present in the keystore")
 	}
 
-	return verifyAndBuildKeyStore(entries, certs)
-}
-
-func verifyAndBuildKeyStore(entries []*Entry, certs []*x509.Certificate) (keyStore, error) {
 	known := make(map[string]bool)
 
 	for idx, entry := range entries {

--- a/internal/keystore/key_store_test.go
+++ b/internal/keystore/key_store_test.go
@@ -184,6 +184,7 @@ r31pyBUcAO9GOL56rDXzHQk=
 
 `)
 
+// nolint: gochecknoglobals
 var pemWithSingleCertificate = []byte(`
 -----BEGIN CERTIFICATE-----
 MIIDYTCCAkmgAwIBAgIURtXjJtmBH6JNhf4v0pgSQkcvoFowDQYJKoZIhvcNAQEL


### PR DESCRIPTION
## Related issue(s)

fixes #2833

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

This PR implements a check to ensure that configured keystores contain at least one key entry