### PR TITLE
fix: Strict validation of `log.level` values

### DIFF
--- a/internal/config/mapstructure_decoder.go
+++ b/internal/config/mapstructure_decoder.go
@@ -53,14 +53,14 @@ func logLevelDecodeHookFunc(from reflect.Type, to reflect.Type, data any) (any, 
 		return zerolog.DebugLevel, nil
 	case "trace":
 		return zerolog.TraceLevel, nil
-	case "no":
-		return zerolog.NoLevel, nil
-	case "disabled":
-		return zerolog.Disabled, nil
 	case "info":
 		return zerolog.InfoLevel, nil
 	default:
-		return zerolog.InfoLevel, nil
+		return data, errorchain.NewWithMessagef(
+			heimdall.ErrConfiguration,
+			"invalid log level '%v'. Supported levels are: panic, fatal, error, warn, info, debug, trace",
+			data,
+		)
 	}
 }
 

--- a/internal/config/mapstructure_decoder_test.go
+++ b/internal/config/mapstructure_decoder_test.go
@@ -39,6 +39,7 @@ func TestDecodeLogLevel(t *testing.T) {
 	for _, tc := range []struct {
 		config string
 		expect zerolog.Level
+		err    string
 	}{
 		{config: `level: debug`, expect: zerolog.DebugLevel},
 		{config: `level: info`, expect: zerolog.InfoLevel},
@@ -46,9 +47,8 @@ func TestDecodeLogLevel(t *testing.T) {
 		{config: `level: error`, expect: zerolog.ErrorLevel},
 		{config: `level: fatal`, expect: zerolog.FatalLevel},
 		{config: `level: panic`, expect: zerolog.PanicLevel},
-		{config: `level: no`, expect: zerolog.NoLevel},
-		{config: `level: disabled`, expect: zerolog.Disabled},
 		{config: `level: trace`, expect: zerolog.TraceLevel},
+		{config: `level: foo`, err: "invalid log level"},
 	} {
 		t.Run(tc.config, func(t *testing.T) {
 			// GIVEN
@@ -67,6 +67,13 @@ func TestDecodeLogLevel(t *testing.T) {
 			err = dec.Decode(conf)
 
 			// THEN
+			if len(tc.err) != 0 {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.err)
+
+				return
+			}
+
 			require.NoError(t, err)
 			assert.Equal(t, tc.expect, typ.Level)
 		})


### PR DESCRIPTION
## Related issue(s)

relates to #3160

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

This PR fixes ambiguous log level handling in configuration decoding. Previously, invalid `log.level` values were accepted and silently mapped to `info`, which made the resulting log output confusing, especially since the default log level is `error` (when `log.level` is not configured).

With this change, unsupported `log.level` values now cause heimdall to fail, so misconfiguration is detected immediately at startup.