### PR TITLE
feat: Usage of key material from JWKS files

### DIFF
--- a/cmd/validate/test_data/config-valid-with-default-rule.yaml
+++ b/cmd/validate/test_data/config-valid-with-default-rule.yaml
@@ -30,6 +30,11 @@ secret_management:
     allow_in_rules: true
     config:
       path: /path/to/secrets.json
+  jwks_secrets:
+    type: jwks
+    config:
+      path: /path/to/jwks.json
+      watch: true
 
 serve:
   port: 4468

--- a/cmd/validate/test_data/config-valid-without-default-rule.yaml
+++ b/cmd/validate/test_data/config-valid-without-default-rule.yaml
@@ -18,6 +18,11 @@ secret_management:
     type: pem
     config:
       path: "${TEST_KEYSTORE_FILE}"
+  jwks_secrets:
+    type: jwks
+    config:
+      path: /path/to/jwks.json
+      watch: true
 
 serve:
   port: 4468

--- a/docs/content/docs/configuration/reference.adoc
+++ b/docs/content/docs/configuration/reference.adoc
@@ -45,6 +45,18 @@ secret_management:
         client_id: ${AUTH_SERVER_CLIENT_ID}
         client_secret: ${AUTH_SERVER_CLIENT_SECRET}
       authz_system_api_key: ${AUTHZ_SYSTEM_API_KEY}
+  secrets_from_file:
+    type: file
+    allow_in_rules: false
+    config:
+      path: /path/to/yaml/or/json/file
+      watch: true
+  jwks_secrets:
+    type: jwks
+    allow_in_rules: false
+    config:
+      path: /path/to/jwks.file
+      watch: false
 
 serve:
   host: 127.0.0.1

--- a/docs/content/docs/operations/secret_management.adoc
+++ b/docs/content/docs/operations/secret_management.adoc
@@ -79,16 +79,16 @@ The following providers are available. Choosing the right one depends on the kin
 |===
 |Provider |Best suited for
 
-|`pem`
+|link:{{< relref "#_pem" >}}[`pem`]
 |Asymmetric key pairs and certificate bundles stored in PEM files. The natural choice when using cert-manager on Kubernetes or managing keys with standard PKI tooling.
 
-|`jwks`
+|link:{{< relref "#_jwks" >}}[`jwks`]
 |Asymmetric and symmetric key material in JWK Set format. Use when keys are already managed in JWKS format, or when you need to use symmetric keys.
 
-|`file`
+|link:{{< relref "#_file" >}}[`file`]
 |Structured credentials and plain string secrets stored in an external YAML or JSON file. Suitable for secrets injected at deployment time (e.g. mounted Kubernetes Secrets) that do not contain key material.
 
-|`inline`
+|link:{{< relref "#_inline" >}}[`inline`]
 |Local development, integration tests, and simple deployments where secrets are injected via environment variables.
 |===
 

--- a/docs/content/docs/operations/secret_management.adoc
+++ b/docs/content/docs/operations/secret_management.adoc
@@ -73,6 +73,25 @@ trust_anchors:
 
 == Secret Providers
 
+The following providers are available. Choosing the right one depends on the kind of key material and the deployment context:
+
+[cols="1,3", options="header"]
+|===
+|Provider |Best suited for
+
+|`pem`
+|Asymmetric key pairs and certificate bundles stored in PEM files. The natural choice when using cert-manager on Kubernetes or managing keys with standard PKI tooling.
+
+|`jwks`
+|Asymmetric and symmetric key material in JWK Set format. Use when keys are already managed in JWKS format, or when you need to use symmetric keys.
+
+|`file`
+|Structured credentials and plain string secrets stored in an external YAML or JSON file. Suitable for secrets injected at deployment time (e.g. mounted Kubernetes Secrets) that do not contain key material.
+
+|`inline`
+|Local development, integration tests, and simple deployments where secrets are injected via environment variables.
+|===
+
 === PEM
 
 The PEM provider reads a PEM-encoded file and exposes either asymmetric key material or a certificate bundle, depending on the file's contents. PKCS#1 and PKCS#8 encodings are supported for private keys.
@@ -102,7 +121,7 @@ NOTE: If the key store contains multiple password-protected keys, all keys must 
 +
 When enabled, heimdall watches the file for changes and reloads the secrets automatically when the file is modified.
 +
-NOTE: Components that consume certificate bundles as `trust_anchors` - such as the `jwt_authenticator` - do not hot-reload trust anchors. Changes to a certificate bundle file take effect for such consumers only after a restart of heimdall.
+NOTE: Components that consume certificate bundles as `trust_anchors` — such as the `jwt_authenticator` — do not hot-reload trust anchors. Changes to a certificate bundle file take effect for such consumers only after a restart of heimdall.
 
 [source,yaml]
 ----
@@ -163,6 +182,81 @@ tls:
 ----
 ====
 
+=== JWKS
+
+The JWKS provider reads key material from a local https://www.rfc-editor.org/rfc/rfc7517[JSON Web Key Set] (JWKS) file. It supports asymmetric private keys (RSA, EC, Ed25519) as well as symmetric keys (`kty: "oct"`), making it the only provider that can expose symmetric key material.
+
+NOTE: Certificate bundles are not supported by the JWKS provider. Use the `pem` provider for trust anchors.
+
+When loading a JWKS file, heimdall performs the following checks:
+
+* Every JWK entry must have a non-empty `kid`. Entries without a key ID are rejected.
+* Key IDs must be unique. Files with duplicate key IDs are rejected.
+* An empty JWKS file (no keys) is rejected.
+* For asymmetric keys with embedded X.509 certificates, the certificate chain is validated. If the chain is invalid, heimdall refuses to start.
+* Symmetric keys (`kty: "oct"`) must be at least 16 bytes long.
+
+To configure this provider, specify `jwks` as provider type. The following options are available under `config`:
+
+* *`path`*: _string_ (mandatory)
++
+Path to the JWKS file.
+
+* *`watch`*: _bool_ (optional, default: `false`)
++
+When enabled, heimdall watches the file for changes and reloads the provider automatically when the file is modified. If the updated file is invalid, the reload is rejected and the last known good state is kept.
+
+[source,yaml]
+----
+secret_management:
+  my_jwks_source:
+    type: jwks
+    config:
+      path: /etc/heimdall/keys.json
+      watch: true
+----
+
+.Example JWKS file with an asymmetric (Ed25519) private key
+====
+[source,json]
+----
+{
+  "keys": [
+    {
+      "kty": "OKP",
+      "kid": "ed25519-2026-01",
+      "crv": "Ed25519",
+      "x": "...",
+      "d": "..."
+    }
+  ]
+}
+----
+====
+
+.Example JWKS file with a symmetric key
+====
+[source,json]
+----
+{
+  "keys": [
+    {
+      "kty": "oct",
+      "kid": "hmac-2026-01",
+      "alg": "HS256",
+      "k": "base64url-encoded-key-material"
+    }
+  ]
+}
+----
+====
+
+NOTE: Encrypted JWK/JWKS files are not yet supported and will be addressed in a future release.
+
+==== Selector
+
+The selector identifies a key by its `kid`. If no selector is specified, the first key in the file is used.
+
 === File
 
 The file secret provider reads secret values and structured credentials from a YAML or JSON file. Unlike the link:{{< relref "#_inline" >}}[inline provider], it keeps sensitive material out of the heimdall configuration file and supports hot-reloading.
@@ -187,7 +281,7 @@ secret_management:
       watch: true
 ----
 
-The file contents follow the same structure as the `config` map of the link:{{< relref "#_inline" >}}[inline provider] - each top-level entry is addressed by its selector and represents either a plain secret value or a structured credentials object. Nesting is not supported; all entries must be top-level keys.
+The file contents follow the same structure as the `config` map of the link:{{< relref "#_inline" >}}[inline provider]. Each top-level entry is addressed by its selector and represents either a plain secret value or a structured credentials object. Nesting is not supported; all entries must be top-level keys.
 
 [source,yaml]
 ----

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -29,6 +29,12 @@ secret_management:
     config:
       path: /path/to/secrets.json
       watch: true
+  jwks_secrets:
+    type: jwks
+    config:
+      path: /path/to/jwks.json
+      watch: true
+
 
 serve:
   host: 127.0.0.1

