### PR TITLE
 fix: Split query from path in envoy gRPC based ExtAuth integration

### DIFF
--- a/internal/handler/envoyextauth/grpcv3/request_context.go
+++ b/internal/handler/envoyextauth/grpcv3/request_context.go
@@ -71,7 +71,6 @@ type RequestContext struct {
 	hmdlReq         *heimdall.Request
 
 	// the following properties are created lazy and cached
-
 	savedBody any
 	outputs   map[string]any
 }
@@ -102,7 +101,11 @@ func (r *RequestContext) Init(ctx context.Context, req *envoy_auth.CheckRequest)
 	}
 
 	httpReq := req.GetAttributes().GetRequest().GetHttp()
-	reqURI, _ := url.ParseRequestURI(httpReq.GetPath())
+
+	parsed, err := url.ParseRequestURI(httpReq.GetPath())
+	if err != nil {
+		parsed = &url.URL{}
+	}
 
 	r.ctx = ctx
 	r.reqHeaders = canonicalizeHeaders(httpReq.GetHeaders())
@@ -111,9 +114,9 @@ func (r *RequestContext) Init(ctx context.Context, req *envoy_auth.CheckRequest)
 	r.hmdlReq.URL.URL = url.URL{
 		Scheme:   httpReq.GetScheme(),
 		Host:     httpReq.GetHost(),
-		Path:     reqURI.Path,
-		RawPath:  reqURI.RawPath,
-		RawQuery: reqURI.RawQuery,
+		RawPath:  parsed.RawPath,
+		Path:     parsed.Path,
+		RawQuery: parsed.RawQuery,
 	}
 	r.hmdlReq.ClientIPAddresses = clientIPs
 }

--- a/internal/handler/envoyextauth/grpcv3/request_context_test.go
+++ b/internal/handler/envoyextauth/grpcv3/request_context_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -38,16 +37,15 @@ func TestNewRequestContext(t *testing.T) {
 	t.Parallel()
 
 	// GIVEN
-	reqURI, err := url.ParseRequestURI("/test/baz?bar=moo#foobar")
-	require.NoError(t, err)
-
 	httpReq := &envoy_auth.AttributeContext_HttpRequest{
-		Method:  http.MethodPatch,
-		Scheme:  "https",
-		Host:    "foo.bar:8080",
-		Path:    reqURI.String(),
-		Body:    "content=heimdall",
-		RawBody: []byte("content=heimdall"),
+		Method:   http.MethodPatch,
+		Scheme:   "https",
+		Host:     "foo.bar:8080",
+		Path:     "/test/baz?bar=moo#foobar",
+		Query:    "", // documented to be empty
+		Fragment: "", // documented to be empty
+		Body:     "content=heimdall",
+		RawBody:  []byte("content=heimdall"),
 		Headers: map[string]string{
 			"x-foo-bar":    "barfoo",
 			"cookie":       "bar=foo;foo=baz",
@@ -79,10 +77,10 @@ func TestNewRequestContext(t *testing.T) {
 	require.Equal(t, httpReq.GetMethod(), ctx.Request().Method)
 	require.Equal(t, httpReq.GetScheme(), ctx.Request().URL.Scheme)
 	require.Equal(t, httpReq.GetHost(), ctx.Request().URL.Host)
-	require.Equal(t, reqURI.Path, ctx.Request().URL.Path)
+	require.Equal(t, "/test/baz", ctx.Request().URL.Path)
 	require.Empty(t, ctx.Request().URL.Fragment)
-	require.Equal(t, reqURI.RawQuery, ctx.Request().URL.RawQuery)
-	require.Equal(t, "moo#foobar", ctx.Request().URL.Query().Get("bar"))
+	require.Equal(t, "bar=moo#foobar", ctx.Request().URL.RawQuery)
+	require.Equal(t, "moo#foobar", ctx.Request().URL.URL.Query().Get("bar"))
 	require.Equal(t, map[string]any{"content": []string{"heimdall"}}, ctx.Request().Body())
 	require.Len(t, ctx.Request().Headers(), 3)
 	require.Equal(t, "barfoo", ctx.Request().Header("X-Foo-Bar"))


### PR DESCRIPTION
## Related issue(s)

fixes https://github.com/dadrus/heimdall/security/advisories/GHSA-r8x2-fhmf-6mxp

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

Per spec, the query and fragment arguments are always empty. Instead, the query must be parsed from the path argument.
