### PR TITLE
chore: Further perf related updates

### DIFF
--- a/internal/config/metrics.go
+++ b/internal/config/metrics.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"fmt"
 	"os"
 )
 
@@ -34,8 +33,7 @@ func envOr(key, defaultValue string) string {
 }
 
 func (c MetricsConfig) Address() string {
-	return fmt.Sprintf("%s:%s",
-		envOr("OTEL_EXPORTER_PROMETHEUS_HOST", "127.0.0.1"),
-		envOr("OTEL_EXPORTER_PROMETHEUS_PORT", "9464"),
-	)
+	return envOr("OTEL_EXPORTER_PROMETHEUS_HOST", "127.0.0.1") +
+		":" +
+		envOr("OTEL_EXPORTER_PROMETHEUS_PORT", "9464")
 }

--- a/internal/handler/decision/service.go
+++ b/internal/handler/decision/service.go
@@ -17,7 +17,6 @@
 package decision
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -70,8 +69,7 @@ func newService(
 		otelhttp.NewMiddleware("",
 			otelhttp.WithServerName(cfg.Address()),
 			otelhttp.WithSpanNameFormatter(func(_ string, req *http.Request) string {
-				return fmt.Sprintf("EntryPoint %s %s%s",
-					strings.ToLower(req.URL.Scheme), httpx.LocalAddress(req), req.URL.Path)
+				return "EntryPoint " + strings.ToLower(req.URL.Scheme) + " " + httpx.LocalAddress(req) + req.URL.Path
 			}),
 		),
 		otelmetrics.New(

--- a/internal/handler/envoyextauth/grpcv3/request_context.go
+++ b/internal/handler/envoyextauth/grpcv3/request_context.go
@@ -18,7 +18,6 @@ package grpcv3
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -183,7 +182,7 @@ func (r *RequestContext) Finalize() (*envoy_auth.CheckResponse, error) {
 		cidx := 0
 
 		for k, v := range r.upstreamCookies {
-			cookies[cidx] = fmt.Sprintf("%s=%s", k, v)
+			cookies[cidx] = k + "=" + v
 			cidx++
 		}
 

--- a/internal/handler/envoyextauth/grpcv3/service.go
+++ b/internal/handler/envoyextauth/grpcv3/service.go
@@ -89,7 +89,7 @@ func newService(
 		grpc.KeepaliveParams(keepalive.ServerParameters{Timeout: cfg.Timeout.Idle}),
 		grpc.ReadBufferSize(safecast.MustConvert[int](uint64(cfg.BufferLimit.Read))),
 		grpc.WriteBufferSize(safecast.MustConvert[int](uint64(cfg.BufferLimit.Write))),
-		grpc.UnknownServiceHandler(func(_ interface{}, _ grpc.ServerStream) error {
+		grpc.UnknownServiceHandler(func(_ any, _ grpc.ServerStream) error {
 			return status.Error(codes.Unknown, "unknown service or method")
 		}),
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),

--- a/internal/handler/management/service.go
+++ b/internal/handler/management/service.go
@@ -17,7 +17,6 @@
 package management
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -56,8 +55,7 @@ func newService(
 			otelhttp.WithServerName(cfg.Address()),
 			otelhttp.WithFilter(opFilter),
 			otelhttp.WithSpanNameFormatter(func(_ string, req *http.Request) string {
-				return fmt.Sprintf("EntryPoint %s %s%s",
-					strings.ToLower(req.URL.Scheme), httpx.LocalAddress(req), req.URL.Path)
+				return "EntryPoint " + strings.ToLower(req.URL.Scheme) + " " + httpx.LocalAddress(req) + req.URL.Path
 			}),
 		),
 		otelmetrics.New(

--- a/internal/handler/middleware/grpc/otelmetrics/interceptor.go
+++ b/internal/handler/middleware/grpc/otelmetrics/interceptor.go
@@ -24,7 +24,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 
@@ -43,7 +43,7 @@ type ServerInterceptor interface {
 }
 
 type metricsInterceptor struct {
-	activeRequests metric.Float64UpDownCounter
+	activeRequests metric.Int64UpDownCounter
 	attributes     []attribute.KeyValue
 	server         string
 	subsystem      attribute.KeyValue
@@ -62,9 +62,9 @@ func New(opts ...Option) ServerInterceptor {
 
 	meter := conf.provider.Meter(instrumentationName)
 
-	activeRequestsMeasure, err := meter.Float64UpDownCounter(
+	activeRequestsMeasure, err := meter.Int64UpDownCounter(
 		requestsActive,
-		metric.WithDescription("Measures the number of concurrent RPC requests that are currently in-flight."),
+		metric.WithDescription("Number of active RPC server requests."),
 		metric.WithUnit("{request}"),
 	)
 	if err != nil {

--- a/internal/handler/middleware/grpc/otelmetrics/interceptor_test.go
+++ b/internal/handler/middleware/grpc/otelmetrics/interceptor_test.go
@@ -31,7 +31,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
 	rpc_status "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -78,10 +78,10 @@ func TestHandlerObserveKnownRequests(t *testing.T) {
 
 				activeRequestsMetric := metrics.Metrics[0]
 				assert.Equal(t, "rpc.server.active_requests", activeRequestsMetric.Name)
-				assert.Equal(t, "Measures the number of concurrent RPC requests that are currently in-flight.",
+				assert.Equal(t, "Number of active RPC server requests.",
 					activeRequestsMetric.Description)
 
-				activeRequests := activeRequestsMetric.Data.(metricdata.Sum[float64]) // nolint: forcetypeassert
+				activeRequests := activeRequestsMetric.Data.(metricdata.Sum[int64]) // nolint: forcetypeassert
 				assert.False(t, activeRequests.IsMonotonic)
 				require.Len(t, activeRequests.DataPoints, 1)
 				require.InDelta(t, float64(0), activeRequests.DataPoints[0].Value, 0.00)
@@ -128,13 +128,13 @@ func TestHandlerObserveKnownRequests(t *testing.T) {
 
 				activeRequestsMetric := metrics.Metrics[0]
 				assert.Equal(t, "rpc.server.active_requests", activeRequestsMetric.Name)
-				assert.Equal(t, "Measures the number of concurrent RPC requests that are currently in-flight.",
+				assert.Equal(t, "Number of active RPC server requests.",
 					activeRequestsMetric.Description)
 
-				activeRequests := activeRequestsMetric.Data.(metricdata.Sum[float64]) // nolint: forcetypeassert
+				activeRequests := activeRequestsMetric.Data.(metricdata.Sum[int64]) // nolint: forcetypeassert
 				assert.False(t, activeRequests.IsMonotonic)
 				require.Len(t, activeRequests.DataPoints, 1)
-				require.InDelta(t, float64(0), activeRequests.DataPoints[0].Value, 0.00)
+				require.InDelta(t, int64(0), activeRequests.DataPoints[0].Value, 0.00)
 				require.Equal(t, 9, activeRequests.DataPoints[0].Attributes.Len())
 				assert.Equal(t, "foobar",
 					attributeValue(activeRequests.DataPoints[0].Attributes, "service.subsystem").AsString())
@@ -172,13 +172,13 @@ func TestHandlerObserveKnownRequests(t *testing.T) {
 
 				activeRequestsMetric := metrics.Metrics[0]
 				assert.Equal(t, "rpc.server.active_requests", activeRequestsMetric.Name)
-				assert.Equal(t, "Measures the number of concurrent RPC requests that are currently in-flight.",
+				assert.Equal(t, "Number of active RPC server requests.",
 					activeRequestsMetric.Description)
 
-				activeRequests := activeRequestsMetric.Data.(metricdata.Sum[float64]) // nolint: forcetypeassert
+				activeRequests := activeRequestsMetric.Data.(metricdata.Sum[int64]) // nolint: forcetypeassert
 				assert.False(t, activeRequests.IsMonotonic)
 				require.Len(t, activeRequests.DataPoints, 1)
-				require.InDelta(t, float64(0), activeRequests.DataPoints[0].Value, 0.00)
+				require.InDelta(t, int64(0), activeRequests.DataPoints[0].Value, 0.00)
 				require.Equal(t, 9, activeRequests.DataPoints[0].Attributes.Len())
 				assert.Equal(t, "foobar",
 					attributeValue(activeRequests.DataPoints[0].Attributes, "service.subsystem").AsString())
@@ -322,13 +322,13 @@ func TestHandlerObserveUnknownRequests(t *testing.T) {
 
 	activeRequestsMetric := metrics.Metrics[0]
 	assert.Equal(t, "rpc.server.active_requests", activeRequestsMetric.Name)
-	assert.Equal(t, "Measures the number of concurrent RPC requests that are currently in-flight.",
+	assert.Equal(t, "Number of active RPC server requests.",
 		activeRequestsMetric.Description)
 
-	activeRequests := activeRequestsMetric.Data.(metricdata.Sum[float64]) // nolint: forcetypeassert
+	activeRequests := activeRequestsMetric.Data.(metricdata.Sum[int64]) // nolint: forcetypeassert
 	assert.False(t, activeRequests.IsMonotonic)
 	require.Len(t, activeRequests.DataPoints, 1)
-	require.InDelta(t, float64(0), activeRequests.DataPoints[0].Value, 0.00)
+	require.InDelta(t, int64(0), activeRequests.DataPoints[0].Value, 0.00)
 	require.Equal(t, 9, activeRequests.DataPoints[0].Attributes.Len())
 	assert.Equal(t, "foobar",
 		attributeValue(activeRequests.DataPoints[0].Attributes, "service.subsystem").AsString())

--- a/internal/handler/middleware/http/accesslog/handler_test.go
+++ b/internal/handler/middleware/http/accesslog/handler_test.go
@@ -18,7 +18,6 @@ package accesslog
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -36,6 +35,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/dadrus/heimdall/internal/accesscontext"
+	"github.com/dadrus/heimdall/internal/x/httpx"
 	"github.com/dadrus/heimdall/internal/x/testsupport"
 )
 
@@ -284,8 +284,8 @@ func TestHandlerExecution(t *testing.T) {
 							otelhttp.WithTracerProvider(otel.GetTracerProvider()),
 							otelhttp.WithServerName("proxy"),
 							otelhttp.WithSpanNameFormatter(func(_ string, req *http.Request) string {
-								return fmt.Sprintf("EntryPoint %s %s%s",
-									strings.ToLower(req.URL.Scheme), "ctx.Context().LocalAddr().String()", req.URL.Path)
+								return "EntryPoint " + strings.ToLower(req.URL.Scheme) + " " +
+									httpx.LocalAddress(req) + req.URL.Path
 							}),
 						)
 					},

--- a/internal/handler/middleware/http/otelmetrics/handler_test.go
+++ b/internal/handler/middleware/http/otelmetrics/handler_test.go
@@ -72,21 +72,17 @@ func TestHandlerExecution(t *testing.T) {
 
 				activeRequestsMetric := metrics.Metrics[0]
 				assert.Equal(t, "http.server.active_requests", activeRequestsMetric.Name)
-				assert.Equal(t, "Measures the number of concurrent HTTP requests that are currently in-flight.",
+				assert.Equal(t, "Number of active HTTP server requests.",
 					activeRequestsMetric.Description)
-				activeRequests := activeRequestsMetric.Data.(metricdata.Sum[float64]) // nolint: forcetypeassert
+				activeRequests := activeRequestsMetric.Data.(metricdata.Sum[int64]) // nolint: forcetypeassert
 				assert.False(t, activeRequests.IsMonotonic)
 				require.Len(t, activeRequests.DataPoints, 1)
 				require.InDelta(t, float64(0), activeRequests.DataPoints[0].Value, 0.00)
-				require.Equal(t, 8, activeRequests.DataPoints[0].Attributes.Len())
+				require.Equal(t, 6, activeRequests.DataPoints[0].Attributes.Len())
 				assert.Equal(t, "foobar",
 					attributeValue(activeRequests.DataPoints[0].Attributes, "service.subsystem").AsString())
 				assert.Equal(t, "zab",
 					attributeValue(activeRequests.DataPoints[0].Attributes, "baz").AsString())
-				assert.Equal(t, "http",
-					attributeValue(activeRequests.DataPoints[0].Attributes, "network.protocol.name").AsString())
-				assert.Equal(t, "1.1",
-					attributeValue(activeRequests.DataPoints[0].Attributes, "network.protocol.version").AsString())
 				assert.Equal(t, http.MethodGet,
 					attributeValue(activeRequests.DataPoints[0].Attributes, "http.request.method").AsString())
 				assert.Equal(t, "http",

--- a/internal/handler/proxy/service.go
+++ b/internal/handler/proxy/service.go
@@ -19,7 +19,6 @@ package proxy
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"net"
 	"net/http"
 	"strings"
@@ -108,8 +107,7 @@ func newService(
 		otelhttp.NewMiddleware("",
 			otelhttp.WithServerName(cfg.Address()),
 			otelhttp.WithSpanNameFormatter(func(_ string, req *http.Request) string {
-				return fmt.Sprintf("EntryPoint %s %s%s",
-					strings.ToLower(req.URL.Scheme), httpx.LocalAddress(req), req.URL.Path)
+				return "EntryPoint " + strings.ToLower(req.URL.Scheme) + " " + httpx.LocalAddress(req) + req.URL.Path
 			}),
 		),
 		otelmetrics.New(

--- a/internal/otel/meter_provider.go
+++ b/internal/otel/meter_provider.go
@@ -23,7 +23,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.38.0/httpconv"
 	"go.uber.org/fx"
 
 	"github.com/dadrus/heimdall/internal/config"
@@ -52,7 +52,7 @@ func initMeterProvider(
 		metric.WithResource(res),
 		metric.WithView(metric.NewView(
 			metric.Instrument{
-				Name: semconv.HTTPServerRequestDurationName,
+				Name: semconv.ServerRequestDuration{}.Name(),
 				Kind: metric.InstrumentKindHistogram,
 			},
 			metric.Stream{

--- a/internal/otel/resource.go
+++ b/internal/otel/resource.go
@@ -18,7 +18,7 @@ package otel
 
 import (
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
 
 	"github.com/dadrus/heimdall/version"
 )

--- a/internal/rules/config/url_rewriter.go
+++ b/internal/rules/config/url_rewriter.go
@@ -17,7 +17,6 @@
 package config
 
 import (
-	"fmt"
 	"net/url"
 	"slices"
 	"strings"
@@ -41,7 +40,7 @@ type PrefixAdder string
 
 func (a PrefixAdder) AddTo(value string) string {
 	if len(a) != 0 {
-		return fmt.Sprintf("%s%s", a, value)
+		return string(a) + value
 	}
 
 	return value

--- a/internal/rules/endpoint/endpoint.go
+++ b/internal/rules/endpoint/endpoint.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -63,7 +62,7 @@ func (e Endpoint) CreateClient(peerName string) *http.Client {
 		Transport: otelhttp.NewTransport(
 			httpx.NewTraceRoundTripper(http.DefaultTransport),
 			otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
-				return fmt.Sprintf("%s %s %s @%s", r.Proto, r.Method, r.URL.Path, peerName)
+				return r.Proto + " " + r.Method + " " + r.URL.Path + " @" + peerName
 			})),
 	}
 

--- a/internal/rules/mechanisms/finalizers/oauth2_client_credentials_finalizer.go
+++ b/internal/rules/mechanisms/finalizers/oauth2_client_credentials_finalizer.go
@@ -17,7 +17,6 @@
 package finalizers
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -182,7 +181,7 @@ func (f *oauth2ClientCredentialsFinalizer) Execute(ctx heimdall.RequestContext, 
 		headerScheme = f.headerScheme
 	}
 
-	ctx.AddHeaderForUpstream(f.headerName, fmt.Sprintf("%s %s", headerScheme, token.AccessToken))
+	ctx.AddHeaderForUpstream(f.headerName, headerScheme+" "+token.AccessToken)
 
 	return nil
 }

--- a/internal/rules/mechanisms/oauth2/server_metadata.go
+++ b/internal/rules/mechanisms/oauth2/server_metadata.go
@@ -17,7 +17,6 @@
 package oauth2
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/dadrus/heimdall/internal/heimdall"
@@ -47,7 +46,7 @@ func (sm ServerMetadata) verify(usedMetadataURL string) error {
 	}
 
 	if strings.Contains(uriSuffix, "/") {
-		expectedIssuer = fmt.Sprintf("%s%s", uriPrefix, strings.Split(uriSuffix, "/")[1])
+		expectedIssuer = uriPrefix + strings.Split(uriSuffix, "/")[1]
 	} else {
 		expectedIssuer = strings.TrimSuffix(uriPrefix, "/")
 	}

--- a/internal/rules/provider/cloudblob/ruleset_endpoint.go
+++ b/internal/rules/provider/cloudblob/ruleset_endpoint.go
@@ -19,7 +19,6 @@ package cloudblob
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"net/url"
 
@@ -41,7 +40,7 @@ type ruleSetEndpoint struct {
 }
 
 func (e *ruleSetEndpoint) ID() string {
-	return fmt.Sprintf("%s/%s", e.URL, e.Prefix)
+	return e.URL.String() + "/" + e.Prefix
 }
 
 func (e *ruleSetEndpoint) FetchRuleSets(
@@ -142,7 +141,7 @@ func (e *ruleSetEndpoint) readRuleSet(
 	}
 
 	contents.Hash = attrs.MD5
-	contents.Source = fmt.Sprintf("%s@%s", key, e.ID())
+	contents.Source = key + "@" + e.ID()
 	contents.ModTime = attrs.ModTime
 
 	return contents, nil

--- a/internal/rules/provider/kubernetes/admissioncontroller/service.go
+++ b/internal/rules/provider/kubernetes/admissioncontroller/service.go
@@ -17,7 +17,6 @@
 package admissioncontroller
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -60,8 +59,7 @@ func newService(
 		otelhttp.NewMiddleware("",
 			otelhttp.WithServerName(serviceName),
 			otelhttp.WithSpanNameFormatter(func(_ string, req *http.Request) string {
-				return fmt.Sprintf("EntryPoint %s %s%s",
-					strings.ToLower(req.URL.Scheme), httpx.LocalAddress(req), req.URL.Path)
+				return "EntryPoint " + strings.ToLower(req.URL.Scheme) + " " + httpx.LocalAddress(req) + req.URL.Path
 			}),
 		),
 		otelmetrics.New(

--- a/internal/x/errorchain/error_chain.go
+++ b/internal/x/errorchain/error_chain.go
@@ -70,7 +70,8 @@ func (ec *ErrorChain) Error() string {
 		if len(c.msg) == 0 {
 			errs = append(errs, c.err.Error())
 		} else {
-			errs = append(errs, fmt.Sprintf("%s: %s", c.err.Error(), c.msg))
+			err := c.err.Error() + ": " + c.msg
+			errs = append(errs, err)
 		}
 	}
 

--- a/internal/x/opentelemetry/mocks/mock.go
+++ b/internal/x/opentelemetry/mocks/mock.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/bridge/opentracing/migration"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.38.0"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/embedded"
 	"go.opentelemetry.io/otel/trace/noop"


### PR DESCRIPTION
## Related issue(s)

relates to #2955

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.

## Description

This PR continues the work done in #2955 in further reduces the memory and CPU footprint by dropping the usage of `fmt.Sprintf` in hot paths.

Additionally, this PR changed the used OTEL semconv version to 1.38.0 and updated the implementation of `http.server.active_requests` and `rpc.server.active_requests` metrics to comply with recent OTEL semantics.