### PR TITLE
fix: Resolution of the request duration metric adjusted to make it meaningful

### DIFF
--- a/internal/otel/meter_provider.go
+++ b/internal/otel/meter_provider.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.uber.org/fx"
 
 	"github.com/dadrus/heimdall/internal/config"
@@ -46,11 +47,31 @@ func initMeterProvider(
 		return err
 	}
 
-	opts := make([]metric.Option, len(metricsReaders)+1)
-	opts[0] = metric.WithResource(res)
+	opts := make([]metric.Option, 0, len(metricsReaders)+2)
+	opts = append(opts,
+		metric.WithResource(res),
+		metric.WithView(metric.NewView(
+			metric.Instrument{
+				Name: semconv.HTTPServerRequestDurationName,
+				Kind: metric.InstrumentKindHistogram,
+			},
+			metric.Stream{
+				Aggregation: metric.AggregationExplicitBucketHistogram{
+					Boundaries: []float64{
+						0.00001, 0.00005, // 10, 50µs
+						0.0001, 0.00025, 0.0005, 0.00075, // 100, 250, 500, 750µs
+						0.001, 0.0025, 0.005, 0.0075, // 1, 2.5, 5, 7.5ms
+						0.01, 0.025, 0.05, 0.075, // 10, 25, 50, 75ms
+						0.1, 0.25, 0.5, 0.75, // 100, 250, 500 750 ms
+						1.0, 2.0, 5.0, // 1, 2, 5
+					},
+				},
+			},
+		)),
+	)
 
-	for i, reader := range metricsReaders {
-		opts[i+1] = metric.WithReader(reader)
+	for _, reader := range metricsReaders {
+		opts = append(opts, metric.WithReader(reader))
 	}
 
 	mp := metric.NewMeterProvider(opts...)


### PR DESCRIPTION
## Related issue(s)

none

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).

## Description

This PR makes the OTEL metric `http.server.request.duration` (and its Prometheus-exported counterpart `http_server_request_duration_seconds`) usable again, restoring the effective resolution that existed in v0.11.1-alpha prior to the migration to OpenTelemetry.

The default OTEL histogram configuration uses a lowest bucket boundary of 5 ms, which is far too coarse for heimdall’s request latency characteristics (typically, P99 of requests complete well below 1 ms). That makes all sub-millisecond latencies collapse into a single bucket and renders percentile calculations (P50–P99) meaningless by obscuring latency regressions.

---
BEGIN_COMMIT_OVERRIDE
fix: Request duration metric resolution adjusted for sub-millisecond latencies (#2954)
END_COMMIT_OVERRIDE