--- a/internal/rules/endpoint/authstrategy/api_key_test.go
+++ b/internal/rules/endpoint/authstrategy/api_key_test.go
@@ -286,7 +286,7 @@ func TestAPIKeyApply(t *testing.T) {
 			setup: func(t *testing.T, sr *secretsmocks.ResolverMock, handle *secretsmocks.SecretHandleMock) {
 				t.Helper()
 
-				secret := types.NewSymmetricKeySecret("bar", "baz", []byte{})
+				secret := types.NewSymmetricKeySecret("bar", "baz", "foo", []byte{})
 
 				sr.EXPECT().
 					Secret(secrets.Reference{Source: "foo", Selector: "bar"}).
@@ -359,7 +359,7 @@ func TestToStringSecret(t *testing.T) {
 			},
 		},
 		"returns kind mismatch for non string secret": {
-			secret: types.NewSymmetricKeySecret("bar", "baz", []byte{}),
+			secret: types.NewSymmetricKeySecret("bar", "baz", "foo", []byte{}),
 			assert: func(t *testing.T, value string, err error) {
 				t.Helper()
 

--- a/internal/secrets/provider/jwks/key_store.go
+++ b/internal/secrets/provider/jwks/key_store.go
@@ -19,7 +19,6 @@ package jwks
 import (
 	"context"
 	"crypto"
-	"errors"
 	"strings"
 
 	"github.com/go-jose/go-jose/v4"
@@ -30,8 +29,6 @@ import (
 )
 
 const minOctetKeySize = 16
-
-var errNoKeyMaterialPresent = errors.New("no key material present in the jwks file")
 
 type keyStore []provider.Secret
 
@@ -70,8 +67,10 @@ func newKeyStore(jwks jose.JSONWebKeySet) (keyStore, error) {
 	}
 
 	if len(secrets) == 0 {
-		return nil, errorchain.New(provider.ErrConfiguration).
-			CausedBy(errNoKeyMaterialPresent)
+		return nil, errorchain.NewWithMessage(
+			provider.ErrConfiguration,
+			"no key material present in the jwks file",
+		)
 	}
 
 	return secrets, nil
@@ -150,10 +149,4 @@ func (s keyStore) getCertificateBundle(
 	_ provider.Selector,
 ) (provider.CertificateBundle, error) {
 	return nil, provider.ErrUnsupportedOperation
-}
-
-func (s keyStore) sameKind(other store) bool {
-	_, ok := other.(keyStore)
-
-	return ok
 }

--- a/internal/secrets/provider/jwks/key_store.go
+++ b/internal/secrets/provider/jwks/key_store.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jwks
+
+import (
+	"context"
+	"crypto"
+	"errors"
+	"strings"
+
+	"github.com/go-jose/go-jose/v4"
+
+	"github.com/dadrus/heimdall/internal/secrets/provider"
+	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/pkix"
+)
+
+const minOctetKeySize = 16
+
+var errNoKeyMaterialPresent = errors.New("no key material present in the jwks file")
+
+type keyStore []provider.Secret
+
+func newKeyStore(jwks jose.JSONWebKeySet) (keyStore, error) {
+	known := make(map[string]struct{}, len(jwks.Keys))
+	secrets := make([]provider.Secret, 0, len(jwks.Keys))
+
+	for idx := range jwks.Keys {
+		jwk := jwks.Keys[idx]
+		kid := strings.TrimSpace(jwk.KeyID)
+
+		if kid == "" {
+			return nil, errorchain.NewWithMessagef(
+				provider.ErrConfiguration,
+				"jwk at index %d is missing required kid",
+				idx,
+			)
+		}
+
+		if _, ok := known[kid]; ok {
+			return nil, errorchain.NewWithMessagef(
+				provider.ErrConfiguration,
+				"duplicate jwk kid '%s' found",
+				kid,
+			)
+		}
+
+		known[kid] = struct{}{}
+
+		secret, err := toSecret(jwk)
+		if err != nil {
+			return nil, err
+		}
+
+		secrets = append(secrets, secret)
+	}
+
+	if len(secrets) == 0 {
+		return nil, errorchain.New(provider.ErrConfiguration).
+			CausedBy(errNoKeyMaterialPresent)
+	}
+
+	return secrets, nil
+}
+
+func toSecret(jwk jose.JSONWebKey) (provider.Secret, error) {
+	switch key := jwk.Key.(type) {
+	case crypto.Signer:
+		return toAsymmetricKeySecret(jwk, key)
+	case []byte:
+		return toSymmetricKeySecret(jwk, key)
+	default:
+		return nil, errorchain.NewWithMessagef(
+			provider.ErrConfiguration,
+			"unsupported jwk key material for kid '%s'", jwk.KeyID,
+		)
+	}
+}
+
+func toSymmetricKeySecret(jwk jose.JSONWebKey, value []byte) (provider.Secret, error) {
+	if len(value) < minOctetKeySize {
+		return nil, errorchain.NewWithMessagef(
+			provider.ErrConfiguration,
+			"oct jwk with kid '%s' contains key material shorter than %d bytes",
+			jwk.KeyID,
+			minOctetKeySize,
+		)
+	}
+
+	return provider.NewSymmetricKeySecret(jwk.KeyID, jwk.KeyID, jwk.Algorithm, value), nil
+}
+
+func toAsymmetricKeySecret(jwk jose.JSONWebKey, signer crypto.Signer) (provider.Secret, error) {
+	chain := pkix.FindChain(signer.Public(), jwk.Certificates)
+	if len(chain) != 0 {
+		if err := pkix.ValidateChain(chain); err != nil {
+			return nil, errorchain.NewWithMessagef(provider.ErrConfiguration,
+				"invalid certificate chain for kid '%s'", jwk.KeyID).CausedBy(err)
+		}
+	} else if len(jwk.Certificates) != 0 {
+		return nil, errorchain.NewWithMessagef(provider.ErrConfiguration,
+			"malformed certificate chain for kid '%s'", jwk.KeyID)
+	}
+
+	return provider.NewAsymmetricKeySecret(jwk.KeyID, jwk.KeyID, signer, chain), nil
+}
+
+func (s keyStore) getSecret(_ context.Context, selector provider.Selector) (provider.Secret, error) {
+	if len(s) == 0 {
+		return nil, provider.ErrSecretNotFound
+	}
+
+	if len(selector.Value) == 0 {
+		return s[0], nil
+	}
+
+	for _, entry := range s {
+		if entry.Selector() == selector.Value {
+			return entry, nil
+		}
+	}
+
+	return nil, errorchain.NewWithMessagef(provider.ErrSecretNotFound, "%s", selector)
+}
+
+func (s keyStore) getSecretSet(_ context.Context, _ provider.Selector) ([]provider.Secret, error) {
+	if len(s) == 0 {
+		return nil, provider.ErrSecretSetNotFound
+	}
+
+	return s, nil
+}
+
+func (s keyStore) getCertificateBundle(
+	_ context.Context,
+	_ provider.Selector,
+) (provider.CertificateBundle, error) {
+	return nil, provider.ErrUnsupportedOperation
+}
+
+func (s keyStore) sameKind(other store) bool {
+	_, ok := other.(keyStore)
+
+	return ok
+}

--- a/internal/secrets/provider/jwks/key_store.go
+++ b/internal/secrets/provider/jwks/key_store.go
@@ -105,14 +105,16 @@ func toSymmetricKeySecret(jwk jose.JSONWebKey, value []byte) (provider.Secret, e
 
 func toAsymmetricKeySecret(jwk jose.JSONWebKey, signer crypto.Signer) (provider.Secret, error) {
 	chain := pkix.FindChain(signer.Public(), jwk.Certificates)
+	if len(jwk.Certificates) != len(chain) {
+		return nil, errorchain.NewWithMessagef(provider.ErrConfiguration,
+			"malformed certificate chain for kid '%s'", jwk.KeyID)
+	}
+
 	if len(chain) != 0 {
 		if err := pkix.ValidateChain(chain); err != nil {
 			return nil, errorchain.NewWithMessagef(provider.ErrConfiguration,
 				"invalid certificate chain for kid '%s'", jwk.KeyID).CausedBy(err)
 		}
-	} else if len(jwk.Certificates) != 0 {
-		return nil, errorchain.NewWithMessagef(provider.ErrConfiguration,
-			"malformed certificate chain for kid '%s'", jwk.KeyID)
 	}
 
 	return provider.NewAsymmetricKeySecret(jwk.KeyID, jwk.KeyID, signer, chain), nil

--- a/internal/secrets/provider/jwks/key_store_test.go
+++ b/internal/secrets/provider/jwks/key_store_test.go
@@ -1,0 +1,634 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jwks
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	x509pkix "crypto/x509/pkix"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dadrus/heimdall/internal/secrets/provider"
+	"github.com/dadrus/heimdall/internal/x/testsupport"
+)
+
+func TestNewKeyStore(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		jwks   func(*testing.T) jose.JSONWebKeySet
+		assert func(*testing.T, keyStore, error)
+	}{
+		"supports symmetric keys": {
+			jwks: func(t *testing.T) jose.JSONWebKeySet {
+				t.Helper()
+
+				return jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:       []byte("0123456789abcdef"),
+							KeyID:     "hmac-key",
+							Algorithm: "HS256",
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, ks keyStore, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.Len(t, ks, 1)
+
+				secret, ok := ks[0].(provider.SymmetricKeySecret)
+				require.True(t, ok)
+
+				assert.Equal(t, "hmac-key", secret.Selector())
+				assert.Equal(t, "hmac-key", secret.KeyID())
+				assert.Equal(t, []byte("0123456789abcdef"), secret.Key())
+
+				require.True(t, ok)
+				assert.Equal(t, "HS256", secret.Algorithm())
+			},
+		},
+		"supports rsa private keys": {
+			jwks: func(t *testing.T) jose.JSONWebKeySet {
+				t.Helper()
+
+				key, err := rsa.GenerateKey(rand.Reader, 2048)
+				require.NoError(t, err)
+
+				return jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   key,
+							KeyID: "rsa-key",
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, ks keyStore, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.Len(t, ks, 1)
+
+				secret, ok := ks[0].(provider.AsymmetricKeySecret)
+				require.True(t, ok)
+
+				assert.Equal(t, "rsa-key", secret.Selector())
+				assert.Equal(t, "rsa-key", secret.KeyID())
+				assert.IsType(t, &rsa.PrivateKey{}, secret.PrivateKey())
+				assert.Empty(t, secret.CertChain())
+			},
+		},
+		"supports ec private keys": {
+			jwks: func(t *testing.T) jose.JSONWebKeySet {
+				t.Helper()
+
+				key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				require.NoError(t, err)
+
+				return jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   key,
+							KeyID: "ec-key",
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, ks keyStore, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.Len(t, ks, 1)
+
+				secret, ok := ks[0].(provider.AsymmetricKeySecret)
+				require.True(t, ok)
+
+				assert.Equal(t, "ec-key", secret.Selector())
+				assert.Equal(t, "ec-key", secret.KeyID())
+				assert.IsType(t, &ecdsa.PrivateKey{}, secret.PrivateKey())
+				assert.Empty(t, secret.CertChain())
+			},
+		},
+		"supports ed25519 private keys": {
+			jwks: func(t *testing.T) jose.JSONWebKeySet {
+				t.Helper()
+
+				_, key, err := ed25519.GenerateKey(rand.Reader)
+				require.NoError(t, err)
+
+				return jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   key,
+							KeyID: "ed25519-key",
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, ks keyStore, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.Len(t, ks, 1)
+
+				secret, ok := ks[0].(provider.AsymmetricKeySecret)
+				require.True(t, ok)
+
+				assert.Equal(t, "ed25519-key", secret.Selector())
+				assert.Equal(t, "ed25519-key", secret.KeyID())
+				assert.IsType(t, ed25519.PrivateKey{}, secret.PrivateKey())
+				assert.Empty(t, secret.CertChain())
+			},
+		},
+		"supports mixed keys": {
+			jwks: func(t *testing.T) jose.JSONWebKeySet {
+				t.Helper()
+
+				rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+				require.NoError(t, err)
+
+				ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+				require.NoError(t, err)
+
+				return jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   rsaKey,
+							KeyID: "rsa-key",
+						},
+						{
+							Key:       []byte("0123456789abcdef"),
+							KeyID:     "hmac-key",
+							Algorithm: "HS256",
+						},
+						{
+							Key:   ecKey,
+							KeyID: "ec-key",
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, ks keyStore, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.Len(t, ks, 3)
+
+				assert.Equal(t, "rsa-key", ks[0].Selector())
+				assert.Equal(t, "hmac-key", ks[1].Selector())
+				assert.Equal(t, "ec-key", ks[2].Selector())
+			},
+		},
+		"returns configuration error for missing kid": {
+			jwks: func(t *testing.T) jose.JSONWebKeySet {
+				t.Helper()
+
+				return jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key: []byte("0123456789abcdef"),
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, _ keyStore, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrConfiguration)
+				require.ErrorContains(t, err, "missing required kid")
+			},
+		},
+		"returns configuration error for blank kid": {
+			jwks: func(t *testing.T) jose.JSONWebKeySet {
+				t.Helper()
+
+				return jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   []byte("0123456789abcdef"),
+							KeyID: "   ",
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, _ keyStore, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrConfiguration)
+				require.ErrorContains(t, err, "missing required kid")
+			},
+		},
+		"returns configuration error for duplicate kid": {
+			jwks: func(t *testing.T) jose.JSONWebKeySet {
+				t.Helper()
+
+				return jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   []byte("0123456789abcdef"),
+							KeyID: "duplicate",
+						},
+						{
+							Key:   []byte("fedcba9876543210"),
+							KeyID: "duplicate",
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, _ keyStore, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrConfiguration)
+				require.ErrorContains(t, err, "duplicate jwk kid 'duplicate' found")
+			},
+		},
+		"returns configuration error for too short symmetric key": {
+			jwks: func(t *testing.T) jose.JSONWebKeySet {
+				t.Helper()
+
+				return jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   []byte("too-short"),
+							KeyID: "short-key",
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, _ keyStore, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrConfiguration)
+				require.ErrorContains(t, err, "contains key material shorter than 16 bytes")
+			},
+		},
+		"returns configuration error for public key": {
+			jwks: func(t *testing.T) jose.JSONWebKeySet {
+				t.Helper()
+
+				key, err := rsa.GenerateKey(rand.Reader, 2048)
+				require.NoError(t, err)
+
+				return jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   &key.PublicKey,
+							KeyID: "public-key",
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, _ keyStore, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrConfiguration)
+				require.ErrorContains(t, err, "unsupported jwk key material")
+			},
+		},
+		"returns configuration error if no keys are present": {
+			jwks: func(t *testing.T) jose.JSONWebKeySet {
+				t.Helper()
+
+				return jose.JSONWebKeySet{}
+			},
+			assert: func(t *testing.T, _ keyStore, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrConfiguration)
+				require.ErrorContains(t, err, "no key material present")
+			},
+		},
+		"supports rsa private keys with self-signed certificate": {
+			jwks: func(t *testing.T) jose.JSONWebKeySet {
+				t.Helper()
+
+				key, err := rsa.GenerateKey(rand.Reader, 2048)
+				require.NoError(t, err)
+
+				cert, err := testsupport.NewCertificateBuilder(
+					testsupport.WithSubject(x509pkix.Name{CommonName: "rsa-key"}),
+					testsupport.WithSubjectPubKey(&key.PublicKey, x509.SHA256WithRSA),
+					testsupport.WithSignaturePrivKey(key),
+					testsupport.WithSelfSigned(),
+					testsupport.WithValidity(time.Now().Add(-time.Hour), 2*time.Hour),
+				).Build()
+				require.NoError(t, err)
+
+				return jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:          key,
+							KeyID:        "rsa-key",
+							Certificates: []*x509.Certificate{cert},
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, ks keyStore, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.Len(t, ks, 1)
+
+				secret, ok := ks[0].(provider.AsymmetricKeySecret)
+				require.True(t, ok)
+
+				assert.Equal(t, "rsa-key", secret.Selector())
+				assert.Equal(t, "rsa-key", secret.KeyID())
+				assert.IsType(t, &rsa.PrivateKey{}, secret.PrivateKey())
+				require.Len(t, secret.CertChain(), 1)
+				assert.Equal(t, "rsa-key", secret.CertChain()[0].Subject.CommonName)
+			},
+		},
+		"returns configuration error for malformed certificate chain": {
+			jwks: func(t *testing.T) jose.JSONWebKeySet {
+				t.Helper()
+
+				key, err := rsa.GenerateKey(rand.Reader, 2048)
+				require.NoError(t, err)
+
+				otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+				require.NoError(t, err)
+
+				cert, err := testsupport.NewCertificateBuilder(
+					testsupport.WithSubject(x509pkix.Name{CommonName: "other-key"}),
+					testsupport.WithSubjectPubKey(&otherKey.PublicKey, x509.SHA256WithRSA),
+					testsupport.WithSignaturePrivKey(otherKey),
+					testsupport.WithSelfSigned(),
+					testsupport.WithValidity(time.Now().Add(-time.Hour), 2*time.Hour),
+				).Build()
+				require.NoError(t, err)
+
+				return jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:          key,
+							KeyID:        "rsa-key",
+							Certificates: []*x509.Certificate{cert},
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, _ keyStore, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrConfiguration)
+				require.ErrorContains(t, err, "malformed certificate chain for kid 'rsa-key'")
+			},
+		},
+		"returns configuration error for invalid certificate chain": {
+			jwks: func(t *testing.T) jose.JSONWebKeySet {
+				t.Helper()
+
+				leafKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+				require.NoError(t, err)
+
+				ca, err := testsupport.NewRootCA("root CA", -1*time.Hour)
+				require.NoError(t, err)
+
+				leaf, err := testsupport.NewCertificateBuilder(
+					testsupport.WithSubject(x509pkix.Name{CommonName: "other-key"}),
+					testsupport.WithSubjectPubKey(&leafKey.PublicKey, x509.ECDSAWithSHA384),
+					testsupport.WithSignaturePrivKey(leafKey),
+					testsupport.WithIssuer(ca.PrivKey, ca.Certificate),
+					testsupport.WithValidity(time.Now().Add(-time.Hour), 2*time.Hour),
+				).Build()
+				require.NoError(t, err)
+
+				return jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:          leafKey,
+							KeyID:        "leaf-key",
+							Certificates: []*x509.Certificate{leaf, ca.Certificate},
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, _ keyStore, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrConfiguration)
+				require.ErrorContains(t, err, "invalid certificate chain for kid 'leaf-key'")
+			},
+		},
+		"supports keys with full certificate chain": {
+			jwks: func(t *testing.T) jose.JSONWebKeySet {
+				t.Helper()
+
+				leafKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+				require.NoError(t, err)
+
+				issCAKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+				require.NoError(t, err)
+
+				rootCA, err := testsupport.NewRootCA("Root CA", 1*time.Hour)
+				require.NoError(t, err)
+
+				issCACert, err := rootCA.IssueCertificate(
+					testsupport.WithSubject(x509pkix.Name{
+						CommonName:   "Iss CA",
+						Organization: []string{"Test"},
+						Country:      []string{"EU"},
+					}),
+					testsupport.WithIsCA(),
+					testsupport.WithValidity(time.Now(), time.Hour*24),
+					testsupport.WithSubjectPubKey(&issCAKey.PublicKey, x509.ECDSAWithSHA384),
+				)
+				require.NoError(t, err)
+
+				issCA := testsupport.NewCA(issCAKey, issCACert)
+				leaf, err := issCA.IssueCertificate(
+					testsupport.WithSubject(x509pkix.Name{CommonName: "ee-key"}),
+					testsupport.WithSubjectPubKey(&leafKey.PublicKey, x509.ECDSAWithSHA384),
+					testsupport.WithSignaturePrivKey(leafKey),
+					testsupport.WithIssuer(issCA.PrivKey, issCA.Certificate),
+					testsupport.WithValidity(time.Now().Add(-time.Hour), 2*time.Hour),
+				)
+				require.NoError(t, err)
+
+				return jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:          leafKey,
+							KeyID:        "leaf-key",
+							Certificates: []*x509.Certificate{leaf, rootCA.Certificate, issCA.Certificate},
+						},
+					},
+				}
+			},
+			assert: func(t *testing.T, ks keyStore, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.Len(t, ks, 1)
+
+				secret, ok := ks[0].(provider.AsymmetricKeySecret)
+				require.True(t, ok)
+
+				assert.Equal(t, "leaf-key", secret.Selector())
+				assert.Equal(t, "leaf-key", secret.KeyID())
+				assert.IsType(t, &ecdsa.PrivateKey{}, secret.PrivateKey())
+				require.Len(t, secret.CertChain(), 3)
+				assert.Equal(t, "ee-key", secret.CertChain()[0].Subject.CommonName)
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			t.Parallel()
+
+			ks, err := newKeyStore(tc.jwks(t))
+			tc.assert(t, ks, err)
+		})
+	}
+}
+
+func TestKeyStoreGetSecret(t *testing.T) {
+	t.Parallel()
+
+	ks := keyStore{
+		provider.NewSymmetricKeySecret("first", "first", "HS256", []byte("0123456789abcdef")),
+		provider.NewSymmetricKeySecret("second", "second", "HS384", []byte("0123456789abcdef0123456789abcdef")),
+	}
+
+	for uc, tc := range map[string]struct {
+		ks       keyStore
+		selector provider.Selector
+		assert   func(*testing.T, provider.Secret, error)
+	}{
+		"returns first entry for empty selector": {
+			ks: ks,
+			assert: func(t *testing.T, secret provider.Secret, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.NotNil(t, secret)
+				assert.Equal(t, "first", secret.Selector())
+			},
+		},
+		"returns entry for existing selector": {
+			ks:       ks,
+			selector: provider.Selector{Value: "second"},
+			assert: func(t *testing.T, secret provider.Secret, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.NotNil(t, secret)
+				assert.Equal(t, "second", secret.Selector())
+			},
+		},
+		"returns error for missing selector": {
+			ks:       ks,
+			selector: provider.Selector{Value: "missing"},
+			assert: func(t *testing.T, _ provider.Secret, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrSecretNotFound)
+			},
+		},
+		"returns error if store is empty": {
+			ks: keyStore{},
+			assert: func(t *testing.T, _ provider.Secret, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrSecretNotFound)
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			t.Parallel()
+
+			secret, err := tc.ks.getSecret(t.Context(), tc.selector)
+			tc.assert(t, secret, err)
+		})
+	}
+}
+
+func TestKeyStoreGetSecretSet(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		ks     keyStore
+		assert func(*testing.T, []provider.Secret, error)
+	}{
+		"returns all entries": {
+			ks: keyStore{
+				provider.NewSymmetricKeySecret("first", "first", "HS256", []byte("0123456789abcdef")),
+				provider.NewSymmetricKeySecret("second", "second", "HS384", []byte("0123456789abcdef0123456789abcdef")),
+			},
+			assert: func(t *testing.T, secrets []provider.Secret, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.Len(t, secrets, 2)
+				assert.Equal(t, "first", secrets[0].Selector())
+				assert.Equal(t, "second", secrets[1].Selector())
+			},
+		},
+		"returns error if store is empty": {
+			ks: keyStore{},
+			assert: func(t *testing.T, secrets []provider.Secret, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrSecretSetNotFound)
+				require.Nil(t, secrets)
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			t.Parallel()
+
+			secrets, err := tc.ks.getSecretSet(t.Context(), provider.Selector{Value: "ignored"})
+			tc.assert(t, secrets, err)
+		})
+	}
+}
+
+func TestKeyStoreGetCertificateBundle(t *testing.T) {
+	t.Parallel()
+
+	ks := keyStore{}
+
+	bundle, err := ks.getCertificateBundle(t.Context(), provider.Selector{})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, provider.ErrUnsupportedOperation)
+	require.Nil(t, bundle)
+}

