### PR TITLE
fix: reset child pointer in wildcard lookup to prevent false cross-host conflict

### DIFF
--- a/internal/rules/repository_impl_test.go
+++ b/internal/rules/repository_impl_test.go
@@ -689,13 +689,13 @@ func TestRepositoryAddRuleSet(t *testing.T) {
 		},
 		"adding rules with different exact hosts sharing a common subdomain prefix from different rulesets is fine": {
 			initRules: func() []rule.Rule {
-				rul := &ruleImpl{id: "1", source: rule.RuleSet{ID: "1"}}
+				rul := &ruleImpl{id: "1", srcID: "1"}
 				rul.routes = append(rul.routes, &routeImpl{rule: rul, host: "formscribe.example.com", path: "/**"})
 
 				return []rule.Rule{rul}
 			}(),
 			tbaRules: func() []rule.Rule {
-				rul := &ruleImpl{id: "2", source: rule.RuleSet{ID: "2"}}
+				rul := &ruleImpl{id: "2", srcID: "2"}
 				rul.routes = append(rul.routes, &routeImpl{rule: rul, host: "funnel.example.com", path: "/.data"})
 
 				return []rule.Rule{rul}
@@ -708,13 +708,13 @@ func TestRepositoryAddRuleSet(t *testing.T) {
 		},
 		"adding rules with different exact hosts sharing a common subdomain prefix and overlapping paths from different rulesets is fine": {
 			initRules: func() []rule.Rule {
-				rul := &ruleImpl{id: "1", source: rule.RuleSet{ID: "1"}}
+				rul := &ruleImpl{id: "1", srcID: "1"}
 				rul.routes = append(rul.routes, &routeImpl{rule: rul, host: "foo.example.com", path: "/**"})
 
 				return []rule.Rule{rul}
 			}(),
 			tbaRules: func() []rule.Rule {
-				rul := &ruleImpl{id: "2", source: rule.RuleSet{ID: "2"}}
+				rul := &ruleImpl{id: "2", srcID: "2"}
 				rul.routes = append(rul.routes, &routeImpl{rule: rul, host: "foobar.example.com", path: "/**"})
 
 				return []rule.Rule{rul}

--- a/internal/rules/repository_impl_test.go
+++ b/internal/rules/repository_impl_test.go
@@ -687,6 +687,44 @@ func TestRepositoryAddRuleSet(t *testing.T) {
 				require.ErrorContains(t, err, "conflicting rules")
 			},
 		},
+		"adding rules with different exact hosts sharing a common subdomain prefix from different rulesets is fine": {
+			initRules: func() []rule.Rule {
+				rul := &ruleImpl{id: "1", source: rule.RuleSet{ID: "1"}}
+				rul.routes = append(rul.routes, &routeImpl{rule: rul, host: "formscribe.example.com", path: "/**"})
+
+				return []rule.Rule{rul}
+			}(),
+			tbaRules: func() []rule.Rule {
+				rul := &ruleImpl{id: "2", source: rule.RuleSet{ID: "2"}}
+				rul.routes = append(rul.routes, &routeImpl{rule: rul, host: "funnel.example.com", path: "/.data"})
+
+				return []rule.Rule{rul}
+			}(),
+			assert: func(t *testing.T, err error, _ *repository) {
+				t.Helper()
+
+				require.NoError(t, err)
+			},
+		},
+		"adding rules with different exact hosts sharing a common subdomain prefix and overlapping paths from different rulesets is fine": {
+			initRules: func() []rule.Rule {
+				rul := &ruleImpl{id: "1", source: rule.RuleSet{ID: "1"}}
+				rul.routes = append(rul.routes, &routeImpl{rule: rul, host: "foo.example.com", path: "/**"})
+
+				return []rule.Rule{rul}
+			}(),
+			tbaRules: func() []rule.Rule {
+				rul := &ruleImpl{id: "2", source: rule.RuleSet{ID: "2"}}
+				rul.routes = append(rul.routes, &routeImpl{rule: rul, host: "foobar.example.com", path: "/**"})
+
+				return []rule.Rule{rul}
+			}(),
+			assert: func(t *testing.T, err error, _ *repository) {
+				t.Helper()
+
+				require.NoError(t, err)
+			},
+		},
 	} {
 		t.Run(uc, func(t *testing.T) {
 			repo := newRepository(&ruleFactory{}).(*repository)

--- a/internal/x/radixtrie/lookup_wildcard.go
+++ b/internal/x/radixtrie/lookup_wildcard.go
@@ -45,6 +45,8 @@ func (s wildcardLookupStrategy[V]) lookupNodes(trie *Trie[V], hostPattern, pathP
 				return s.lookupNodes(child, "", tokens[childTokenLen:])
 			}
 
+			child = nil
+
 			break
 		}
 	}

--- a/internal/x/radixtrie/trie_test.go
+++ b/internal/x/radixtrie/trie_test.go
@@ -789,3 +789,20 @@ func TestTrieClone(t *testing.T) {
 		assert.Equal(t, values[1], entry.Value)
 	}
 }
+
+func TestTrieWildcardLookupDoesNotMatchDifferentExactHostsWithSharedPrefix(t *testing.T) {
+	t.Parallel()
+
+	tree := New[string]()
+
+	// Add a route for one exact host
+	err := tree.Add("foo.example.com", "/**", "foo-catchall")
+	require.NoError(t, err)
+
+	// Wildcard lookup for a different exact host sharing a subdomain prefix ("f")
+	// should NOT return any nodes
+	nodes, err := tree.Lookup("fuu.example.com", "", WithWildcardMatch[string]())
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrNotFound)
+	require.Empty(t, nodes)
+}


### PR DESCRIPTION
When two different hosts share a common domain and subdomain prefix (e.g. foo.example.com and fuu.example.com), the wildcard lookup incorrectly traverses into a sibling host's subtree. The cause is a stale child variable from static child lookup that is not cleared after the full token comparison fails.

<!--
Please note: This project expects semantic PRs. That means each PR name must comply to the pattern "tag: description",
with "tag" being one from the following list and "description" being the name/description of your PR:

* build - The PR is related to the build system of the project
* chore - The PR is about housekeeping, like fixing typos, and alike
* ci - The PR updates the CI
* docs - The PR updates the documentation
* deps - The PR updates dependencies
* feat - The PR implements a new feature
* fix - The PR fixes for a bug
* perf - The PR implements new performance tests
* refactor - The PR is about code refactoring
* revert - The PR reverts one of the previous PRs
* style - The PR updates the UI style
* test - The PR implements new tests
* wip - The PR is not yet ready for review; it is Work in Progress.

E.g.: "feat: Some cool feature".

If this PR introduces a breaking change, please put a "!" after the "tag" and before the colon.

E.g.: "feat!: Some cool feature"

When you create PRs which are not yet complete in sense of the implementation/changes, please use the "wip" tag
to inform the maintainers, you're not ready with your work, and you're not expecting a review.

As of today only PRs tagged with "feat", "fix", "deps" and "docs" as well as all breaking change PRs (those with
a "!" after the tag) are included into the change list of a release. This may change in the future. All contributors
are referenced in the release, despite whether the actual PR is listed ot not.

If your PR addresses multiple changes, you can represent these by adding additional semantic commit messages at the
end of the Description section (See below)
-->

## Related issue(s)
close #3169
<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, please create a new issue first, which describes the bug;
3. implements a new feature, link the issue describing the idea in the format of `#1234`;
4. improves documentation, updates dependencies, implements new tests, etc, no issue reference is required. Please delete this section in such case.

You can discuss changes with maintainers in the Github Discussions in this repository.
-->

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [ ] I have updated the documentation.

## Description

Reset the `child` variable to `nil` to prevent it to spill over.

Note that the issue was debugged with AI and it helped me to write the test code.
<!--
Describe your changes here to communicate 

1. why your PR should be accepted, why you chose the solution you did and what alternatives you considered, etc...
2. which changes/updates it introduces. If your change includes breaking changes please add a code block documenting the breaking change
-->

<!--
If your PR addresses multiple changes, you can represent these by adding additional semantic commit messages at the
end of this section. Otherwise, if the name of this PR is enough, delete this section.

E.g.
Other changes done by this PR:

feat: Other cool feature

fix: Fixes this and that issue

refactor: This and that refactored
-->
