### PR TITLE
feat: add configurable OAuth2 scope matching

### DIFF
--- a/docs/content/docs/configuration/types.adoc
+++ b/docs/content/docs/configuration/types.adoc
@@ -824,8 +824,27 @@ Scopes matcher is a configuration type allowing configuration of different strat
 
 Regardless of the strategy, each matcher can explicitly be configured and supports the following configuration properties:
 
-* `matching_strategy` - the type of the mathing strategy.
-* `values` - the list of scope patterns
+* `matching_strategy` - the type of the matching strategy. Defaults to `exact`.
+* `match` - whether all configured scope values must match, or any one configured scope value is sufficient. Supported values are `all` and `any`. Defaults to `all`.
+* `pattern_source` - when `matching_strategy` is set to `wildcard`, controls which side may contain wildcard patterns. Supported values are `granted` and `required`. Defaults to `granted`.
+* `values` - the list of required scope values
+
+The `matching_strategy` property controls how a configured scope value is compared with scopes granted to the token. The `match` property controls how the configured list is evaluated. With the default `all` value, every configured entry must match. With `any`, one matching entry is sufficient.
+
+.Matching any required scope
+====
+
+[source, yaml]
+----
+matching_strategy: exact
+match: any
+values:
+  - documents.read
+  - reports.read
+----
+
+This configuration is satisfied if the token has either the `documents.read` or the `reports.read` scope.
+====
 
 === Exact
 
@@ -845,6 +864,7 @@ However, as written in the link:{{< relref "#_scopes_matcher">}}[Scopes Matcher]
 [source, yaml]
 ----
 matching_strategy: exact
+match: all
 values:
   - foo
   - bar
@@ -908,7 +928,36 @@ would not match.
 
 This matcher enables matching scopes using wildcards. It goes beyond the link:{{< relref "#_hierarchic">}}[Hierarchic] scope matcher by enabling usage of wildcards.
 
-This matcher can only be used by explicitly setting the `matching_strategy` to `wildcard` and defining the required patterns in the `values` property.
+This matcher can only be used by explicitly setting the `matching_strategy` to `wildcard` and defining the required values in the `values` property.
+
+.Matching granted wildcard scopes
+====
+
+[source, yaml]
+----
+matching_strategy: wildcard
+values:
+  - documents.read
+----
+
+With the default `pattern_source: granted`, wildcard patterns are expected in the scopes granted to the token. A token with the scope `documents.*` satisfies the configured required scope `documents.read`.
+====
+
+.Matching required wildcard scopes
+====
+
+[source, yaml]
+----
+matching_strategy: wildcard
+pattern_source: required
+match: any
+values:
+  - documents.*
+  - reports.*
+----
+
+With `pattern_source: required`, wildcard patterns are expected in the configured required scopes. A token with the concrete scope `documents.read` satisfies the configured required scope `documents.*`.
+====
 
 
 == Session Lifespan

--- a/internal/rules/mechanisms/oauth2/any_scope_matcher.go
+++ b/internal/rules/mechanisms/oauth2/any_scope_matcher.go
@@ -1,0 +1,51 @@
+// Copyright 2022 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2
+
+type AnyScopeMatcher struct {
+	required []string
+	matchers []ScopesMatcher
+}
+
+func NewAnyScopeMatcher(required []string, createMatcher scopeMatcherFactory) (AnyScopeMatcher, error) {
+	matchers := make([]ScopesMatcher, len(required))
+
+	for idx, scope := range required {
+		matcher, err := createMatcher([]string{scope})
+		if err != nil {
+			return AnyScopeMatcher{}, err
+		}
+
+		matchers[idx] = matcher
+	}
+
+	return AnyScopeMatcher{required: required, matchers: matchers}, nil
+}
+
+func (m AnyScopeMatcher) Match(scopes []string) error {
+	if len(m.required) == 0 {
+		return nil
+	}
+
+	for _, matcher := range m.matchers {
+		if err := matcher.Match(scopes); err == nil {
+			return nil
+		}
+	}
+
+	return NewScopeMismatchError(m.required, nil)
+}