--- a/internal/secrets/provider/jwks/provider.go
+++ b/internal/secrets/provider/jwks/provider.go
@@ -145,15 +145,13 @@ func (p *jwksProvider) Start(ctx context.Context) error {
 	}
 
 	if err = p.watcher.Add(p.path); err != nil {
-		return errorchain.NewWithMessagef(
-			provider.ErrInternal,
+		return errorchain.NewWithMessagef(provider.ErrInternal,
 			"failed to register jwks provider watch for %s", p.path,
 		).CausedBy(err)
 	}
 
 	if err = p.watcher.Start(context.WithoutCancel(ctx)); err != nil {
-		return errorchain.NewWithMessagef(
-			provider.ErrInternal,
+		return errorchain.NewWithMessagef(provider.ErrInternal,
 			"failed to start jwks provider watch for %s", p.path,
 		).CausedBy(err)
 	}

--- a/internal/secrets/provider/jwks/provider.go
+++ b/internal/secrets/provider/jwks/provider.go
@@ -1,0 +1,204 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jwks
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rs/zerolog"
+
+	"github.com/dadrus/heimdall/internal/encoding"
+	"github.com/dadrus/heimdall/internal/secrets/provider"
+	"github.com/dadrus/heimdall/internal/secrets/registry"
+	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/fswatch"
+)
+
+const providerType = "jwks"
+
+// by intention. Used only during application bootstrap.
+//
+//nolint:gochecknoinits
+func init() {
+	registry.Register(providerType, provider.FactoryFunc(newProvider))
+}
+
+type jwksProvider struct {
+	path     string
+	observer provider.ChangeObserver
+	watcher  *fswatch.Watcher
+	logger   zerolog.Logger
+
+	mu    sync.RWMutex
+	store store
+}
+
+func newProvider(args provider.Args) (provider.Provider, error) {
+	type config struct {
+		Path  string `mapstructure:"path" validate:"required"`
+		Watch bool   `mapstructure:"watch"`
+	}
+
+	var cfg config
+
+	dec := args.DecoderFactory.Decoder(encoding.WithTagName("mapstructure"))
+	if err := dec.DecodeMap(&cfg, args.Config); err != nil {
+		return nil, err
+	}
+
+	prv := &jwksProvider{
+		path:     cfg.Path,
+		logger:   args.Logger,
+		observer: args.Observer,
+	}
+
+	if !cfg.Watch {
+		return prv, nil
+	}
+
+	watcher, err := fswatch.New(
+		fswatch.EventHandlerFunc(prv.reload),
+		fswatch.WithLogger(args.Logger),
+	)
+	if err != nil {
+		return nil, errorchain.NewWithMessage(
+			provider.ErrInternal,
+			"failed to initialize jwks provider watcher",
+		).CausedBy(err)
+	}
+
+	prv.watcher = watcher
+
+	return prv, nil
+}
+
+func (*jwksProvider) Dependencies() []provider.Reference { return nil }
+func (*jwksProvider) IsNamespaceAware() bool             { return false }
+func (*jwksProvider) Type() string                       { return providerType }
+
+func (p *jwksProvider) GetSecret(
+	ctx context.Context,
+	selector provider.Selector,
+) (provider.Secret, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	return p.store.getSecret(ctx, selector)
+}
+
+func (p *jwksProvider) GetSecretSet(
+	ctx context.Context,
+	selector provider.Selector,
+) ([]provider.Secret, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	return p.store.getSecretSet(ctx, selector)
+}
+
+func (p *jwksProvider) GetCredentials(
+	_ context.Context,
+	_ provider.Selector,
+) (provider.Credentials, error) {
+	return nil, provider.ErrUnsupportedOperation
+}
+
+func (p *jwksProvider) GetCertificateBundle(
+	ctx context.Context,
+	selector provider.Selector,
+) (provider.CertificateBundle, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	return p.store.getCertificateBundle(ctx, selector)
+}
+
+func (p *jwksProvider) Start(ctx context.Context) error {
+	p.logger.Info().Str("_file", p.path).Msg("Loading jwks file")
+
+	store, err := loadStore(p.path)
+	if err != nil {
+		return err
+	}
+
+	p.mu.Lock()
+	p.store = store
+	p.mu.Unlock()
+
+	if p.watcher == nil {
+		return nil
+	}
+
+	if err = p.watcher.Add(p.path); err != nil {
+		return errorchain.NewWithMessagef(
+			provider.ErrInternal,
+			"failed to register jwks provider watch for %s", p.path,
+		).CausedBy(err)
+	}
+
+	if err = p.watcher.Start(context.WithoutCancel(ctx)); err != nil {
+		return errorchain.NewWithMessagef(
+			provider.ErrInternal,
+			"failed to start jwks provider watch for %s", p.path,
+		).CausedBy(err)
+	}
+
+	return nil
+}
+
+func (p *jwksProvider) Stop(ctx context.Context) error {
+	if p.watcher == nil {
+		return nil
+	}
+
+	watcher := p.watcher
+	p.watcher = nil
+
+	return watcher.Stop(ctx)
+}
+
+func (p *jwksProvider) reload(evt fswatch.Event) error {
+	if evt.Op != fswatch.OpChanged {
+		return nil
+	}
+
+	next, err := loadStore(p.path)
+	if err != nil {
+		return err
+	}
+
+	p.mu.Lock()
+
+	if !p.store.sameKind(next) {
+		p.mu.Unlock()
+
+		return errorchain.NewWithMessage(
+			provider.ErrConfiguration,
+			"Reloading jwks file failed because store kind changed",
+		)
+	}
+
+	p.store = next
+
+	p.mu.Unlock()
+
+	p.logger.Info().Str("_file", p.path).Msg("jwks file reloaded")
+	p.observer.Notify(provider.ChangeEvent{})
+
+	return nil
+}

--- a/internal/secrets/provider/jwks/provider.go
+++ b/internal/secrets/provider/jwks/provider.go
@@ -50,7 +50,7 @@ type jwksProvider struct {
 
 func newProvider(args provider.Args) (provider.Provider, error) {
 	type config struct {
-		Path  string `mapstructure:"path" validate:"required"`
+		Path  string `mapstructure:"path"  validate:"required"`
 		Watch bool   `mapstructure:"watch"`
 	}
 
@@ -183,15 +183,6 @@ func (p *jwksProvider) reload(evt fswatch.Event) error {
 	}
 
 	p.mu.Lock()
-
-	if !p.store.sameKind(next) {
-		p.mu.Unlock()
-
-		return errorchain.NewWithMessage(
-			provider.ErrConfiguration,
-			"Reloading jwks file failed because store kind changed",
-		)
-	}
 
 	p.store = next
 

--- a/internal/secrets/provider/jwks/provider_test.go
+++ b/internal/secrets/provider/jwks/provider_test.go
@@ -1,0 +1,505 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jwks
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/goccy/go-json"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dadrus/heimdall/internal/encoding"
+	"github.com/dadrus/heimdall/internal/secrets/provider"
+	"github.com/dadrus/heimdall/internal/secrets/provider/mocks"
+	"github.com/dadrus/heimdall/internal/validation"
+	"github.com/dadrus/heimdall/internal/x/fswatch"
+)
+
+func TestNewProvider(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		config func(t *testing.T, path string) map[string]any
+		assert func(t *testing.T, err error, prv *jwksProvider)
+	}{
+		"creates provider": {
+			config: func(t *testing.T, path string) map[string]any {
+				t.Helper()
+
+				return map[string]any{"path": path}
+			},
+			assert: func(t *testing.T, err error, prv *jwksProvider) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.NotNil(t, prv)
+
+				assert.Equal(t, providerType, prv.Type())
+				assert.Empty(t, prv.Dependencies())
+				assert.False(t, prv.IsNamespaceAware())
+				assert.NotEmpty(t, prv.path)
+				assert.Nil(t, prv.watcher)
+			},
+		},
+		"creates provider with watch enabled": {
+			config: func(t *testing.T, path string) map[string]any {
+				t.Helper()
+
+				return map[string]any{"path": path, "watch": true}
+			},
+			assert: func(t *testing.T, err error, prv *jwksProvider) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.NotNil(t, prv)
+
+				assert.Equal(t, providerType, prv.Type())
+				assert.Empty(t, prv.Dependencies())
+				assert.False(t, prv.IsNamespaceAware())
+				assert.NotEmpty(t, prv.path)
+				assert.NotNil(t, prv.watcher)
+			},
+		},
+		"fails if path is missing": {
+			config: func(t *testing.T, _ string) map[string]any {
+				t.Helper()
+
+				return map[string]any{}
+			},
+			assert: func(t *testing.T, err error, prv *jwksProvider) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.Nil(t, prv)
+				require.ErrorContains(t, err, "path")
+			},
+		},
+		"fails for invalid watch field": {
+			config: func(t *testing.T, path string) map[string]any {
+				t.Helper()
+
+				return map[string]any{"path": path, "watch": "yes"}
+			},
+			assert: func(t *testing.T, err error, prv *jwksProvider) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.Nil(t, prv)
+				require.ErrorContains(t, err, "watch")
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "keys.jwks")
+
+			validator, err := validation.NewValidator()
+			require.NoError(t, err)
+
+			df := encoding.NewDecoderFactory(encoding.ValidatorFunc(validator.ValidateStruct))
+			prv, err := newProvider(provider.Args{
+				Config:         tc.config(t, path),
+				Logger:         zerolog.Nop(),
+				DecoderFactory: df,
+				Observer:       mocks.NewChangeObserverMock(t),
+			})
+
+			var jwksPrv *jwksProvider
+			if err == nil {
+				jwksPrv = prv.(*jwksProvider)
+			}
+
+			tc.assert(t, err, jwksPrv)
+		})
+	}
+}
+
+func TestProviderGetSecret(t *testing.T) {
+	t.Parallel()
+
+	prv := &jwksProvider{
+		store: keyStore{
+			provider.NewSymmetricKeySecret("first", "first", "HS256", []byte("0123456789abcdef")),
+			provider.NewSymmetricKeySecret("second", "second", "HS384", []byte("0123456789abcdef0123456789abcdef")),
+		},
+	}
+
+	for uc, tc := range map[string]struct {
+		selector provider.Selector
+		assert   func(t *testing.T, secret provider.Secret, err error)
+	}{
+		"returns first entry for empty selector": {
+			assert: func(t *testing.T, secret provider.Secret, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.NotNil(t, secret)
+				assert.Equal(t, "first", secret.Selector())
+			},
+		},
+		"returns selected entry": {
+			selector: provider.Selector{Value: "second"},
+			assert: func(t *testing.T, secret provider.Secret, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.NotNil(t, secret)
+				assert.Equal(t, "second", secret.Selector())
+			},
+		},
+		"returns not found error": {
+			selector: provider.Selector{Value: "missing"},
+			assert: func(t *testing.T, secret provider.Secret, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrSecretNotFound)
+				require.Nil(t, secret)
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			t.Parallel()
+
+			secret, err := prv.GetSecret(t.Context(), tc.selector)
+			tc.assert(t, secret, err)
+		})
+	}
+}
+
+func TestProviderGetSecretSet(t *testing.T) {
+	t.Parallel()
+
+	prv := &jwksProvider{
+		store: keyStore{
+			provider.NewSymmetricKeySecret("first", "first", "HS256", []byte("0123456789abcdef")),
+			provider.NewSymmetricKeySecret("second", "second", "HS384", []byte("0123456789abcdef0123456789abcdef")),
+		},
+	}
+
+	secrets, err := prv.GetSecretSet(t.Context(), provider.Selector{Value: "ignored"})
+
+	require.NoError(t, err)
+	require.Len(t, secrets, 2)
+	assert.Equal(t, "first", secrets[0].Selector())
+	assert.Equal(t, "second", secrets[1].Selector())
+}
+
+func TestProviderGetCredentials(t *testing.T) {
+	t.Parallel()
+
+	prv := &jwksProvider{}
+
+	credentials, err := prv.GetCredentials(t.Context(), provider.Selector{})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, provider.ErrUnsupportedOperation)
+	require.Nil(t, credentials)
+}
+
+func TestProviderGetCertificateBundle(t *testing.T) {
+	t.Parallel()
+
+	prv := &jwksProvider{
+		store: keyStore{},
+	}
+
+	bundle, err := prv.GetCertificateBundle(t.Context(), provider.Selector{})
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, provider.ErrUnsupportedOperation)
+	require.Nil(t, bundle)
+}
+
+func TestProviderLifecycleManagement(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		config      func(t *testing.T, path string) map[string]any
+		setupMock   func(t *testing.T, observer *mocks.ChangeObserverMock)
+		beforeStart func(t *testing.T, path string)
+		afterStart  func(t *testing.T, path string)
+		event       fswatch.Event
+		assert      func(t *testing.T, prv *jwksProvider, err error)
+	}{
+		"fails loading store": {
+			config: func(t *testing.T, path string) map[string]any {
+				t.Helper()
+
+				return map[string]any{"path": path}
+			},
+			beforeStart: func(t *testing.T, path string) {
+				t.Helper()
+
+				require.NoError(t, os.WriteFile(path, []byte(`{`), 0o600))
+			},
+			assert: func(t *testing.T, prv *jwksProvider, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrConfiguration)
+				assert.Nil(t, prv.store)
+			},
+		},
+		"starts without watching for changes": {
+			config: func(t *testing.T, path string) map[string]any {
+				t.Helper()
+
+				return map[string]any{"path": path, "watch": false}
+			},
+			beforeStart: func(t *testing.T, path string) {
+				t.Helper()
+
+				raw, err := json.Marshal(jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   []byte("0123456789abcdef"),
+							KeyID: "initial",
+						},
+					},
+				})
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(path, raw, 0o600))
+			},
+			assert: func(t *testing.T, prv *jwksProvider, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				assert.NotNil(t, prv.store)
+				assert.Nil(t, prv.watcher)
+
+				secret, err := prv.GetSecret(t.Context(), provider.Selector{})
+				require.NoError(t, err)
+				assert.Equal(t, "initial", secret.Selector())
+			},
+		},
+		"starts with watching for changes": {
+			config: func(t *testing.T, path string) map[string]any {
+				t.Helper()
+
+				return map[string]any{"path": path, "watch": true}
+			},
+			beforeStart: func(t *testing.T, path string) {
+				t.Helper()
+
+				raw, err := json.Marshal(jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   []byte("0123456789abcdef"),
+							KeyID: "initial",
+						},
+					},
+				})
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(path, raw, 0o600))
+			},
+			assert: func(t *testing.T, prv *jwksProvider, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				assert.NotNil(t, prv.store)
+				assert.NotNil(t, prv.watcher)
+
+				secret, err := prv.GetSecret(t.Context(), provider.Selector{})
+				require.NoError(t, err)
+				assert.Equal(t, "initial", secret.Selector())
+			},
+		},
+		"ignores non-change events": {
+			config: func(t *testing.T, path string) map[string]any {
+				t.Helper()
+
+				return map[string]any{"path": path}
+			},
+			beforeStart: func(t *testing.T, path string) {
+				t.Helper()
+
+				raw, err := json.Marshal(jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   []byte("0123456789abcdef"),
+							KeyID: "initial",
+						},
+					},
+				})
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(path, raw, 0o600))
+			},
+			afterStart: func(t *testing.T, path string) {
+				t.Helper()
+
+				raw, err := json.Marshal(jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   []byte("0123456789abcdef"),
+							KeyID: "reloaded",
+						},
+					},
+				})
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(path, raw, 0o600))
+			},
+			event: fswatch.Event{Op: fswatch.OpAdded},
+			assert: func(t *testing.T, prv *jwksProvider, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+
+				secret, err := prv.GetSecret(t.Context(), provider.Selector{})
+				require.NoError(t, err)
+				assert.Equal(t, "initial", secret.Selector())
+			},
+		},
+		"reloads changed file": {
+			config: func(t *testing.T, path string) map[string]any {
+				t.Helper()
+
+				return map[string]any{"path": path}
+			},
+			setupMock: func(t *testing.T, observer *mocks.ChangeObserverMock) {
+				t.Helper()
+
+				observer.EXPECT().
+					Notify(mock.MatchedBy(func(e provider.ChangeEvent) bool {
+						return len(e.Selectors) == 0
+					})).
+					Once()
+			},
+			beforeStart: func(t *testing.T, path string) {
+				t.Helper()
+
+				raw, err := json.Marshal(jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   []byte("0123456789abcdef"),
+							KeyID: "initial",
+						},
+					},
+				})
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(path, raw, 0o600))
+			},
+			afterStart: func(t *testing.T, path string) {
+				t.Helper()
+
+				raw, err := json.Marshal(jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   []byte("0123456789abcdef"),
+							KeyID: "reloaded",
+						},
+					},
+				})
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(path, raw, 0o600))
+			},
+			event: fswatch.Event{Op: fswatch.OpChanged},
+			assert: func(t *testing.T, prv *jwksProvider, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+
+				secret, err := prv.GetSecret(t.Context(), provider.Selector{})
+				require.NoError(t, err)
+				assert.Equal(t, "reloaded", secret.Selector())
+			},
+		},
+		"keeps old store if reload fails": {
+			config: func(t *testing.T, path string) map[string]any {
+				t.Helper()
+
+				return map[string]any{"path": path}
+			},
+			beforeStart: func(t *testing.T, path string) {
+				t.Helper()
+
+				raw, err := json.Marshal(jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   []byte("0123456789abcdef"),
+							KeyID: "initial",
+						},
+					},
+				})
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(path, raw, 0o600))
+			},
+			afterStart: func(t *testing.T, path string) {
+				t.Helper()
+
+				require.NoError(t, os.WriteFile(path, []byte(`{`), 0o600))
+			},
+			event: fswatch.Event{Op: fswatch.OpChanged},
+			assert: func(t *testing.T, prv *jwksProvider, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrConfiguration)
+
+				secret, err := prv.GetSecret(t.Context(), provider.Selector{})
+				require.NoError(t, err)
+				assert.Equal(t, "initial", secret.Selector())
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "keys.jwks")
+			tc.beforeStart(t, path)
+
+			observer := mocks.NewChangeObserverMock(t)
+			if tc.setupMock != nil {
+				tc.setupMock(t, observer)
+			}
+
+			validator, err := validation.NewValidator()
+			require.NoError(t, err)
+
+			df := encoding.NewDecoderFactory(encoding.ValidatorFunc(validator.ValidateStruct))
+			prv, err := newProvider(provider.Args{
+				Config:         tc.config(t, path),
+				Logger:         zerolog.Nop(),
+				DecoderFactory: df,
+				Observer:       observer,
+			})
+			require.NoError(t, err)
+
+			jwksPrv := prv.(*jwksProvider)
+
+			err = jwksPrv.Start(t.Context())
+			t.Cleanup(func() {
+				_ = jwksPrv.Stop(context.Background())
+			})
+
+			if err == nil && tc.afterStart != nil {
+				tc.afterStart(t, path)
+				err = jwksPrv.reload(tc.event)
+			}
+
+			tc.assert(t, jwksPrv, err)
+		})
+	}
+}

