### PR TITLE
fix: Request duration entry in access log is now positive

### DIFF
--- a/internal/handler/middleware/grpc/accesslog/interceptor.go
+++ b/internal/handler/middleware/grpc/accesslog/interceptor.go
@@ -103,7 +103,7 @@ func (i *accessLogInterceptor) finalizeTransaction(
 
 	logAccessStatus(ctx, accLog.Info(), err).
 		Uint32("_grpc_status_code", uint32(grpcStatus.Code())).
-		Int64("_tx_duration_ms", time.Until(start).Milliseconds()).
+		Int64("_tx_duration_ms", time.Since(start).Milliseconds()).
 		Msg("TX finished")
 }
 

--- a/internal/handler/middleware/http/accesslog/handler.go
+++ b/internal/handler/middleware/http/accesslog/handler.go
@@ -63,7 +63,7 @@ func New(logger zerolog.Logger) func(http.Handler) http.Handler {
 			logAccessStatus(ctx, accLog.Info(), metrics.Code).
 				Int64("_body_bytes_sent", metrics.Written).
 				Int("_http_status_code", metrics.Code).
-				Int64("_tx_duration_ms", time.Until(start).Milliseconds()).
+				Int64("_tx_duration_ms", time.Since(start).Milliseconds()).
 				Msg("TX finished")
 		})
 	}


### PR DESCRIPTION
## Related issue(s)

fixes #2979

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.


## Description

This PR makes the `_tx_duration_ms` entry in access logs positive.