--- a/internal/rules/mechanisms/oauth2/any_scope_matcher_test.go
+++ b/internal/rules/mechanisms/oauth2/any_scope_matcher_test.go
@@ -1,0 +1,122 @@
+// Copyright 2022 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnyScopeMatcherMatch(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		matcher        AnyScopeMatcher
+		providedScopes []string
+		assert         func(t *testing.T, err error)
+	}{
+		"matches when the first required scope is present": {
+			matcher: mustAnyScopeMatcher(t, []string{"read", "write"}, func(scopes []string) (ScopesMatcher, error) {
+				return ExactScopeStrategyMatcher(scopes), nil
+			}),
+			providedScopes: []string{"read"},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+			},
+		},
+		"matches when only a later required scope is present": {
+			matcher: mustAnyScopeMatcher(t, []string{"read", "write"}, func(scopes []string) (ScopesMatcher, error) {
+				return ExactScopeStrategyMatcher(scopes), nil
+			}),
+			providedScopes: []string{"write"},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+			},
+		},
+		"matches when a provided hierarchical scope includes a required scope": {
+			matcher: mustAnyScopeMatcher(t, []string{"orders.read", "inventory.read"}, func(scopes []string) (ScopesMatcher, error) {
+				return HierarchicScopeStrategyMatcher(scopes), nil
+			}),
+			providedScopes: []string{"inventory"},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+			},
+		},
+		"matches when a provided wildcard scope includes a required scope": {
+			matcher: mustAnyScopeMatcher(t, []string{"orders.read", "inventory.read"}, func(scopes []string) (ScopesMatcher, error) {
+				return WildcardScopeStrategyMatcher(scopes), nil
+			}),
+			providedScopes: []string{"orders.*"},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+			},
+		},
+		"doesn't match when none of the required scopes is present": {
+			matcher: mustAnyScopeMatcher(t, []string{"read", "write"}, func(scopes []string) (ScopesMatcher, error) {
+				return ExactScopeStrategyMatcher(scopes), nil
+			}),
+			providedScopes: []string{"profile"},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+
+				var mismatch *ScopeMismatchError
+				require.ErrorAs(t, err, &mismatch)
+				require.ElementsMatch(t, []string{"read", "write"}, mismatch.RequiredScopes())
+				require.Empty(t, mismatch.MissingScopes())
+			},
+		},
+		"matches if no required scopes are defined": {
+			matcher: mustAnyScopeMatcher(t, []string{}, func(scopes []string) (ScopesMatcher, error) {
+				return ExactScopeStrategyMatcher(scopes), nil
+			}),
+			providedScopes: []string{"profile"},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.matcher.Match(tc.providedScopes)
+
+			tc.assert(t, err)
+		})
+	}
+}
+
+func mustAnyScopeMatcher(t *testing.T, required []string, createMatcher scopeMatcherFactory) AnyScopeMatcher {
+	t.Helper()
+
+	matcher, err := NewAnyScopeMatcher(required, createMatcher)
+	require.NoError(t, err)
+
+	return matcher
+}