--- a/internal/secrets/provider/jwks/store.go
+++ b/internal/secrets/provider/jwks/store.go
@@ -1,0 +1,37 @@
+package jwks
+
+import (
+	"context"
+	"os"
+
+	"github.com/dadrus/heimdall/internal/secrets/provider"
+	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/go-jose/go-jose/v4"
+	"github.com/goccy/go-json"
+)
+
+type store interface {
+	getSecret(ctx context.Context, selector provider.Selector) (provider.Secret, error)
+	getSecretSet(ctx context.Context, selector provider.Selector) ([]provider.Secret, error)
+	getCertificateBundle(ctx context.Context, selector provider.Selector) (provider.CertificateBundle, error)
+
+	sameKind(other store) bool
+}
+
+func loadStore(path string) (store, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, errorchain.NewWithMessagef(provider.ErrConfiguration,
+			"failed to read jwks file %s", path).CausedBy(err)
+	}
+
+	var jwks jose.JSONWebKeySet
+	if err = json.Unmarshal(data, &jwks); err != nil {
+		return nil, errorchain.NewWithMessage(
+			provider.ErrConfiguration,
+			"failed to decode jwks file",
+		).CausedBy(err)
+	}
+
+	return newKeyStore(jwks)
+}

--- a/internal/secrets/provider/jwks/store.go
+++ b/internal/secrets/provider/jwks/store.go
@@ -4,18 +4,17 @@ import (
 	"context"
 	"os"
 
-	"github.com/dadrus/heimdall/internal/secrets/provider"
-	"github.com/dadrus/heimdall/internal/x/errorchain"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/goccy/go-json"
+
+	"github.com/dadrus/heimdall/internal/secrets/provider"
+	"github.com/dadrus/heimdall/internal/x/errorchain"
 )
 
 type store interface {
 	getSecret(ctx context.Context, selector provider.Selector) (provider.Secret, error)
 	getSecretSet(ctx context.Context, selector provider.Selector) ([]provider.Secret, error)
 	getCertificateBundle(ctx context.Context, selector provider.Selector) (provider.CertificateBundle, error)
-
-	sameKind(other store) bool
 }
 
 func loadStore(path string) (store, error) {

--- a/internal/secrets/provider/jwks/store_test.go
+++ b/internal/secrets/provider/jwks/store_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package jwks
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dadrus/heimdall/internal/secrets/provider"
+)
+
+func TestLoadStore(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		path   func(t *testing.T) string
+		assert func(t *testing.T, err error, s store)
+	}{
+		"loads jwks file": {
+			path: func(t *testing.T) string {
+				t.Helper()
+
+				path := filepath.Join(t.TempDir(), "keys.jwks")
+
+				key, err := rsa.GenerateKey(rand.Reader, 2048)
+				require.NoError(t, err)
+
+				raw, err := json.Marshal(jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   key,
+							KeyID: "rsa-key",
+						},
+						{
+							Key:       []byte("0123456789abcdef"),
+							KeyID:     "hmac-key",
+							Algorithm: "HS256",
+						},
+					},
+				})
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(path, raw, 0o600))
+
+				return path
+			},
+			assert: func(t *testing.T, err error, store store) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.NotNil(t, store)
+
+				secrets, err := store.getSecretSet(t.Context(), provider.Selector{})
+				require.NoError(t, err)
+				require.Len(t, secrets, 2)
+
+				assert.Equal(t, "rsa-key", secrets[0].Selector())
+				assert.Equal(t, "hmac-key", secrets[1].Selector())
+			},
+		},
+		"returns configuration error if file cannot be read": {
+			path: func(t *testing.T) string {
+				t.Helper()
+
+				return "missing.jwks"
+			},
+			assert: func(t *testing.T, err error, _ store) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrConfiguration)
+				require.ErrorContains(t, err, "failed to read jwks file")
+			},
+		},
+		"returns configuration error for malformed jwks file": {
+			path: func(t *testing.T) string {
+				t.Helper()
+
+				path := filepath.Join(t.TempDir(), "keys.jwks")
+
+				require.NoError(t, os.WriteFile(path, []byte(`{`), 0o600))
+
+				return path
+			},
+			assert: func(t *testing.T, err error, _ store) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrConfiguration)
+				require.ErrorContains(t, err, "failed to decode jwks file")
+			},
+		},
+		"returns configuration error for jwks without key material": {
+			path: func(t *testing.T) string {
+				t.Helper()
+
+				path := filepath.Join(t.TempDir(), "keys.jwks")
+
+				raw, err := json.Marshal(jose.JSONWebKeySet{})
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(path, raw, 0o600))
+
+				return path
+			},
+			assert: func(t *testing.T, err error, _ store) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrConfiguration)
+				require.ErrorContains(t, err, "no key material present")
+			},
+		},
+		"returns configuration error from key store validation": {
+			path: func(t *testing.T) string {
+				t.Helper()
+
+				path := filepath.Join(t.TempDir(), "keys.jwks")
+
+				raw, err := json.Marshal(jose.JSONWebKeySet{
+					Keys: []jose.JSONWebKey{
+						{
+							Key:   []byte("too-short"),
+							KeyID: "short-key",
+						},
+					},
+				})
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(path, raw, 0o600))
+
+				return path
+			},
+			assert: func(t *testing.T, err error, _ store) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, provider.ErrConfiguration)
+				require.ErrorContains(t, err, "contains key material shorter than 16 bytes")
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := loadStore(tc.path(t))
+
+			tc.assert(t, err, store)
+		})
+	}
+}

