### PR TITLE
fix: include CA certificate bundle in container image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,7 @@ WORKDIR /opt/heimdall
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /build/heimdall .
 
 USER ${USER}:${USER}


### PR DESCRIPTION
## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).

## Description

The release container image is built `FROM scratch` and only copies the binary, `passwd`, `group`, and `zoneinfo` files from the builder. No CA certificate bundle is copied in, so Go's `crypto/x509` system pool is empty
inside the running container.

As a result, **any** outbound HTTPS call from heimdall fails with:

`x509: certificate signed by unknown authority`

— regardless of who signed the upstream certificate. This breaks any configuration that fetches keys or metadata over HTTPS, e.g. a JWKS endpoint hosted on a public domain:

request to JWKS endpoint failed: Get "https://example.com/.well-known/jwks.json": tls: failed to verify certificate: x509: certificate signed by unknown authority

### Fix

Copy `/etc/ssl/certs/ca-certificates.crt` from the `golang:1.26.3-bookworm` builder (which already ships the `ca-certificates` package) into the final scratch stage. After this, the published image trusts standard public
CAs out of the box and no per-deployment workaround (host bind-mount of the CA bundle) is required.

### Alternatives considered

- **Mount the host CA bundle into the container at deploy time** — works, but every operator has to do it themselves and it leaks host paths into orchestrator configs.
- **Switch the base image away from `scratch`** — much larger blast radius for a one-line problem.