--- a/internal/rules/mechanisms/oauth2/mapstructure_decoder.go
+++ b/internal/rules/mechanisms/oauth2/mapstructure_decoder.go
@@ -62,29 +62,27 @@ func DecodeScopesMatcherHookFunc() mapstructure.DecodeHookFunc {
 
 type scopeMatcherFactory func(scopes []string) (ScopesMatcher, error)
 
+type scopePatternSource string
+
+const (
+	scopePatternSourceGranted  scopePatternSource = "granted"
+	scopePatternSourceRequired scopePatternSource = "required"
+)
+
 func decodeMatcherFromMap(data any) (ScopesMatcher, error) {
 	typed, err := asStringMap(data)
 	if err != nil {
 		return nil, err
 	}
 
-	createMatcher := func(scopes []string) (ScopesMatcher, error) {
-		return ExactScopeStrategyMatcher(scopes), nil
+	createMatcher, err := scopeMatcherFactoryFromConfig(typed)
+	if err != nil {
+		return nil, err
 	}
 
-	if name, ok := typed["matching_strategy"]; ok {
-		strategy, ok := name.(string)
-		if !ok {
-			return nil, errorchain.NewWithMessage(
-				pipeline.ErrConfiguration,
-				"invalid matching strategy type",
-			)
-		}
-
-		createMatcher, err = matcherFactory(strategy)
-		if err != nil {
-			return nil, err
-		}
+	match, err := scopeListMatchFromConfig(typed)
+	if err != nil {
+		return nil, err
 	}
 
 	values, ok := typed["values"]
@@ -95,10 +93,118 @@ func decodeMatcherFromMap(data any) (ScopesMatcher, error) {
 		)
 	}
 
-	return createMatcherFromValues(createMatcher, values)
+	scopes, err := scopesFromValues(values)
+	if err != nil {
+		return nil, err
+	}
+
+	return createListMatcher(match, scopes, createMatcher)
+}
+
+func scopeMatcherFactoryFromConfig(typed map[string]any) (scopeMatcherFactory, error) {
+	createMatcher := func(scopes []string) (ScopesMatcher, error) {
+		return ExactScopeStrategyMatcher(scopes), nil
+	}
+
+	rawStrategy, ok := typed["matching_strategy"]
+	if !ok {
+		if _, ok := typed["pattern_source"]; ok {
+			return nil, errorchain.NewWithMessage(
+				pipeline.ErrConfiguration,
+				"scope pattern source is only supported with wildcard matching strategy",
+			)
+		}
+
+		return createMatcher, nil
+	}
+
+	strategy, ok := rawStrategy.(string)
+	if !ok {
+		return nil, errorchain.NewWithMessage(
+			pipeline.ErrConfiguration,
+			"invalid matching strategy type",
+		)
+	}
+
+	patternSource, err := scopePatternSourceFromConfig(typed)
+	if err != nil {
+		return nil, err
+	}
+
+	return matcherFactory(strategy, patternSource)
+}
+
+func scopePatternSourceFromConfig(typed map[string]any) (scopePatternSource, error) {
+	raw, ok := typed["pattern_source"]
+	if !ok {
+		return "", nil
+	}
+
+	source, ok := raw.(string)
+	if !ok {
+		return "", errorchain.NewWithMessage(
+			pipeline.ErrConfiguration,
+			"invalid scope pattern source type",
+		)
+	}
+
+	switch source {
+	case string(scopePatternSourceGranted):
+		return scopePatternSourceGranted, nil
+	case string(scopePatternSourceRequired):
+		return scopePatternSourceRequired, nil
+	default:
+		return "", errorchain.NewWithMessagef(
+			pipeline.ErrConfiguration,
+			"unsupported scope pattern source \"%s\"",
+			source,
+		)
+	}
+}
+
+func scopeListMatchFromConfig(typed map[string]any) (string, error) {
+	raw, ok := typed["match"]
+	if !ok {
+		return "all", nil
+	}
+
+	match, ok := raw.(string)
+	if !ok {
+		return "", errorchain.NewWithMessage(
+			pipeline.ErrConfiguration,
+			"invalid scope match type",
+		)
+	}
+
+	return match, nil
+}
+
+func createListMatcher(match string, scopes []string, createMatcher scopeMatcherFactory) (ScopesMatcher, error) {
+	switch match {
+	case "all":
+		return createMatcher(scopes)
+	case "any":
+		matcher, err := NewAnyScopeMatcher(scopes, createMatcher)
+		if err != nil {
+			return nil, err
+		}
+
+		return matcher, nil
+	default:
+		return nil, errorchain.NewWithMessagef(pipeline.ErrConfiguration, "unsupported scope match \"%s\"", match)
+	}
 }
 
 func createMatcherFromValues(createMatcher scopeMatcherFactory, values any) (ScopesMatcher, error) {
+	scopes, err := scopesFromValues(values)
+	if err != nil {
+		return nil, err
+	}
+
+	return createMatcher(scopes)
+}
+
+func scopesFromValues(values any) ([]string, error) {
 	raw, ok := values.([]any)
 	if !ok {
 		return nil, errorchain.NewWithMessage(
@@ -120,26 +226,57 @@ func createMatcherFromValues(createMatcher scopeMatcherFactory, values any) (Sco
 		scopes[i] = scope
 	}
 
-	return createMatcher(scopes)
+	return scopes, nil
 }
 
-func matcherFactory(name string) (scopeMatcherFactory, error) {
+func matcherFactory(name string, patternSource scopePatternSource) (scopeMatcherFactory, error) {
 	switch name {
 	case "exact":
+		if patternSource != "" {
+			return nil, errorchain.NewWithMessage(
+				pipeline.ErrConfiguration,
+				"scope pattern source is only supported with wildcard matching strategy",
+			)
+		}
+
 		return func(scopes []string) (ScopesMatcher, error) {
 			return ExactScopeStrategyMatcher(scopes), nil
 		}, nil
 	case "hierarchic":
+		if patternSource != "" {
+			return nil, errorchain.NewWithMessage(
+				pipeline.ErrConfiguration,
+				"scope pattern source is only supported with wildcard matching strategy",
+			)
+		}
+
 		return func(scopes []string) (ScopesMatcher, error) {
 			return HierarchicScopeStrategyMatcher(scopes), nil
 		}, nil
 	case "wildcard":
-		return func(scopes []string) (ScopesMatcher, error) {
-			return WildcardScopeStrategyMatcher(scopes), nil
-		}, nil
+		if patternSource == "" {
+			patternSource = scopePatternSourceGranted
+		}
+
+		switch patternSource {
+		case scopePatternSourceGranted:
+			return func(scopes []string) (ScopesMatcher, error) {
+				return WildcardScopeStrategyMatcher(scopes), nil
+			}, nil
+		case scopePatternSourceRequired:
+			return func(scopes []string) (ScopesMatcher, error) {
+				return RequiredWildcardScopeStrategyMatcher(scopes), nil
+			}, nil
+		}
 	default:
 		return nil, errorchain.NewWithMessagef(pipeline.ErrConfiguration, "unsupported strategy \"%s\"", name)
 	}
+
+	return nil, errorchain.NewWithMessagef(
+		pipeline.ErrConfiguration,
+		"unsupported scope pattern source \"%s\"",
+		patternSource,
+	)
 }
 
 func DecodePoPStrategyHookFunc(ctx app.Context) mapstructure.DecodeHookFunc {

--- a/internal/rules/mechanisms/oauth2/mapstructure_decoder_test.go
+++ b/internal/rules/mechanisms/oauth2/mapstructure_decoder_test.go
@@ -62,6 +62,41 @@ scopes:
 				assert.ElementsMatch(t, matcher, []string{"foo", "bar"})
 			},
 		},
+		"structure with scopes under value, wildcard strategy and default pattern source": {
+			config: []byte(`
+scopes:
+  values:
+    - documents.read
+  matching_strategy: wildcard
+`),
+			assert: func(t *testing.T, err error, matcher ScopesMatcher) {
+				t.Helper()
+
+				require.NoError(t, err)
+
+				assert.IsType(t, WildcardScopeStrategyMatcher{}, matcher)
+				require.NoError(t, matcher.Match([]string{"documents.*"}))
+				require.Error(t, matcher.Match([]string{"documents.write"}))
+			},
+		},
+		"structure with scopes under value, wildcard strategy and required pattern source": {
+			config: []byte(`
+scopes:
+  values:
+    - documents.*
+  matching_strategy: wildcard
+  pattern_source: required
+`),
+			assert: func(t *testing.T, err error, matcher ScopesMatcher) {
+				t.Helper()
+
+				require.NoError(t, err)
+
+				assert.IsType(t, RequiredWildcardScopeStrategyMatcher{}, matcher)
+				require.NoError(t, matcher.Match([]string{"documents.read"}))
+				require.Error(t, matcher.Match([]string{"reports.read"}))
+			},
+		},
 		"structure with scopes under value and exact strategy": {
 			config: []byte(`
 scopes:
@@ -94,6 +129,72 @@ scopes:
 
 				assert.IsType(t, HierarchicScopeStrategyMatcher{}, matcher)
 				assert.ElementsMatch(t, matcher, []string{"foo", "bar"})
+			},
+		},
+		"structure with scopes under value and any match": {
+			config: []byte(`
+scopes:
+  values:
+    - read
+    - write
+  match: any
+`),
+			assert: func(t *testing.T, err error, matcher ScopesMatcher) {
+				t.Helper()
+
+				require.NoError(t, err)
+
+				anyMatcher, ok := matcher.(AnyScopeMatcher)
+				require.True(t, ok)
+				assert.ElementsMatch(t, []string{"read", "write"}, anyMatcher.required)
+				assert.Len(t, anyMatcher.matchers, 2)
+			},
+		},
+		"structure with scopes under value, any match and wildcard strategy": {
+			config: []byte(`
+scopes:
+  values:
+    - documents.read
+    - reports.read
+  match: any
+  matching_strategy: wildcard
+`),
+			assert: func(t *testing.T, err error, matcher ScopesMatcher) {
+				t.Helper()
+
+				require.NoError(t, err)
+
+				anyMatcher, ok := matcher.(AnyScopeMatcher)
+				require.True(t, ok)
+				assert.ElementsMatch(t, []string{"documents.read", "reports.read"}, anyMatcher.required)
+				require.Len(t, anyMatcher.matchers, 2)
+				assert.IsType(t, WildcardScopeStrategyMatcher{}, anyMatcher.matchers[0])
+				assert.IsType(t, WildcardScopeStrategyMatcher{}, anyMatcher.matchers[1])
+			},
+		},
+		"structure with scopes under value, any match, wildcard strategy and required pattern source": {
+			config: []byte(`
+scopes:
+  values:
+    - documents.*
+    - reports.*
+  match: any
+  matching_strategy: wildcard
+  pattern_source: required
+`),
+			assert: func(t *testing.T, err error, matcher ScopesMatcher) {
+				t.Helper()
+
+				require.NoError(t, err)
+
+				anyMatcher, ok := matcher.(AnyScopeMatcher)
+				require.True(t, ok)
+				assert.ElementsMatch(t, []string{"documents.*", "reports.*"}, anyMatcher.required)
+				require.Len(t, anyMatcher.matchers, 2)
+				assert.IsType(t, RequiredWildcardScopeStrategyMatcher{}, anyMatcher.matchers[0])
+				assert.IsType(t, RequiredWildcardScopeStrategyMatcher{}, anyMatcher.matchers[1])
+				require.NoError(t, matcher.Match([]string{"reports.read"}))
+				require.Error(t, matcher.Match([]string{"admin"}))
 			},
 		},
 		"only scopes provided under values property": {
@@ -166,6 +267,108 @@ scopes:
 
 				require.ErrorIs(t, err, pipeline.ErrConfiguration)
 				require.ErrorContains(t, err, `invalid matching strategy type`)
+			},
+		},
+		"fails if match is unsupported": {
+			config: []byte(`
+scopes:
+  values:
+    - read
+  match: unsupported
+`),
+			assert: func(t *testing.T, err error, _ ScopesMatcher) {
+				t.Helper()
+
+				require.ErrorIs(t, err, pipeline.ErrConfiguration)
+				require.ErrorContains(t, err, `unsupported scope match "unsupported"`)
+			},
+		},
+		"fails if match is of wrong type": {
+			config: []byte(`
+scopes:
+  values:
+    - read
+  match: 1
+`),
+			assert: func(t *testing.T, err error, _ ScopesMatcher) {
+				t.Helper()
+
+				require.ErrorIs(t, err, pipeline.ErrConfiguration)
+				require.ErrorContains(t, err, `invalid scope match type`)
+			},
+		},
+		"fails if pattern source is unsupported": {
+			config: []byte(`
+scopes:
+  values:
+    - read
+  matching_strategy: wildcard
+  pattern_source: unsupported
+`),
+			assert: func(t *testing.T, err error, _ ScopesMatcher) {
+				t.Helper()
+
+				require.ErrorIs(t, err, pipeline.ErrConfiguration)
+				require.ErrorContains(t, err, `unsupported scope pattern source "unsupported"`)
+			},
+		},
+		"fails if pattern source is of wrong type": {
+			config: []byte(`
+scopes:
+  values:
+    - read
+  matching_strategy: wildcard
+  pattern_source: 1
+`),
+			assert: func(t *testing.T, err error, _ ScopesMatcher) {
+				t.Helper()
+
+				require.ErrorIs(t, err, pipeline.ErrConfiguration)
+				require.ErrorContains(t, err, `invalid scope pattern source type`)
+			},
+		},
+		"fails if pattern source is configured without wildcard strategy": {
+			config: []byte(`
+scopes:
+  values:
+    - read
+  matching_strategy: exact
+  pattern_source: required
+`),
+			assert: func(t *testing.T, err error, _ ScopesMatcher) {
+				t.Helper()
+
+				require.ErrorIs(t, err, pipeline.ErrConfiguration)
+				require.ErrorContains(t, err, `scope pattern source is only supported with wildcard matching strategy`)
+			},
+		},
+		"fails if granted pattern source is configured without wildcard strategy": {
+			config: []byte(`
+scopes:
+  values:
+    - read
+  matching_strategy: exact
+  pattern_source: granted
+`),
+			assert: func(t *testing.T, err error, _ ScopesMatcher) {
+				t.Helper()
+
+				require.ErrorIs(t, err, pipeline.ErrConfiguration)
+				require.ErrorContains(t, err, `scope pattern source is only supported with wildcard matching strategy`)
+			},
+		},
+		"fails if pattern source is configured without matching strategy": {
+			config: []byte(`
+scopes:
+  values:
+    - read
+  pattern_source: granted
+`),
+			assert: func(t *testing.T, err error, _ ScopesMatcher) {
+				t.Helper()
+
+				require.ErrorIs(t, err, pipeline.ErrConfiguration)
+				require.ErrorContains(t, err, `scope pattern source is only supported with wildcard matching strategy`)
 			},
 		},
 		"fails if values are missing": {

--- a/internal/rules/mechanisms/oauth2/required_wildcard_scopes_matcher.go
+++ b/internal/rules/mechanisms/oauth2/required_wildcard_scopes_matcher.go
@@ -1,0 +1,35 @@
+// Copyright 2022 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2
+
+type RequiredWildcardScopeStrategyMatcher []string
+
+func (m RequiredWildcardScopeStrategyMatcher) Match(scopes []string) error {
+	var missing []string
+
+	for _, required := range m {
+		if !wildcardScopeMatch([]string{required}, scopes...) {
+			missing = append(missing, required)
+		}
+	}
+
+	if len(missing) != 0 {
+		return NewScopeMismatchError([]string(m), missing)
+	}
+
+	return nil
+}

--- a/internal/rules/mechanisms/oauth2/required_wildcard_scopes_matcher_test.go
+++ b/internal/rules/mechanisms/oauth2/required_wildcard_scopes_matcher_test.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequiredWildcardScopeStrategyMatcher(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		requiredScopes RequiredWildcardScopeStrategyMatcher
+		providedScopes []string
+		assert         func(t *testing.T, err error)
+	}{
+		"configured wildcard matches concrete token scope": {
+			requiredScopes: RequiredWildcardScopeStrategyMatcher{"documents.*"},
+			providedScopes: []string{"documents.read"},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+			},
+		},
+		"configured wildcard does not match another namespace": {
+			requiredScopes: RequiredWildcardScopeStrategyMatcher{"documents.*"},
+			providedScopes: []string{"reports.read"},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+			},
+		},
+		"configured wildcard on later required scope must also match": {
+			requiredScopes: RequiredWildcardScopeStrategyMatcher{"documents.*", "reports.*"},
+			providedScopes: []string{"documents.read"},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.Error(t, err)
+			},
+		},
+		"matches if no required scopes are defined": {
+			requiredScopes: RequiredWildcardScopeStrategyMatcher{},
+			providedScopes: []string{"documents.read"},
+			assert: func(t *testing.T, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.requiredScopes.Match(tc.providedScopes)
+
+			tc.assert(t, err)
+		})
+	}
+}

--- a/internal/rules/mechanisms/oauth2/wildcard_scopes_matcher.go
+++ b/internal/rules/mechanisms/oauth2/wildcard_scopes_matcher.go
@@ -24,7 +24,7 @@ func (m WildcardScopeStrategyMatcher) Match(scopes []string) error {
 	var missing []string
 
 	for _, required := range m {
-		if !m.doMatch(scopes, required) {
+		if !wildcardScopeMatch(scopes, required) {
 			missing = append(missing, required)
 		}
 	}
@@ -36,7 +36,17 @@ func (m WildcardScopeStrategyMatcher) Match(scopes []string) error {
 	return nil
 }
 
-func (m WildcardScopeStrategyMatcher) doMatch(matchers []string, needle string) bool {
+func wildcardScopeMatch(matchers []string, needles ...string) bool {
+	for _, needle := range needles {
+		if doWildcardScopeMatch(matchers, needle) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func doWildcardScopeMatch(matchers []string, needle string) bool {
 	needleParts := strings.Split(needle, ".")
 
 	for _, matcher := range matchers {

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -1335,13 +1335,50 @@
                     "wildcard"
                   ]
                 },
+                "match": {
+                  "description": "Sets whether all configured scope values must match, or whether any single configured scope value is sufficient.",
+                  "type": "string",
+                  "default": "all",
+                  "enum": [
+                    "all",
+                    "any"
+                  ]
+                },
+                "pattern_source": {
+                  "description": "Sets which side may contain wildcard patterns when matching_strategy is wildcard. The default value preserves the existing behavior, where granted token scopes may contain wildcard patterns. Use required to allow configured required scopes to contain wildcard patterns matched against concrete token scopes.",
+                  "type": "string",
+                  "default": "granted",
+                  "enum": [
+                    "granted",
+                    "required"
+                  ]
+                },
                 "values": {
                   "type": "array",
                   "items": {
                     "type": "string"
                   }
                 }
-              }
+              },
+              "allOf": [
+                {
+                  "if": {
+                    "required": [
+                      "pattern_source"
+                    ]
+                  },
+                  "then": {
+                    "required": [
+                      "matching_strategy"
+                    ],
+                    "properties": {
+                      "matching_strategy": {
+                        "const": "wildcard"
+                      }
+                    }
+                  }
+                }
+              ]
             },
             {
               "description": "An array of OAuth 2.0 scopes that are required when accessing an endpoint protected by this mechanism.\n If the token used in the Authorization header did not request that specific scope, the request is denied. When only the actual scopes are configured the matching strategy is 'exact'",


### PR DESCRIPTION
## Related issue(s)

Closes #3331

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

This PR makes OAuth2 scope validation more explicit for configurations where the resource server policy should express accepted scope patterns while runtime access tokens carry concrete scopes.

It adds two opt-in scope matcher settings:

- `match`, which controls whether all configured scope values must match or whether any one configured value is sufficient. The default is `all`, preserving existing behavior.
- `pattern_source`, which controls which side of wildcard matching is interpreted as the wildcard pattern source. The default is `granted`, preserving existing behavior where granted token scopes may contain wildcard patterns. The new `required` option lets a policy configure required scopes such as `documents.*` and match concrete token scopes such as `documents.read`.

`pattern_source` is only valid with `matching_strategy: wildcard`. The schema and runtime decoder both reject configurations that try to use it with exact or hierarchic matching, or without explicitly selecting wildcard matching.

This avoids forcing wildcard scope values into runtime tokens solely to make gateway policy matching ergonomic. The existing alternative is to enumerate every concrete scope in Heimdall configuration and keep that list synchronized with the authorization server's scope catalog, which is brittle for scope namespaces that evolve over time.

The change is intended to be backwards compatible: existing configurations continue to use `match: all` and `pattern_source: granted` unless the new settings are explicitly configured.

## Changelist

feat: Add configurable OAuth2 scope list aggregation and wildcard pattern source

test: Cover any-match aggregation, required-side wildcard matching, and invalid pattern source combinations

docs: Document scope matcher `match` and `pattern_source` settings

Validation:

- `go test ./internal/rules/mechanisms/oauth2 ./internal/rules/mechanisms/authenticators`
- `go test ./internal/rules/mechanisms/... ./internal/rules/endpoint/...`
- `go test ./...`
- `jq empty schema/config.schema.json`
- `git diff --check`
- `git diff --cached --check`