--- a/internal/secrets/provider/pem/key_store.go
+++ b/internal/secrets/provider/pem/key_store.go
@@ -141,10 +141,11 @@ func buildStore(entries []keyEntry, certs []*x509.Certificate) (keyStore, error)
 	result := make([]provider.Secret, len(entries))
 
 	for idx, entry := range entries {
-		chain := findChain(entry.privateKey.Public(), certs)
+		chain := pkix.FindChain(entry.privateKey.Public(), certs)
 		if len(chain) != 0 {
-			if err := validateChain(chain); err != nil {
-				return nil, err
+			if err := pkix.ValidateChain(chain); err != nil {
+				return nil, errorchain.NewWithMessagef(provider.ErrConfiguration,
+					"invalid certificate chain for %d entry", idx+1).CausedBy(err)
 			}
 		}
 

--- a/internal/secrets/provider/pem/provider.go
+++ b/internal/secrets/provider/pem/provider.go
@@ -61,8 +61,6 @@ type pemProvider struct {
 }
 
 func newProvider(args provider.Args) (provider.Provider, error) {
-	logger := args.Logger
-
 	type config struct {
 		Path     string `mapstructure:"path"     validate:"required"`
 		Password string `mapstructure:"password"`
@@ -79,7 +77,7 @@ func newProvider(args provider.Args) (provider.Provider, error) {
 	prv := &pemProvider{
 		path:     cfg.Path,
 		password: cfg.Password,
-		logger:   logger,
+		logger:   args.Logger,
 		observer: args.Observer,
 	}
 
@@ -89,7 +87,7 @@ func newProvider(args provider.Args) (provider.Provider, error) {
 
 	watcher, err := fswatch.New(
 		fswatch.EventHandlerFunc(prv.reload),
-		fswatch.WithLogger(logger),
+		fswatch.WithLogger(args.Logger),
 	)
 	if err != nil {
 		return nil, errorchain.NewWithMessage(
@@ -145,9 +143,7 @@ func (p *pemProvider) GetCertificateBundle(
 }
 
 func (p *pemProvider) Start(ctx context.Context) error {
-	p.logger.Info().
-		Str("_file", p.path).
-		Msg("Loading pem file")
+	p.logger.Info().Str("_file", p.path).Msg("Loading pem file")
 
 	store, err := loadStore(p.path, p.password)
 	if err != nil {
@@ -215,10 +211,7 @@ func (p *pemProvider) reload(evt fswatch.Event) error {
 
 	p.mu.Unlock()
 
-	p.logger.Info().
-		Str("_file", p.path).
-		Msg("pem file reloaded")
-
+	p.logger.Info().Str("_file", p.path).Msg("pem file reloaded")
 	p.observer.Notify(provider.ChangeEvent{})
 
 	return nil

--- a/internal/secrets/source/repository.go
+++ b/internal/secrets/source/repository.go
@@ -30,6 +30,7 @@ import (
 	"github.com/dadrus/heimdall/internal/pipeline"
 	_ "github.com/dadrus/heimdall/internal/secrets/provider/file"
 	_ "github.com/dadrus/heimdall/internal/secrets/provider/inline"
+	_ "github.com/dadrus/heimdall/internal/secrets/provider/jwks"
 	_ "github.com/dadrus/heimdall/internal/secrets/provider/pem"
 	"github.com/dadrus/heimdall/internal/secrets/types"
 	"github.com/dadrus/heimdall/internal/x/errorchain"

--- a/internal/secrets/types/secret.go
+++ b/internal/secrets/types/secret.go
@@ -45,7 +45,7 @@ type SymmetricKeySecret interface {
 	Secret
 	KeyID() string
 	Key() []byte
-	Algorithms() string
+	Algorithm() string
 }
 
 type AsymmetricKeySecret interface {
@@ -111,9 +111,9 @@ func NewSymmetricKeySecret(selector, kid, algorithm string, value []byte) Symmet
 	}
 }
 
-func (s *symmetricKeySecret) KeyID() string      { return s.keyID }
-func (s *symmetricKeySecret) Key() []byte        { return s.value }
-func (s *symmetricKeySecret) Algorithms() string { return s.algorithm }
+func (s *symmetricKeySecret) KeyID() string     { return s.keyID }
+func (s *symmetricKeySecret) Key() []byte       { return s.value }
+func (s *symmetricKeySecret) Algorithm() string { return s.algorithm }
 
 type asymmetricKeySecret struct {
 	baseSecret

--- a/internal/secrets/types/secret.go
+++ b/internal/secrets/types/secret.go
@@ -45,6 +45,7 @@ type SymmetricKeySecret interface {
 	Secret
 	KeyID() string
 	Key() []byte
+	Algorithms() string
 }
 
 type AsymmetricKeySecret interface {
@@ -93,23 +94,26 @@ func (s *stringSecret) Value() string { return s.value }
 type symmetricKeySecret struct {
 	baseSecret
 
-	keyID string
-	value []byte
+	keyID     string
+	value     []byte
+	algorithm string
 }
 
-func NewSymmetricKeySecret(selector, kid string, value []byte) SymmetricKeySecret {
+func NewSymmetricKeySecret(selector, kid, algorithm string, value []byte) SymmetricKeySecret {
 	return &symmetricKeySecret{
 		baseSecret: baseSecret{
 			selector: selector,
 			kind:     SecretKindSymmetricKey,
 		},
-		keyID: kid,
-		value: value,
+		keyID:     kid,
+		value:     value,
+		algorithm: algorithm,
 	}
 }
 
-func (s *symmetricKeySecret) KeyID() string { return s.keyID }
-func (s *symmetricKeySecret) Key() []byte   { return s.value }
+func (s *symmetricKeySecret) KeyID() string      { return s.keyID }
+func (s *symmetricKeySecret) Key() []byte        { return s.value }
+func (s *symmetricKeySecret) Algorithms() string { return s.algorithm }
 
 type asymmetricKeySecret struct {
 	baseSecret

--- a/internal/secrets/types/secret_test.go
+++ b/internal/secrets/types/secret_test.go
@@ -35,8 +35,8 @@ func TestNewStringSecret(t *testing.T) {
 	assert.Equal(t, "bar", secret.Value())
 }
 
-func TestNewBytesSecret(t *testing.T) {
-	secret := NewSymmetricKeySecret("foo/bar", "bar", []byte("secret"))
+func TestNewSymmetricSecret(t *testing.T) {
+	secret := NewSymmetricKeySecret("foo/bar", "bar", "foo", []byte("secret"))
 
 	assert.Equal(t, "foo/bar", secret.Selector())
 	assert.Equal(t, "bar", secret.KeyID())
@@ -44,7 +44,7 @@ func TestNewBytesSecret(t *testing.T) {
 	assert.Equal(t, []byte("secret"), secret.Key())
 }
 
-func TestNewSignerSecret(t *testing.T) {
+func TestNewAsymmetricKeySecret(t *testing.T) {
 	signer, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
@@ -58,7 +58,7 @@ func TestNewSignerSecret(t *testing.T) {
 	assert.Equal(t, []*x509.Certificate{cert}, secret.CertChain())
 }
 
-func TestNewTrustStoreSecret(t *testing.T) {
+func TestNewCertificateBundle(t *testing.T) {
 	cert := &x509.Certificate{}
 	secret := NewCertificateBundle("trust", []*x509.Certificate{cert})
 

--- a/internal/x/pkix/cert_chain.go
+++ b/internal/x/pkix/cert_chain.go
@@ -14,19 +14,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package pem
+package pkix
 
 import (
 	"bytes"
 	"crypto"
 	"crypto/x509"
-
-	"github.com/dadrus/heimdall/internal/secrets/provider"
-	"github.com/dadrus/heimdall/internal/x/errorchain"
-	"github.com/dadrus/heimdall/internal/x/pkix"
 )
 
-func findChain(key crypto.PublicKey, certPool []*x509.Certificate) []*x509.Certificate {
+func FindChain(key crypto.PublicKey, certPool []*x509.Certificate) []*x509.Certificate {
 	publicKey, ok := key.(interface {
 		Equal(other crypto.PublicKey) bool
 	})
@@ -67,7 +63,7 @@ func isIssuerOf(child, issuer *x509.Certificate) bool {
 	return bytes.Equal(child.RawIssuer, issuer.RawSubject)
 }
 
-func validateChain(chain []*x509.Certificate) error {
+func ValidateChain(chain []*x509.Certificate) error {
 	// The validation of the chain happens without the usage of the system
 	// trust store. Given the way how buildChain works, the last certificate
 	// in the chain is considered to be the root of trust, the first is the
@@ -85,13 +81,12 @@ func validateChain(chain []*x509.Certificate) error {
 		intermediates = append(intermediates, chain[1:len(chain)-1]...)
 	}
 
-	err := pkix.ValidateCertificate(chain[0],
-		pkix.WithRootCACertificates([]*x509.Certificate{chain[len(chain)-1]}),
-		pkix.WithIntermediateCACertificates(intermediates),
+	err := ValidateCertificate(chain[0],
+		WithRootCACertificates([]*x509.Certificate{chain[len(chain)-1]}),
+		WithIntermediateCACertificates(intermediates),
 	)
 	if err != nil {
-		return errorchain.NewWithMessage(provider.ErrConfiguration,
-			"invalid certificate chain").CausedBy(err)
+		return err
 	}
 
 	return nil

--- a/internal/x/pkix/cert_chain_test.go
+++ b/internal/x/pkix/cert_chain_test.go
@@ -14,7 +14,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package pem
+package pkix
 
 import (
 	"crypto"
@@ -88,7 +88,7 @@ func TestFindChain(t *testing.T) {
 		t.Run(uc, func(t *testing.T) {
 			t.Parallel()
 
-			tc.assert(t, findChain(tc.key, tc.pool))
+			tc.assert(t, FindChain(tc.key, tc.pool))
 		})
 	}
 }
@@ -157,7 +157,7 @@ func TestValidateChain(t *testing.T) {
 		t.Run(uc, func(t *testing.T) {
 			t.Parallel()
 
-			tc.assert(t, validateChain(tc.chain))
+			tc.assert(t, ValidateChain(tc.chain))
 		})
 	}
 }

--- a/internal/x/pkix/cert_chain_test.go
+++ b/internal/x/pkix/cert_chain_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dadrus/heimdall/internal/secrets/provider"
 	"github.com/dadrus/heimdall/internal/x/testsupport"
 )
 
@@ -97,7 +96,7 @@ func TestValidateChain(t *testing.T) {
 	t.Parallel()
 
 	rootCA, intermediateCA, leafCert, _ := createLeafWithIntermediateCA(t)
-	badRootCA, err := testsupport.NewRootCA("PEM Bad Root CA", 24*time.Hour)
+	badRootCA, err := testsupport.NewRootCA("Bad Root CA", 24*time.Hour)
 	require.NoError(t, err)
 
 	for uc, tc := range map[string]struct {
@@ -135,8 +134,7 @@ func TestValidateChain(t *testing.T) {
 				t.Helper()
 
 				require.Error(t, err)
-				require.ErrorIs(t, err, provider.ErrConfiguration)
-				require.ErrorContains(t, err, "invalid certificate chain")
+				require.ErrorIs(t, err, ErrCertificateValidation)
 			},
 		},
 		"returns configuration error for malformed issuer": {
@@ -149,8 +147,7 @@ func TestValidateChain(t *testing.T) {
 				t.Helper()
 
 				require.Error(t, err)
-				require.ErrorIs(t, err, provider.ErrConfiguration)
-				require.ErrorContains(t, err, "invalid certificate chain")
+				require.ErrorIs(t, err, ErrCertificateValidation)
 			},
 		},
 	} {
@@ -167,7 +164,7 @@ func createLeafWithIntermediateCA(
 ) (*testsupport.CA, *testsupport.CA, *x509.Certificate, *ecdsa.PrivateKey) {
 	t.Helper()
 
-	rootCA, err := testsupport.NewRootCA("PEM Test Root CA", 24*time.Hour)
+	rootCA, err := testsupport.NewRootCA("Test Root CA", 24*time.Hour)
 	require.NoError(t, err)
 
 	intermediateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
@@ -175,7 +172,7 @@ func createLeafWithIntermediateCA(
 
 	intermediateCert, err := rootCA.IssueCertificate(
 		testsupport.WithSubject(x509pkix.Name{
-			CommonName:   "PEM Test Intermediate CA",
+			CommonName:   "Test Intermediate CA",
 			Organization: []string{"Heimdall"},
 			Country:      []string{"EU"},
 		}),
@@ -193,7 +190,7 @@ func createLeafWithIntermediateCA(
 
 	leafCert, err := intermediateCA.IssueCertificate(
 		testsupport.WithSubject(x509pkix.Name{
-			CommonName:   "PEM Test EE",
+			CommonName:   "Test EE",
 			Organization: []string{"Heimdall"},
 			Country:      []string{"EU"},
 		}),

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -108,6 +108,43 @@
         }
       }
     },
+    "secretSourceJWKS": {
+      "description": "JWKS file based secret source",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "config"
+      ],
+      "properties": {
+        "type": {
+          "const": "jwks"
+        },
+        "allow_in_rules": {
+          "description": "Whether this secret source can be used in rules",
+          "type": "boolean",
+          "default": false
+        },
+        "config": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "path"
+          ],
+          "properties": {
+            "path": {
+              "description": "Path to the JWKS file",
+              "type": "string"
+            },
+            "watch": {
+              "description": "Whether this secret source should be watched for changes",
+              "type": "boolean",
+              "default": false
+            }
+          }
+        }
+      }
+    },
     "secretReference": {
       "description": "Reference to a secret",
       "type": "object",
@@ -2912,7 +2949,7 @@
         "required": ["type"],
         "properties": {
           "type": {
-            "enum": ["pem", "file", "inline"]
+            "enum": ["pem", "file", "inline", "jwks"]
           }
         },
         "allOf": [
@@ -2936,6 +2973,13 @@
               "properties": { "type": { "const": "inline" } }
             },
             "then": { "$ref": "#/definitions/secretSourceInline" }
+          },
+          {
+            "if": {
+              "required": ["type"],
+              "properties": { "type": { "const": "jwks" } }
+            },
+            "then": { "$ref": "#/definitions/secretSourceJWKS" }
           }
         ]
       }


### PR DESCRIPTION
## Related issue(s)

closes #3112

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

This PR adds a new `jwks` secret provider for loading key material from local JWKS files.

Supported key material:

* RSA private keys
* EC private keys
* Ed25519 private keys
* symmetric keys (`kty: "oct"`)

All JWK entries must define a non-empty `kid`. The provider rejects JWKS files with duplicate key IDs.

Out of scope for this PR:

* support for HS256, HS384 and HS512 in the `jwt` finalizer (will be addressed in a separate PR later)
* support for HS256, HS384 and HS512 in the `jwt` authenticator as requested in #614 (will be addressed in a separate PR later)
* encrypted JWK/JWKS support (will be addressed in a separate PR later).

As with other secret providers implemented as part of #3238, the configuration goes into the `secret_management` top-level property of heimdall's configuration:

```yaml
secret_management:
  # Freely choseable name for the source
  signing_keys:
    # jwks is the type f the new secret provider
    type: jwks
    # Whether secrets from this provider can be used from rules. Optional, defaults to false
    allow_in_rules: false
    # Mandatory configuration of the provider
    config:
      # Path to the JWKS file containing key material. Mandatory.
      path: /path/to/jwks.json
      # Whether to watch the JWKS file for changes. Optional and defaults to false.
      watch: true
```

Example JWKS file with a symmetric key:

```json
{
  "keys": [
    {
      "kty": "oct",
      "kid": "hmac-2026-01",
      "alg": "HS256",
      "k": "base64url-encoded-key-material"
    }
  ]
}
```

Example JWKS file with an asymmetric private key:

```json
{
  "keys": [
    {
      "kty": "OKP",
      "kid": "ed25519-2026-01",
      "crv": "Ed25519",
      "x": "...",
      "d": "..."
    }
  ]
}
```

