### PR TITLE
fix: Made HTTP Message Signatures auth type usable in endpoint configuration

### DIFF
--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -370,7 +370,7 @@ mechanisms:
           my_endpoint: "https://some-other.service/users/{{ .Values.user_id }}"
         values:
           user_id: "{{ .Subject.ID }}"
-    - id: profile_data_contextualizer
+    - id: contextualizer_with_api_key_usage
       type: generic
       config:
         endpoint:
@@ -383,6 +383,24 @@ mechanisms:
               in: query
               name: key
               value: super duper secret
+        values:
+          some-key: some-value
+    - id: contextualizer_with_http_sig_usage
+      type: generic
+      config:
+        endpoint:
+          url: http://profile/{{ .Subject.ID }}
+          headers:
+            foo: bar
+          auth:
+            type: http_message_signatures
+            config:
+              components: ["@method", "content-digest", "@authority", "@target-uri", "@scheme"]
+              signer:
+                name: heimdall
+                key_store:
+                  path: /opt/heimdall/keystore.pem
+                  password: VeryInsecure!
         values:
           some-key: some-value
   finalizers:

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -802,6 +802,9 @@
                 },
                 {
                   "$ref": "#/definitions/endpointAuth2ClientCredentialsProperties"
+                },
+                {
+                  "$ref": "#/definitions/endpointAuthHTTPMessageSignaturesProperties"
                 }
               ]
             },
@@ -1107,6 +1110,73 @@
         },
         "config": {
           "$ref": "#/definitions/oauth2ClientCredentialsFlowConfig"
+        }
+      }
+    },
+    "endpointAuthHTTPMessageSignaturesProperties": {
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "config"
+      ],
+      "properties": {
+        "type": {
+          "const": "http_message_signatures"
+        },
+        "config": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "components",
+            "signer"
+          ],
+          "properties": {
+            "components": {
+              "description": "The components to be covered by the signature.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "label": {
+              "description": "The label to use. Defaults to sig.",
+              "type": "string",
+              "default": "sig"
+            },
+            "ttl": {
+              "type": "string",
+              "description": "The TTL of the resulting signature. Defaults to 1m. Responsible for setting created and expires parameters in the resulting signature.",
+              "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
+              "default": "1m",
+              "examples": [
+                "1h",
+                "1m",
+                "30s"
+              ]
+            },
+            "signer": {
+              "description": "The configuration of the key material used for signature creation purposes, as well as the name used for the tag parameter in the resulting signature.",
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "key_store"
+              ],
+              "properties": {
+                "name": {
+                  "description": "The name of the signer. Used for the 'tag' parameter in the resulting signature.",
+                  "type": "string",
+                  "default": "heimdall"
+                },
+                "key_store": {
+                  "$ref": "#/definitions/keyStore"
+                },
+                "key_id": {
+                  "description": "The key id referencing the entry in the key store.",
+                  "type": "string"
+                }
+              }
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Related issue(s)

none
## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [ ] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

Although the `http_message_signatures` auth type was implemented long time ago, it was not usable due to missing schema definition. This PR fixes that.