### PR TITLE
feat: add HTTP message signature support

### DIFF
--- a/docs/content/docs/configuration/types.adoc
+++ b/docs/content/docs/configuration/types.adoc
@@ -468,6 +468,82 @@ config:
 ----
 ====
 
+== HTTP Message Signatures Authenticator
+
+This authenticator verifies inbound HTTP message signatures according to https://datatracker.ietf.org/doc/html/rfc9421[RFC 9421].
+
+`type` must be set to `http_message_signatures`. `config` supports the following properties:
+
+* *`key_store`*: _link:{{< relref "/docs/operations/secret_management.adoc#_secret_references" >}}[Secret Reference]_ (mandatory)
++
+Reference to the secret set containing the keys accepted for request signature verification.
+
+* *`required_components`*: _string array_ (mandatory)
++
+The HTTP message components that must be covered by the signature. Use `@authority` for request authority coverage. The literal `host` field is rejected for this authenticator because it does not consistently represent authority across HTTP versions.
+
+* *`tag`*: _string_ (optional)
++
+The required HTTP Message Signatures `tag` parameter. If `validate_all_signatures` is set to `false`, `tag` is mandatory.
+
+* *`max_age`*: _link:{{< relref "#_duration" >}}[Duration]_ (optional)
++
+Maximum accepted age of the signature. Defaults to `30s`.
+
+* *`allowed_time_skew`*: _link:{{< relref "#_duration" >}}[Duration]_ (optional)
++
+Allowed clock skew for `created` and `expires` signature parameters. Defaults to `0s`.
+
+* *`max_body_size`*: _link:{{< relref "#_bytesize" >}}[ByteSize]_ (optional)
++
+Maximum request body size that can be read while verifying signature components such as `content-digest`. Defaults to `1MB`.
+
+* *`created_timestamp_required`*: _boolean_ (optional)
++
+Whether the `created` signature parameter is required. Defaults to `true`.
+
+* *`expires_timestamp_required`*: _boolean_ (optional)
++
+Whether the `expires` signature parameter is required. Defaults to `true`.
+
+* *`validate_all_signatures`*: _boolean_ (optional)
++
+Whether all request signatures should be validated when no `tag` is configured. Defaults to `true`.
+
+* *`principal`*: _link:{{< relref "#_principal" >}}[Principal]_ (optional)
++
+Where to extract the principal information from the verified key data. The default principal id expression is `key_id`.
+
+* *`error_signaling`*: _HTTP Message Signatures Error Signaling_ (optional)
++
+Configures whether missing or non-applicable signatures should be signaled using the `Accept-Signature` response header. Signature negotiation is only available for tagged HMS profiles, so `tag` must be configured for heimdall to emit this header.
+
+== HTTP Message Signatures Finalizer
+
+This finalizer signs the upstream HTTP request according to https://datatracker.ietf.org/doc/html/rfc9421[RFC 9421].
+
+`type` must be set to `http_message_signatures`. `config` supports the following properties:
+
+* *`signer`*: _link:{{< relref "/docs/configuration/types.adoc#_signer" >}}[Signer]_ (mandatory, not overridable)
++
+Defines the key material used for signing. `name` is used as the HTTP Message Signatures `tag` parameter and defaults to `heimdall`.
+
+* *`components`*: _string array_ (mandatory, overridable)
++
+The HTTP message components to cover with the signature. Use `@authority` for request authority coverage. The literal `host` field is rejected because it does not consistently represent authority across HTTP versions.
+
+* *`ttl`*: _link:{{< relref "#_duration" >}}[Duration]_ (optional, overridable)
++
+Signature validity duration. Defaults to `1m`.
+
+* *`label`*: _string_ (optional, overridable)
++
+The signature label used in `Signature` and `Signature-Input`. Defaults to `sig`.
+
+* *`max_body_size`*: _link:{{< relref "#_bytesize" >}}[ByteSize]_ (optional, overridable)
++
+Maximum request body size that can be read while signing components such as `content-digest`. Defaults to `1MB`.
+
 == Authorization Expression
 
 Authorization expressions define, as the name implies expressions for authorization purposes and have the following properties:

--- a/docs/content/docs/mechanisms/authenticators.adoc
+++ b/docs/content/docs/mechanisms/authenticators.adoc
@@ -101,6 +101,87 @@ config:
 ----
 ====
 
+== HTTP Message Signatures
+
+This authenticator verifies HTTP message signatures according to https://datatracker.ietf.org/doc/html/rfc9421[RFC 9421]. If verification succeeds, it creates a link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_principal" >}}[Principal] from the verified key information. By default, the principal id is the verified signature key id.
+
+To enable the usage of this authenticator, you have to set the `type` property to `http_message_signatures`.
+
+Configuration using the `config` property is mandatory. Following properties are available:
+
+* *`key_store`*: _link:{{< relref "/docs/operations/secret_management.adoc#_secret_references" >}}[Secret Reference]_ (mandatory, not overridable)
++
+Reference to the secret set containing the asymmetric or symmetric keys accepted for request signature verification. For asymmetric keys, heimdall uses the public key corresponding to the configured key material.
+
+* *`required_components`*: _string array_ (mandatory, overridable)
++
+The HTTP message components that must be covered by the signature, for example `@method`, `@authority`, and `@path`. Use `@authority` for request authority coverage. The literal `host` field is rejected for this authenticator because it does not consistently represent authority across HTTP versions.
+
+* *`tag`*: _string_ (optional, overridable)
++
+The required HTTP Message Signatures `tag` parameter. Configure this when a rule must enforce a specific HMS profile. If error signaling is enabled, this also lets heimdall negotiate a missing signature for that profile.
+
+* *`max_age`*: _link:{{< relref "/docs/configuration/types.adoc#_duration" >}}[Duration]_ (optional, overridable)
++
+Maximum accepted age of the signature. Defaults to `30s`.
+
+* *`allowed_time_skew`*: _link:{{< relref "/docs/configuration/types.adoc#_duration" >}}[Duration]_ (optional, overridable)
++
+Allowed clock skew for `created` and `expires` signature parameters. Defaults to `0s`.
+
+* *`max_body_size`*: _link:{{< relref "/docs/configuration/types.adoc#_bytesize" >}}[ByteSize]_ (optional, overridable)
++
+Maximum request body size that can be read while verifying signature components such as `content-digest`. Requests whose body exceeds this limit fail authentication. Defaults to `1MB`.
+
+* *`created_timestamp_required`*: _boolean_ (optional, overridable)
++
+Whether the `created` signature parameter is required. Defaults to `true`.
+
+* *`expires_timestamp_required`*: _boolean_ (optional, overridable)
++
+Whether the `expires` signature parameter is required. Defaults to `true`.
+
+* *`validate_all_signatures`*: _boolean_ (optional, overridable)
++
+Whether all request signatures should be validated when no `tag` is configured. Defaults to `true`. If this is set to `false`, `tag` must be configured.
+
+* *`principal`*: _link:{{< relref "/docs/configuration/types.adoc#_principal" >}}[Principal]_ (optional, overridable)
++
+Where to extract the principal information from the verified key data. The default principal id expression is `key_id`.
+
+* *`error_signaling`*: _HTTPMessageSignaturesErrorSignaling_ (optional, overridable)
++
+Configures whether missing or non-applicable signatures should be signaled using the `Accept-Signature` response header. Signature negotiation is only available for tagged HMS profiles, so `tag` must be configured for heimdall to emit this header.
++
+Following properties are available:
+
+** *`enabled`*: _boolean_ (optional, overridable)
++
+Enables the error signaling. Defaults to `false`.
+
+.Full configuration of HTTP Message Signatures authenticator
+====
+[source, yaml]
+----
+id: hms_clients
+type: http_message_signatures
+config:
+  key_store:
+    source: my_jwks_source
+    selector: clients
+  required_components:
+    - "@method"
+    - "@authority"
+    - "@path"
+  max_body_size: 1MB
+  tag: hms-client
+  principal:
+    id: key_id
+  error_signaling:
+    enabled: true
+----
+====
+
 == Generic
 
 This authenticator is kind of a Swiss knife and can do a lot depending on the given configuration. It verifies the authentication status of a principal by making use of values available in cookies, headers, query parameters, or even body of the HTTP request and by communicating with the actual authentication system to perform the verification of the principal authentication status on the one hand, and to get the information about the principal on the other hand. There is however one limitation: it can only deal with JSON responses.

--- a/docs/content/docs/mechanisms/finalizers.adoc
+++ b/docs/content/docs/mechanisms/finalizers.adoc
@@ -156,6 +156,57 @@ In a rule that references the `jwt_finalizer`, additional claims can be dynamica
 ----
 ====
 
+== HTTP Message Signatures
+
+This finalizer signs the HTTP request that will be forwarded to the upstream service according to https://www.rfc-editor.org/rfc/rfc9421[RFC 9421]. In decision mode, heimdall returns the generated `Signature`, `Signature-Input`, and `Content-Digest` headers so the integrating proxy can add them to the protected request. In proxy mode, heimdall signs after the `forward_to` target, upstream headers, cookies, forwarded headers, and final upstream host have been applied.
+
+To enable this finalizer, set the `type` property to `http_message_signatures`.
+
+Configuration using the `config` property is mandatory. The following properties are available:
+
+* *`signer`*: _link:{{< relref "/docs/configuration/types.adoc#_signer" >}}[Signer]_ (mandatory, not overridable)
++
+Defines the key material used to sign the upstream HTTP message. The `name` property is used as the HTTP Message Signatures `tag` parameter. If omitted, it defaults to `heimdall`.
+
+* *`components`*: _string array_ (mandatory, overridable)
++
+The HTTP message components that must be covered by the signature. Use `@authority` for request authority coverage. The literal `host` field is rejected because it does not consistently represent authority across HTTP versions.
+
+* *`ttl`*: _link:{{< relref "/docs/configuration/types.adoc#_duration" >}}[Duration]_ (optional, overridable)
++
+Defines the signature validity period. Defaults to `1m`.
+
+* *`label`*: _string_ (optional, overridable)
++
+The signature label used in the `Signature` and `Signature-Input` headers. Defaults to `sig`.
+
+* *`max_body_size`*: _link:{{< relref "/docs/configuration/types.adoc#_bytesize" >}}[ByteSize]_ (optional, overridable)
++
+Maximum request body size that can be read while signing components such as `content-digest`. Defaults to `1MB`.
+
+.HTTP Message Signatures finalizer configuration
+====
+[source, yaml]
+----
+id: upstream_hms
+type: http_message_signatures
+config:
+  signer:
+    name: heimdall
+    secret:
+      source: key_store
+      selector: upstream_hms_key
+  components:
+    - "@method"
+    - "@authority"
+    - "@path"
+    - "content-digest"
+    - "content-type"
+    - "content-length"
+  ttl: 1m
+----
+====
+
 == OAuth2 Client Credentials
 
 This finalizer drives the https://www.rfc-editor.org/rfc/rfc6749#section-4.4[OAuth2 Client Credentials Grant] flow to obtain a token, which should be used for communication with the upstream service. By default, as long as not otherwise configured (see the options below), the obtained token is made available to your upstream service in the HTTP `Authorization` header with `Bearer` scheme set. Unlike the other finalizers, it does not have access to any objects created by the rule execution pipeline.

--- a/internal/handler/decision/request_context.go
+++ b/internal/handler/decision/request_context.go
@@ -87,6 +87,10 @@ func (r *requestContext) Finalize(_ pipeline.Backend) error {
 
 	zerolog.Ctx(r.Context()).Debug().Msg("Creating response")
 
+	if err := r.applyHTTPMessageFinalizers(); err != nil {
+		return err
+	}
+
 	uh := r.UpstreamHeaders()
 	for name, values := range uh {
 		for _, value := range values {
@@ -101,4 +105,55 @@ func (r *requestContext) Finalize(_ pipeline.Backend) error {
 	r.rw.WriteHeader(r.responseCode)
 
 	return nil
+}
+
+func (r *requestContext) applyHTTPMessageFinalizers() error {
+	finalizers := r.HTTPMessageFinalizersForUpstream()
+	if len(finalizers) == 0 {
+		return nil
+	}
+
+	msg, err := r.HTTPMessage()
+	if err != nil {
+		return err
+	}
+
+	msg.Header = r.upstreamHeaderView(msg.Header)
+
+	header, err := pipeline.ApplyHTTPMessageFinalizers(msg, finalizers...)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range []string{"Content-Digest", "Signature", "Signature-Input"} {
+		r.UpstreamHeaders().Del(name)
+
+		for _, value := range header.Values(name) {
+			r.AddHeaderForUpstream(name, value)
+		}
+	}
+
+	if cookie := header.Get("Cookie"); len(r.UpstreamCookies()) != 0 && len(cookie) != 0 {
+		r.UpstreamHeaders().Set("Cookie", cookie)
+	}
+
+	return nil
+}
+
+func (r *requestContext) upstreamHeaderView(header http.Header) http.Header {
+	res := header.Clone()
+
+	for name, values := range r.UpstreamHeaders() {
+		res.Del(name)
+
+		for _, value := range values {
+			res.Add(name, value)
+		}
+	}
+
+	if cookie := requestcontext.CookieHeader(r.UpstreamCookies()); len(cookie) != 0 {
+		res.Set("Cookie", cookie)
+	}
+
+	return res
 }

--- a/internal/handler/decision/service_test.go
+++ b/internal/handler/decision/service_test.go
@@ -17,9 +17,11 @@
 package decision
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -31,6 +33,7 @@ import (
 	"github.com/dadrus/heimdall/internal/cache/mocks"
 	"github.com/dadrus/heimdall/internal/config"
 	"github.com/dadrus/heimdall/internal/handler/listener"
+	"github.com/dadrus/heimdall/internal/handler/testsupport/hmstest"
 	"github.com/dadrus/heimdall/internal/pipeline"
 	mocks2 "github.com/dadrus/heimdall/internal/pipeline/mocks"
 	"github.com/dadrus/heimdall/internal/x/testsupport"
@@ -578,4 +581,156 @@ func TestHandleDecisionEndpointRequest(t *testing.T) {
 			tc.assertResponse(t, err, resp)
 		})
 	}
+}
+
+func TestDecisionServiceHTTPMessageSignaturesAuthenticator(t *testing.T) {
+	t.Parallel()
+
+	port, err := testsupport.GetFreePort()
+	require.NoError(t, err)
+
+	privateKey := hmstest.NewEd25519PrivateKey(t)
+	authenticator := hmstest.NewHTTPMessageSignaturesAuthenticatorStep(
+		t,
+		privateKey,
+		hmstest.RequestWithDigestComponents(),
+	)
+
+	exec := mocks2.NewExecutorMock(t)
+	exec.EXPECT().Execute(mock.Anything).RunAndReturn(func(ctx pipeline.Context) (pipeline.Backend, error) {
+		sub := make(pipeline.Subject)
+
+		return nil, authenticator.Execute(ctx, sub)
+	})
+
+	conf := &config.Configuration{
+		Serve: config.ServeConfig{
+			Timeout: config.Timeout{
+				Read:  time.Second,
+				Write: time.Second,
+				Idle:  time.Second,
+			},
+			Host: "127.0.0.1",
+			Port: port,
+		},
+	}
+
+	decision := newService(conf, mocks.NewCacheMock(t), log.Logger, exec)
+	defer decision.Shutdown(t.Context())
+
+	factory, err := listener.NewFactory(conf.Serve.Address(), conf.Serve.TLS, nil)
+	require.NoError(t, err)
+
+	lstnr, err := factory.Create(t.Context())
+	require.NoError(t, err)
+
+	go func() {
+		_ = decision.Serve(lstnr)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	body := []byte(`{"message":"hello"}`)
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		fmt.Sprintf("http://%s/foo", conf.Serve.Address()),
+		bytes.NewReader(body),
+	)
+	require.NoError(t, err)
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	hmstest.SignRequest(t, req, privateKey, hmstest.RequestWithDigestComponents())
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestDecisionServiceHTTPMessageSignaturesFinalizer(t *testing.T) {
+	t.Parallel()
+
+	port, err := testsupport.GetFreePort()
+	require.NoError(t, err)
+
+	privateKey := hmstest.NewEd25519PrivateKey(t)
+	finalizer := hmstest.NewHTTPMessageSignaturesFinalizerStep(
+		t,
+		privateKey,
+		hmstest.RequestWithDigestComponents(),
+	)
+
+	exec := mocks2.NewExecutorMock(t)
+	exec.EXPECT().Execute(mock.Anything).RunAndReturn(func(ctx pipeline.Context) (pipeline.Backend, error) {
+		return nil, finalizer.Execute(ctx, make(pipeline.Subject))
+	})
+
+	conf := &config.Configuration{
+		Serve: config.ServeConfig{
+			Timeout: config.Timeout{
+				Read:  time.Second,
+				Write: time.Second,
+				Idle:  time.Second,
+			},
+			Host: "127.0.0.1",
+			Port: port,
+		},
+	}
+
+	decision := newService(conf, mocks.NewCacheMock(t), log.Logger, exec)
+	defer decision.Shutdown(t.Context())
+
+	factory, err := listener.NewFactory(conf.Serve.Address(), conf.Serve.TLS, nil)
+	require.NoError(t, err)
+
+	lstnr, err := factory.Create(t.Context())
+	require.NoError(t, err)
+
+	go func() {
+		_ = decision.Serve(lstnr)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	body := []byte(`{"message":"hello"}`)
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		fmt.Sprintf("http://%s/foo", conf.Serve.Address()),
+		bytes.NewReader(body),
+	)
+	require.NoError(t, err)
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.NotEmpty(t, resp.Header.Get("Signature"))
+	assert.NotEmpty(t, resp.Header.Get("Signature-Input"))
+	assert.NotEmpty(t, resp.Header.Get("Content-Digest"))
+
+	signedReq, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		fmt.Sprintf("http://%s/foo", conf.Serve.Address()),
+		bytes.NewReader(body),
+	)
+	require.NoError(t, err)
+
+	signedReq.Header.Set("Content-Type", "application/json")
+	signedReq.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	signedReq.Header.Set("Signature", resp.Header.Get("Signature"))
+	signedReq.Header.Set("Signature-Input", resp.Header.Get("Signature-Input"))
+	signedReq.Header.Set("Content-Digest", resp.Header.Get("Content-Digest"))
+
+	hmstest.VerifyRequest(t, signedReq, privateKey, hmstest.RequestWithDigestComponents())
 }

--- a/internal/handler/envoyextauth/grpcv3/request_context.go
+++ b/internal/handler/envoyextauth/grpcv3/request_context.go
@@ -17,7 +17,9 @@
 package grpcv3
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -30,6 +32,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/dadrus/heimdall/internal/handler/requestcontext"
 	"github.com/dadrus/heimdall/internal/pipeline"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/contenttype"
 	"github.com/dadrus/heimdall/internal/x"
@@ -68,6 +71,7 @@ type RequestContext struct {
 	reqRawBody      []byte
 	upstreamHeaders http.Header
 	upstreamCookies map[string]string
+	upstreamHMFs    []pipeline.HTTPMessageFinalizer
 	err             error
 	hmdlReq         *pipeline.Request
 
@@ -136,6 +140,7 @@ func (r *RequestContext) Reset() {
 	r.reqRawBody = nil
 	r.savedBody = nil
 	r.err = nil
+	r.upstreamHMFs = r.upstreamHMFs[:0]
 
 	clear(r.upstreamHeaders)
 	clear(r.upstreamCookies)
@@ -160,6 +165,36 @@ func canonicalizeHeaders(headers map[string]string) map[string]string {
 func (r *RequestContext) Request() *pipeline.Request { return r.hmdlReq }
 func (r *RequestContext) Headers() map[string]string { return r.reqHeaders }
 func (r *RequestContext) Header(name string) string  { return r.reqHeaders[name] }
+
+func (r *RequestContext) HTTPMessage(options ...pipeline.HTTPMessageOption) (*pipeline.HTTPMessage, error) {
+	header := make(http.Header, len(r.reqHeaders))
+	for name, value := range r.reqHeaders {
+		if name != "Host" {
+			header.Set(name, value)
+		}
+	}
+
+	opts := pipeline.NewHTTPMessageOptions(options...)
+
+	return &pipeline.HTTPMessage{
+		Context:   r.ctx,
+		Method:    r.hmdlReq.Method,
+		Authority: r.hmdlReq.URL.Host,
+		URL:       new(r.hmdlReq.URL.URL),
+		Header:    header,
+		Body: func() (io.ReadCloser, error) {
+			if r.reqRawBody == nil {
+				return http.NoBody, nil
+			}
+
+			if opts.MaxBodySize > 0 && int64(len(r.reqRawBody)) > opts.MaxBodySize {
+				return nil, pipeline.ErrHTTPMessageBodyTooLarge
+			}
+
+			return io.NopCloser(bytes.NewReader(r.reqRawBody)), nil
+		},
+	}, nil
+}
 
 func (r *RequestContext) Cookie(name string) string {
 	values, ok := r.reqHeaders["Cookie"]
@@ -204,6 +239,13 @@ func (r *RequestContext) Error() error                            { return r.err
 func (r *RequestContext) AddHeaderForUpstream(name, value string) { r.upstreamHeaders.Add(name, value) }
 func (r *RequestContext) AddCookieForUpstream(name, value string) { r.upstreamCookies[name] = value }
 func (r *RequestContext) Outputs() map[string]any                 { return r.outputs }
+func (r *RequestContext) AddHTTPMessageFinalizerForUpstream(finalizer pipeline.HTTPMessageFinalizer) {
+	r.upstreamHMFs = append(r.upstreamHMFs, finalizer)
+}
+
+func (r *RequestContext) HTTPMessageFinalizersForUpstream() []pipeline.HTTPMessageFinalizer {
+	return r.upstreamHMFs
+}
 
 func (r *RequestContext) WithParent(ctx context.Context) pipeline.Context {
 	r.ctx = ctx
@@ -217,6 +259,10 @@ func (r *RequestContext) Finalize() (*envoy_auth.CheckResponse, error) {
 	}
 
 	zerolog.Ctx(r.ctx).Debug().Msg("Creating response")
+
+	if err := r.applyHTTPMessageFinalizers(); err != nil {
+		return nil, err
+	}
 
 	headers := make([]*envoy_core.HeaderValueOption,
 		len(r.upstreamHeaders)+x.IfThenElse(len(r.upstreamCookies) == 0, 0, 1))
@@ -233,19 +279,11 @@ func (r *RequestContext) Finalize() (*envoy_auth.CheckResponse, error) {
 		hidx++
 	}
 
-	if len(r.upstreamCookies) != 0 {
-		cookies := make([]string, len(r.upstreamCookies))
-		cidx := 0
-
-		for k, v := range r.upstreamCookies {
-			cookies[cidx] = k + "=" + v
-			cidx++
-		}
-
+	if cookie := requestcontext.CookieHeader(r.upstreamCookies); len(cookie) != 0 {
 		headers[hidx] = &envoy_core.HeaderValueOption{
 			Header: &envoy_core.HeaderValue{
 				Key:   "Cookie",
-				Value: strings.Join(cookies, ";"),
+				Value: cookie,
 			},
 		}
 	}
@@ -256,4 +294,51 @@ func (r *RequestContext) Finalize() (*envoy_auth.CheckResponse, error) {
 			OkResponse: &envoy_auth.OkHttpResponse{Headers: headers},
 		},
 	}, nil
+}
+
+func (r *RequestContext) applyHTTPMessageFinalizers() error {
+	finalizers := r.HTTPMessageFinalizersForUpstream()
+	if len(finalizers) == 0 {
+		return nil
+	}
+
+	msg, err := r.HTTPMessage()
+	if err != nil {
+		return err
+	}
+
+	msg.Header = r.upstreamHeaderView(msg.Header)
+
+	header, err := pipeline.ApplyHTTPMessageFinalizers(msg, finalizers...)
+	if err != nil {
+		return err
+	}
+
+	for _, name := range []string{"Content-Digest", "Signature", "Signature-Input"} {
+		r.upstreamHeaders.Del(name)
+
+		for _, value := range header.Values(name) {
+			r.AddHeaderForUpstream(name, value)
+		}
+	}
+
+	return nil
+}
+
+func (r *RequestContext) upstreamHeaderView(header http.Header) http.Header {
+	res := header.Clone()
+
+	for name, values := range r.upstreamHeaders {
+		res.Del(name)
+
+		for _, value := range values {
+			res.Add(name, value)
+		}
+	}
+
+	if cookie := requestcontext.CookieHeader(r.upstreamCookies); len(cookie) != 0 {
+		res.Set("Cookie", cookie)
+	}
+
+	return res
 }

--- a/internal/handler/envoyextauth/grpcv3/request_context_test.go
+++ b/internal/handler/envoyextauth/grpcv3/request_context_test.go
@@ -18,8 +18,8 @@ package grpcv3
 
 import (
 	"context"
+	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -161,6 +161,82 @@ func TestNewRequestContextXForwardedForMixedValues(t *testing.T) {
 	assert.Equal(t, []string{"127.0.0.1", "192.168.1.1", "10.0.0.2"}, ctx.Request().ClientIPAddresses)
 }
 
+func TestRequestContextHTTPMessage(t *testing.T) {
+	t.Parallel()
+
+	rawBody := []byte(`{"message":"hello"}`)
+	checkReq := &envoy_auth.CheckRequest{
+		Attributes: &envoy_auth.AttributeContext{
+			Request: &envoy_auth.AttributeContext_Request{
+				Http: &envoy_auth.AttributeContext_HttpRequest{
+					Method:  http.MethodPost,
+					Scheme:  "https",
+					Host:    "api.example.test",
+					Path:    "/foo?bar=baz",
+					RawBody: rawBody,
+					Headers: map[string]string{
+						"content-type":   "application/json",
+						"content-length": "19",
+					},
+				},
+			},
+		},
+	}
+
+	cf := newContextFactory()
+
+	ctx := cf.Create(t.Context(), checkReq)
+	defer cf.Destroy(ctx)
+
+	msg, err := ctx.HTTPMessage()
+
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	assert.Equal(t, http.MethodPost, msg.Method)
+	assert.Equal(t, "https://api.example.test/foo?bar=baz", msg.URL.String())
+	assert.Equal(t, "api.example.test", msg.Authority)
+	assert.Equal(t, "application/json", msg.Header.Get("Content-Type"))
+	assert.Equal(t, "19", msg.Header.Get("Content-Length"))
+
+	bodyReader, err := msg.Body()
+	require.NoError(t, err)
+
+	body, err := io.ReadAll(bodyReader)
+	require.NoError(t, err)
+	assert.Equal(t, rawBody, body)
+}
+
+func TestRequestContextHTTPMessageRejectsBodyOverMaxBodySize(t *testing.T) {
+	t.Parallel()
+
+	checkReq := &envoy_auth.CheckRequest{
+		Attributes: &envoy_auth.AttributeContext{
+			Request: &envoy_auth.AttributeContext_Request{
+				Http: &envoy_auth.AttributeContext_HttpRequest{
+					Method:  http.MethodPost,
+					Scheme:  "https",
+					Host:    "api.example.test",
+					Path:    "/foo",
+					RawBody: []byte(`{"message":"hello"}`),
+				},
+			},
+		},
+	}
+
+	cf := newContextFactory()
+
+	ctx := cf.Create(t.Context(), checkReq)
+	defer cf.Destroy(ctx)
+
+	msg, err := ctx.HTTPMessage(pipeline.WithMaxHTTPMessageBodySize(4))
+	require.NoError(t, err)
+
+	bodyReader, err := msg.Body()
+
+	require.ErrorIs(t, err, pipeline.ErrHTTPMessageBodyTooLarge)
+	assert.Nil(t, bodyReader)
+}
+
 func TestRequestContextFinalize(t *testing.T) {
 	t.Parallel()
 
@@ -255,10 +331,11 @@ func TestRequestContextFinalize(t *testing.T) {
 
 				require.Len(t, okResponse.GetHeaders(), 1)
 				assert.Equal(t, "Cookie", okResponse.GetHeaders()[0].GetHeader().GetKey())
-				values := strings.Split(okResponse.GetHeaders()[0].GetHeader().GetValue(), ";")
-				assert.Len(t, values, 2)
-				assert.Contains(t, okResponse.GetHeaders()[0].GetHeader().GetValue(), "some-cookie=value-1")
-				assert.Contains(t, okResponse.GetHeaders()[0].GetHeader().GetValue(), "some-other-cookie=value-2")
+				assert.Equal(
+					t,
+					"some-cookie=value-1; some-other-cookie=value-2",
+					okResponse.GetHeaders()[0].GetHeader().GetValue(),
+				)
 			},
 		},
 		"successful with multiple header and cookie": {

--- a/internal/handler/proxy/request_context.go
+++ b/internal/handler/proxy/request_context.go
@@ -18,6 +18,7 @@ package proxy
 
 import (
 	"crypto/tls"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -136,15 +137,17 @@ func (r *requestContext) Finalize(upstream pipeline.Backend) error {
 		ErrorHandler: func(_ http.ResponseWriter, _ *http.Request, err error) {
 			logger.Error().Err(err).Msg("Proxying error")
 
-			errHolder.err = errorchain.NewWithMessage(pipeline.ErrCommunication, "Failed to proxy request").
-				CausedBy(err)
+			errHolder.err = proxyError(err)
 		},
 		Rewrite: r.rewriteRequest(upstream.URL(), upstream.ForwardHostHeader()),
-		Transport: otelhttp.NewTransport(
-			httpx.NewTraceRoundTripper(r.rt),
-			otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
-				return r.Proto + " " + r.Method + " " + r.URL.Path + " @" + r.URL.Host
-			})),
+		Transport: &httpMessageFinalizingRoundTripper{
+			base: otelhttp.NewTransport(
+				httpx.NewTraceRoundTripper(r.rt),
+				otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
+					return r.Proto + " " + r.Method + " " + r.URL.Path + " @" + r.URL.Host
+				})),
+			finalizers: r.HTTPMessageFinalizersForUpstream,
+		},
 	}
 
 	proxy.ServeHTTP(r.rw, r.req)
@@ -175,6 +178,57 @@ func (r *requestContext) rewriteRequest(targetURL *url.URL, passHostHeader bool)
 			proxyReq.Out.Host = proxyReq.In.Host
 		}
 	}
+}
+
+type httpMessageFinalizingRoundTripper struct {
+	base       http.RoundTripper
+	finalizers func() []pipeline.HTTPMessageFinalizer
+}
+
+func (rt *httpMessageFinalizingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	finalizers := rt.finalizers()
+	if len(finalizers) == 0 {
+		return rt.base.RoundTrip(req)
+	}
+
+	header, err := pipeline.ApplyHTTPMessageFinalizers(
+		pipeline.HTTPMessageFromHTTPRequest(
+			req,
+			pipeline.WithMaxHTTPMessageBodySize(pipeline.MaxHTTPMessageFinalizerBodySize(finalizers...)),
+		),
+		finalizers...,
+	)
+	if err != nil {
+		return nil, errorchain.NewWithMessage(
+			pipeline.ErrInternal,
+			"failed to finalize upstream http message",
+		).CausedBy(err)
+	}
+
+	req.Header = header
+
+	return rt.base.RoundTrip(req)
+}
+
+func proxyError(err error) error {
+	for _, target := range []error{
+		pipeline.ErrArgument,
+		pipeline.ErrAuthentication,
+		pipeline.ErrAuthorization,
+		pipeline.ErrCommunication,
+		pipeline.ErrCommunicationTimeout,
+		pipeline.ErrConfiguration,
+		pipeline.ErrInternal,
+		pipeline.ErrNoRuleFound,
+		pipeline.ErrMalformedRequest,
+	} {
+		if errors.Is(err, target) {
+			return err
+		}
+	}
+
+	return errorchain.NewWithMessage(pipeline.ErrCommunication, "Failed to proxy request").
+		CausedBy(err)
 }
 
 func (r *requestContext) rewriteForwardedHeader(in, out *http.Request) {

--- a/internal/handler/proxy/service_test.go
+++ b/internal/handler/proxy/service_test.go
@@ -17,6 +17,7 @@
 package proxy
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -36,6 +37,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/inhies/go-bytesize"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -48,6 +50,7 @@ import (
 	"github.com/dadrus/heimdall/internal/cache/mocks"
 	"github.com/dadrus/heimdall/internal/config"
 	"github.com/dadrus/heimdall/internal/handler/listener"
+	"github.com/dadrus/heimdall/internal/handler/testsupport/hmstest"
 	"github.com/dadrus/heimdall/internal/pipeline"
 	mocks2 "github.com/dadrus/heimdall/internal/pipeline/mocks"
 	"github.com/dadrus/heimdall/internal/secrets"
@@ -1078,6 +1081,277 @@ func TestProxyService(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestProxyServiceHTTPMessageSignaturesAuthenticator(t *testing.T) {
+	t.Parallel()
+
+	port, err := testsupport.GetFreePort()
+	require.NoError(t, err)
+
+	body := []byte(`{"message":"hello"}`)
+	upstreamCalled := false
+
+	upstreamSrv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		upstreamCalled = true
+
+		receivedBody, err := io.ReadAll(req.Body)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Equal(t, body, receivedBody)
+
+		rw.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstreamSrv.Close()
+
+	upstreamURL, err := url.Parse(upstreamSrv.URL)
+	require.NoError(t, err)
+
+	privateKey := hmstest.NewEd25519PrivateKey(t)
+	authenticator := hmstest.NewHTTPMessageSignaturesAuthenticatorStep(
+		t,
+		privateKey,
+		hmstest.RequestWithDigestComponents(),
+	)
+
+	exec := mocks2.NewExecutorMock(t)
+	exec.EXPECT().Execute(mock.Anything).RunAndReturn(func(ctx pipeline.Context) (pipeline.Backend, error) {
+		sub := make(pipeline.Subject)
+		if err := authenticator.Execute(ctx, sub); err != nil {
+			return nil, err
+		}
+
+		return hmstest.Backend{Target: upstreamURL, ForwardHost: false}, nil
+	})
+
+	conf := &config.Configuration{
+		Serve: config.ServeConfig{
+			Timeout: config.Timeout{
+				Read:  time.Second,
+				Write: time.Second,
+				Idle:  time.Second,
+			},
+			Host: "127.0.0.1",
+			Port: port,
+		},
+	}
+
+	proxy := newService(conf, mocks.NewCacheMock(t), log.Logger, exec)
+	defer proxy.Shutdown(t.Context())
+
+	factory, err := listener.NewFactory(conf.Serve.Address(), conf.Serve.TLS, nil)
+	require.NoError(t, err)
+
+	lstnr, err := factory.Create(t.Context())
+	require.NoError(t, err)
+
+	go func() {
+		_ = proxy.Serve(lstnr)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		fmt.Sprintf("http://%s/foo", conf.Serve.Address()),
+		bytes.NewReader(body),
+	)
+	require.NoError(t, err)
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	hmstest.SignRequest(t, req, privateKey, hmstest.RequestWithDigestComponents())
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.True(t, upstreamCalled)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestProxyServiceHTTPMessageSignaturesFinalizer(t *testing.T) {
+	t.Parallel()
+
+	port, err := testsupport.GetFreePort()
+	require.NoError(t, err)
+
+	body := []byte(`{"message":"hello"}`)
+	privateKey := hmstest.NewEd25519PrivateKey(t)
+	upstreamCalled := false
+
+	upstreamSrv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		upstreamCalled = true
+
+		assert.Equal(t, http.MethodPost, req.Method)
+		assert.Equal(t, "/signed", req.URL.Path)
+		assert.Empty(t, req.URL.Host)
+		assert.NotEmpty(t, req.Header.Get("Signature"))
+		assert.NotEmpty(t, req.Header.Get("Signature-Input"))
+		assert.NotEmpty(t, req.Header.Get("Content-Digest"))
+
+		hmstest.VerifyRequest(t, req, privateKey, hmstest.RequestWithDigestComponents())
+
+		receivedBody, err := io.ReadAll(req.Body)
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Equal(t, body, receivedBody)
+
+		rw.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstreamSrv.Close()
+
+	upstreamURL, err := url.Parse(upstreamSrv.URL + "/signed")
+	require.NoError(t, err)
+
+	finalizer := hmstest.NewHTTPMessageSignaturesFinalizerStep(
+		t,
+		privateKey,
+		hmstest.RequestWithDigestComponents(),
+	)
+
+	exec := mocks2.NewExecutorMock(t)
+	exec.EXPECT().Execute(mock.Anything).RunAndReturn(func(ctx pipeline.Context) (pipeline.Backend, error) {
+		if err := finalizer.Execute(ctx, make(pipeline.Subject)); err != nil {
+			return nil, err
+		}
+
+		return hmstest.Backend{Target: upstreamURL, ForwardHost: false}, nil
+	})
+
+	conf := &config.Configuration{
+		Serve: config.ServeConfig{
+			Timeout: config.Timeout{
+				Read:  time.Second,
+				Write: time.Second,
+				Idle:  time.Second,
+			},
+			Host: "127.0.0.1",
+			Port: port,
+		},
+	}
+
+	proxy := newService(conf, mocks.NewCacheMock(t), log.Logger, exec)
+	defer proxy.Shutdown(t.Context())
+
+	factory, err := listener.NewFactory(conf.Serve.Address(), conf.Serve.TLS, nil)
+	require.NoError(t, err)
+
+	lstnr, err := factory.Create(t.Context())
+	require.NoError(t, err)
+
+	go func() {
+		_ = proxy.Serve(lstnr)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		fmt.Sprintf("http://%s/original", conf.Serve.Address()),
+		bytes.NewReader(body),
+	)
+	require.NoError(t, err)
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.True(t, upstreamCalled)
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestProxyServiceHTTPMessageSignaturesFinalizerRejectsOversizedBody(t *testing.T) {
+	t.Parallel()
+
+	port, err := testsupport.GetFreePort()
+	require.NoError(t, err)
+
+	privateKey := hmstest.NewEd25519PrivateKey(t)
+	upstreamCalled := false
+
+	upstreamSrv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		upstreamCalled = true
+
+		rw.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstreamSrv.Close()
+
+	upstreamURL, err := url.Parse(upstreamSrv.URL + "/signed")
+	require.NoError(t, err)
+
+	finalizer := hmstest.NewHTTPMessageSignaturesFinalizerStep(
+		t,
+		privateKey,
+		hmstest.RequestWithDigestComponents(),
+		4*bytesize.B,
+	)
+
+	exec := mocks2.NewExecutorMock(t)
+	exec.EXPECT().Execute(mock.Anything).RunAndReturn(func(ctx pipeline.Context) (pipeline.Backend, error) {
+		if err := finalizer.Execute(ctx, make(pipeline.Subject)); err != nil {
+			return nil, err
+		}
+
+		return hmstest.Backend{Target: upstreamURL, ForwardHost: false}, nil
+	})
+
+	conf := &config.Configuration{
+		Serve: config.ServeConfig{
+			Timeout: config.Timeout{
+				Read:  time.Second,
+				Write: time.Second,
+				Idle:  time.Second,
+			},
+			Host: "127.0.0.1",
+			Port: port,
+		},
+	}
+
+	proxy := newService(conf, mocks.NewCacheMock(t), log.Logger, exec)
+	defer proxy.Shutdown(t.Context())
+
+	factory, err := listener.NewFactory(conf.Serve.Address(), conf.Serve.TLS, nil)
+	require.NoError(t, err)
+
+	lstnr, err := factory.Create(t.Context())
+	require.NoError(t, err)
+
+	go func() {
+		_ = proxy.Serve(lstnr)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	req, err := http.NewRequestWithContext(
+		t.Context(),
+		http.MethodPost,
+		fmt.Sprintf("http://%s/original", conf.Serve.Address()),
+		strings.NewReader("too large"),
+	)
+	require.NoError(t, err)
+
+	req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("Content-Length", "9")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	assert.False(t, upstreamCalled)
+	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
 }
 
 func TestWebSocketSupport(t *testing.T) {

--- a/internal/handler/requestcontext/request_context.go
+++ b/internal/handler/requestcontext/request_context.go
@@ -20,9 +20,11 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"math"
 	"net/http"
 	"net/textproto"
 	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/dadrus/heimdall/internal/pipeline"
@@ -33,6 +35,7 @@ import (
 type RequestContext struct {
 	upstreamHeaders http.Header
 	upstreamCookies map[string]string
+	upstreamHMFs    []pipeline.HTTPMessageFinalizer
 	hmdlReq         *pipeline.Request
 	req             *http.Request
 	ctx             context.Context //nolint: containedctx
@@ -74,6 +77,7 @@ func (r *RequestContext) Reset() {
 	r.err = nil
 	r.req = nil
 	r.ctx = nil
+	r.upstreamHMFs = r.upstreamHMFs[:0]
 
 	clear(r.outputs)
 	clear(r.headers)
@@ -153,20 +157,116 @@ func (r *RequestContext) Body() any {
 	return r.savedBody
 }
 
+func (r *RequestContext) HTTPMessage(options ...pipeline.HTTPMessageOption) (*pipeline.HTTPMessage, error) {
+	var (
+		getBody      func() (io.ReadCloser, error)
+		bodySnapshot []byte
+	)
+
+	opts := pipeline.NewHTTPMessageOptions(options...)
+
+	switch {
+	case r.req.GetBody != nil:
+		getBody = r.req.GetBody
+	case r.req.Body == nil || r.req.Body == http.NoBody:
+		getBody = func() (io.ReadCloser, error) { return http.NoBody, nil }
+	default:
+		getBody = func() (io.ReadCloser, error) {
+			if len(bodySnapshot) != 0 {
+				return io.NopCloser(bytes.NewReader(bodySnapshot)), nil
+			}
+
+			body, err := readRequestBody(r.req.Body, opts.MaxBodySize)
+			if err != nil {
+				_ = r.req.Body.Close()
+
+				return nil, err
+			}
+
+			if err := r.req.Body.Close(); err != nil {
+				return nil, err
+			}
+
+			bodySnapshot = body
+			r.req.Body = io.NopCloser(bytes.NewReader(bodySnapshot))
+
+			return io.NopCloser(bytes.NewReader(bodySnapshot)), nil
+		}
+	}
+
+	return &pipeline.HTTPMessage{
+		Context:   r.ctx,
+		Method:    r.hmdlReq.Method,
+		Authority: r.hmdlReq.URL.Host,
+		URL:       new(r.hmdlReq.URL.URL),
+		Header:    r.req.Header.Clone(),
+		Body:      getBody,
+	}, nil
+}
+
+func readRequestBody(body io.Reader, maxBodySize int64) ([]byte, error) {
+	var (
+		buf    bytes.Buffer
+		reader = body
+	)
+
+	if maxBodySize > 0 && maxBodySize < math.MaxInt64 {
+		reader = io.LimitReader(body, maxBodySize+1)
+	}
+
+	if _, err := buf.ReadFrom(reader); err != nil {
+		return nil, err
+	}
+
+	if maxBodySize > 0 && int64(buf.Len()) > maxBodySize {
+		return nil, pipeline.ErrHTTPMessageBodyTooLarge
+	}
+
+	return buf.Bytes(), nil
+}
+
 func (r *RequestContext) Request() *pipeline.Request              { return r.hmdlReq }
 func (r *RequestContext) AddHeaderForUpstream(name, value string) { r.upstreamHeaders.Add(name, value) }
 func (r *RequestContext) UpstreamHeaders() http.Header            { return r.upstreamHeaders }
 func (r *RequestContext) AddCookieForUpstream(name, value string) { r.upstreamCookies[name] = value }
 func (r *RequestContext) UpstreamCookies() map[string]string      { return r.upstreamCookies }
-func (r *RequestContext) Context() context.Context                { return r.ctx }
-func (r *RequestContext) SetError(err error)                      { r.err = err }
-func (r *RequestContext) Error() error                            { return r.err }
-func (r *RequestContext) Outputs() map[string]any                 { return r.outputs }
+func (r *RequestContext) AddHTTPMessageFinalizerForUpstream(finalizer pipeline.HTTPMessageFinalizer) {
+	r.upstreamHMFs = append(r.upstreamHMFs, finalizer)
+}
+
+func (r *RequestContext) HTTPMessageFinalizersForUpstream() []pipeline.HTTPMessageFinalizer {
+	return r.upstreamHMFs
+}
+
+func (r *RequestContext) Context() context.Context { return r.ctx }
+func (r *RequestContext) SetError(err error)       { r.err = err }
+func (r *RequestContext) Error() error             { return r.err }
+func (r *RequestContext) Outputs() map[string]any  { return r.outputs }
 
 func (r *RequestContext) WithParent(ctx context.Context) pipeline.Context {
 	r.ctx = ctx
 
 	return r
+}
+
+func CookieHeader(cookies map[string]string) string {
+	if len(cookies) == 0 {
+		return ""
+	}
+
+	names := make([]string, 0, len(cookies))
+	for name := range cookies {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	req := http.Request{Header: make(http.Header, 1)}
+	for _, name := range names {
+		req.AddCookie(&http.Cookie{Name: name, Value: cookies[name]})
+	}
+
+	return req.Header.Get("Cookie")
 }
 
 func requestClientIPs(ips []string, req *http.Request) []string {

--- a/internal/handler/testsupport/hmstest/hmstest.go
+++ b/internal/handler/testsupport/hmstest/hmstest.go
@@ -1,0 +1,252 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hmstest
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/dadrus/httpsig"
+	"github.com/inhies/go-bytesize"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dadrus/heimdall/internal/app"
+	"github.com/dadrus/heimdall/internal/config"
+	"github.com/dadrus/heimdall/internal/encoding"
+	"github.com/dadrus/heimdall/internal/pipeline"
+	_ "github.com/dadrus/heimdall/internal/rules/mechanisms/authenticators" // registers authenticators
+	_ "github.com/dadrus/heimdall/internal/rules/mechanisms/finalizers"     // registers finalizers
+	"github.com/dadrus/heimdall/internal/rules/mechanisms/registry"
+	"github.com/dadrus/heimdall/internal/rules/mechanisms/types"
+	"github.com/dadrus/heimdall/internal/secrets"
+	secretsmocks "github.com/dadrus/heimdall/internal/secrets/mocks"
+	secrettypes "github.com/dadrus/heimdall/internal/secrets/types"
+	"github.com/dadrus/heimdall/internal/validation"
+)
+
+const (
+	KeyID    = "test-key"
+	KeySet   = "hms_keys"
+	Selector = "clients"
+	Tag      = "hms"
+)
+
+func RequestWithDigestComponents() []string {
+	return []string{
+		"@method",
+		"@authority",
+		"@path",
+		"content-digest",
+		"content-length",
+		"content-type",
+	}
+}
+
+func NewEd25519PrivateKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	return privateKey
+}
+
+func NewHTTPMessageSignaturesAuthenticatorStep(
+	t *testing.T,
+	privateKey ed25519.PrivateKey,
+	components []string,
+) pipeline.Step {
+	t.Helper()
+
+	validator, err := validation.NewValidator()
+	require.NoError(t, err)
+
+	resolver := secretsmocks.NewResolverMock(t)
+	handle := secretsmocks.NewSecretSetHandleMock(t)
+
+	resolver.EXPECT().
+		SecretSet(secrets.Reference{Source: KeySet, Selector: Selector}).
+		Return(handle, nil)
+
+	handle.EXPECT().
+		OnUpdate(mock.MatchedBy(func(cb secrets.UpdateFunc[[]secrets.Secret]) bool {
+			err := cb(t.Context(), []secrets.Secret{
+				secrettypes.NewAsymmetricKeySecret(KeyID, KeyID, privateKey, nil),
+			})
+			require.NoError(t, err)
+
+			return true
+		}))
+
+	appCtx := app.NewContextMock(t)
+	appCtx.EXPECT().Logger().Return(log.Logger)
+	appCtx.EXPECT().SecretResolver().Maybe().Return(resolver)
+	appCtx.EXPECT().
+		DecoderFactory().
+		Return(encoding.NewDecoderFactory(encoding.ValidatorFunc(validator.ValidateStruct)))
+
+	rawComponents := make([]any, 0, len(components))
+	for _, component := range components {
+		rawComponents = append(rawComponents, component)
+	}
+
+	mechanism, err := registry.Create(appCtx,
+		types.KindAuthenticator,
+		"http_message_signatures",
+		"hms",
+		config.MechanismConfig{
+			"key_store": map[string]any{
+				"source":   KeySet,
+				"selector": Selector,
+			},
+			"required_components": rawComponents,
+			"tag":                 Tag,
+		})
+	require.NoError(t, err)
+
+	step, err := mechanism.CreateStep(resolver, types.StepDefinition{})
+	require.NoError(t, err)
+
+	return step
+}
+
+func NewHTTPMessageSignaturesFinalizerStep(
+	t *testing.T,
+	privateKey ed25519.PrivateKey,
+	components []string,
+	maxBodySize ...bytesize.ByteSize,
+) pipeline.Step {
+	t.Helper()
+
+	validator, err := validation.NewValidator()
+	require.NoError(t, err)
+
+	resolver := secretsmocks.NewResolverMock(t)
+	handle := secretsmocks.NewSecretHandleMock(t)
+
+	resolver.EXPECT().
+		Secret(secrets.Reference{Source: KeySet, Selector: Selector}).
+		Return(handle, nil)
+
+	handle.EXPECT().
+		OnUpdate(mock.MatchedBy(func(cb secrets.UpdateFunc[secrets.Secret]) bool {
+			err := cb(t.Context(), secrettypes.NewAsymmetricKeySecret(KeyID, KeyID, privateKey, nil))
+			require.NoError(t, err)
+
+			return true
+		}))
+
+	appCtx := app.NewContextMock(t)
+	appCtx.EXPECT().Logger().Return(log.Logger)
+	appCtx.EXPECT().SecretResolver().Maybe().Return(resolver)
+	appCtx.EXPECT().KeyRegistry().Maybe().Return(nil)
+	appCtx.EXPECT().
+		DecoderFactory().
+		Return(encoding.NewDecoderFactory(encoding.ValidatorFunc(validator.ValidateStruct)))
+
+	rawComponents := make([]any, 0, len(components))
+	for _, component := range components {
+		rawComponents = append(rawComponents, component)
+	}
+
+	rawConfig := config.MechanismConfig{
+		"signer": map[string]any{
+			"name": Tag,
+			"secret": map[string]any{
+				"source":   KeySet,
+				"selector": Selector,
+			},
+		},
+		"components": rawComponents,
+		"ttl":        "30s",
+	}
+
+	if len(maxBodySize) != 0 {
+		rawConfig["max_body_size"] = maxBodySize[0]
+	}
+
+	mechanism, err := registry.Create(appCtx,
+		types.KindFinalizer,
+		"http_message_signatures",
+		"hms",
+		rawConfig)
+	require.NoError(t, err)
+
+	step, err := mechanism.CreateStep(resolver, types.StepDefinition{})
+	require.NoError(t, err)
+
+	return step
+}
+
+func SignRequest(
+	t *testing.T,
+	req *http.Request,
+	privateKey ed25519.PrivateKey,
+	components []string,
+) {
+	t.Helper()
+
+	signer, err := httpsig.NewSigner(
+		httpsig.Key{KeyID: KeyID, Algorithm: httpsig.Ed25519, Key: privateKey},
+		httpsig.WithComponents(components...),
+		httpsig.WithTag(Tag),
+	)
+	require.NoError(t, err)
+
+	headers, err := signer.Sign(httpsig.MessageFromRequest(req))
+	require.NoError(t, err)
+
+	req.Header = headers
+}
+
+func VerifyRequest(
+	t *testing.T,
+	req *http.Request,
+	privateKey ed25519.PrivateKey,
+	components []string,
+) {
+	t.Helper()
+
+	verifier, err := httpsig.NewVerifier(
+		httpsig.Key{
+			KeyID:     KeyID,
+			Algorithm: httpsig.Ed25519,
+			Key:       privateKey.Public(),
+		},
+		httpsig.WithRequiredTag(Tag, httpsig.WithRequiredComponents(components...)),
+	)
+	require.NoError(t, err)
+	require.NoError(t, verifier.Verify(httpsig.MessageFromRequest(req)))
+}
+
+type Backend struct {
+	Target      *url.URL
+	ForwardHost bool
+}
+
+func (b Backend) URL() *url.URL {
+	return b.Target
+}
+
+func (b Backend) ForwardHostHeader() bool {
+	return b.ForwardHost
+}

--- a/internal/pipeline/http_message.go
+++ b/internal/pipeline/http_message.go
@@ -1,0 +1,274 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package pipeline
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/url"
+)
+
+var ErrHTTPMessageBodyTooLarge = errors.New(
+	"http message body exceeds configured maximum size",
+)
+
+type HTTPMessage struct {
+	Context   context.Context //nolint:containedctx
+	Method    string
+	Authority string
+	URL       *url.URL
+	Header    http.Header
+	Body      func() (io.ReadCloser, error)
+}
+
+type HTTPMessageFinalizer struct {
+	fn          func(*HTTPMessage) (http.Header, error)
+	maxBodySize int64
+}
+
+func NewHTTPMessageFinalizer(
+	maxBodySize int64,
+	fn func(*HTTPMessage) (http.Header, error),
+) HTTPMessageFinalizer {
+	return HTTPMessageFinalizer{fn: fn, maxBodySize: maxBodySize}
+}
+
+func (f HTTPMessageFinalizer) Finalize(msg *HTTPMessage) (http.Header, error) {
+	return f.fn(msg)
+}
+
+func (f HTTPMessageFinalizer) MaxBodySize() int64 {
+	return f.maxBodySize
+}
+
+type HTTPMessageFinalizerRegistry interface {
+	AddHTTPMessageFinalizerForUpstream(finalizer HTTPMessageFinalizer)
+	HTTPMessageFinalizersForUpstream() []HTTPMessageFinalizer
+}
+
+type HTTPMessageOptions struct {
+	MaxBodySize int64
+}
+
+type HTTPMessageOption func(*HTTPMessageOptions)
+
+func WithMaxHTTPMessageBodySize(maxBodySize int64) HTTPMessageOption {
+	return func(opts *HTTPMessageOptions) {
+		opts.MaxBodySize = maxBodySize
+	}
+}
+
+func NewHTTPMessageOptions(options ...HTTPMessageOption) HTTPMessageOptions {
+	var opts HTTPMessageOptions
+	for _, option := range options {
+		option(&opts)
+	}
+
+	return opts
+}
+
+type HTTPMessageProvider interface {
+	HTTPMessage(options ...HTTPMessageOption) (*HTTPMessage, error)
+}
+
+func HTTPMessageFromRequest(ctx context.Context, req *Request, options ...HTTPMessageOption) (*HTTPMessage, error) {
+	if provider, ok := req.RequestFunctions.(HTTPMessageProvider); ok {
+		return provider.HTTPMessage(options...)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, req.Method, req.URL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for name, value := range req.Headers() {
+		if name == "Host" {
+			httpReq.Host = value
+
+			continue
+		}
+
+		httpReq.Header.Set(name, value)
+	}
+
+	if len(httpReq.Host) == 0 {
+		httpReq.Host = req.URL.Host
+	}
+
+	return &HTTPMessage{
+		Context:   ctx,
+		Method:    req.Method,
+		Authority: httpReq.Host,
+		URL:       new(req.URL.URL),
+		Header:    httpReq.Header.Clone(),
+		Body:      func() (io.ReadCloser, error) { return http.NoBody, nil },
+	}, nil
+}
+
+func HTTPMessageFromHTTPRequest(req *http.Request, options ...HTTPMessageOption) *HTTPMessage {
+	var (
+		getBody      func() (io.ReadCloser, error)
+		bodySnapshot []byte
+	)
+
+	opts := NewHTTPMessageOptions(options...)
+
+	switch {
+	case req.GetBody != nil:
+		getBody = req.GetBody
+	case req.Body == nil || req.Body == http.NoBody:
+		getBody = func() (io.ReadCloser, error) { return http.NoBody, nil }
+	default:
+		getBody = func() (io.ReadCloser, error) {
+			if len(bodySnapshot) != 0 {
+				return io.NopCloser(bytes.NewReader(bodySnapshot)), nil
+			}
+
+			body, err := readHTTPMessageBody(req.Body, opts.MaxBodySize)
+			if err != nil {
+				_ = req.Body.Close()
+
+				return nil, err
+			}
+
+			if err := req.Body.Close(); err != nil {
+				return nil, err
+			}
+
+			bodySnapshot = body
+			req.Body = io.NopCloser(bytes.NewReader(bodySnapshot))
+
+			return io.NopCloser(bytes.NewReader(bodySnapshot)), nil
+		}
+	}
+
+	return &HTTPMessage{
+		Context:   req.Context(),
+		Method:    req.Method,
+		Authority: req.Host,
+		URL:       req.URL,
+		Header:    req.Header.Clone(),
+		Body:      getBody,
+	}
+}
+
+func ApplyHTTPMessageFinalizers(msg *HTTPMessage, finalizers ...HTTPMessageFinalizer) (http.Header, error) {
+	header := msg.Header.Clone()
+
+	for _, finalizer := range finalizers {
+		msg.Header = header
+
+		signed, err := finalizer.Finalize(msg)
+		if err != nil {
+			return nil, err
+		}
+
+		header = signed.Clone()
+	}
+
+	return header, nil
+}
+
+func MaxHTTPMessageFinalizerBodySize(finalizers ...HTTPMessageFinalizer) int64 {
+	var maxBodySize int64
+
+	for _, finalizer := range finalizers {
+		if finalizer.MaxBodySize() > maxBodySize {
+			maxBodySize = finalizer.MaxBodySize()
+		}
+	}
+
+	return maxBodySize
+}
+
+func readHTTPMessageBody(body io.Reader, maxBodySize int64) ([]byte, error) {
+	var (
+		buf    bytes.Buffer
+		reader = body
+	)
+
+	if maxBodySize > 0 && maxBodySize < math.MaxInt64 {
+		reader = io.LimitReader(body, maxBodySize+1)
+	}
+
+	if _, err := buf.ReadFrom(reader); err != nil {
+		return nil, err
+	}
+
+	if maxBodySize > 0 && int64(buf.Len()) > maxBodySize {
+		return nil, ErrHTTPMessageBodyTooLarge
+	}
+
+	return buf.Bytes(), nil
+}
+
+func HTTPMessageBodyWithMaxSize(
+	body func() (io.ReadCloser, error),
+	maxBodySize int64,
+) func() (io.ReadCloser, error) {
+	return func() (io.ReadCloser, error) {
+		rc, err := body()
+		if err != nil {
+			return nil, err
+		}
+
+		return &maxBytesReadCloser{
+			rc:        rc,
+			remaining: maxBodySize,
+		}, nil
+	}
+}
+
+type maxBytesReadCloser struct {
+	rc        io.ReadCloser
+	remaining int64
+}
+
+func (r *maxBytesReadCloser) Read(chunk []byte) (int, error) {
+	if r.remaining == 0 {
+		var b [1]byte
+
+		n, err := r.rc.Read(b[:])
+		if n > 0 {
+			if closeErr := r.rc.Close(); closeErr != nil {
+				return 0, fmt.Errorf("%w: %w", ErrHTTPMessageBodyTooLarge, closeErr)
+			}
+
+			return 0, ErrHTTPMessageBodyTooLarge
+		}
+
+		return 0, err
+	}
+
+	if int64(len(chunk)) > r.remaining {
+		chunk = chunk[:int(r.remaining)]
+	}
+
+	n, err := r.rc.Read(chunk)
+	r.remaining -= int64(n)
+
+	return n, err
+}
+
+func (r *maxBytesReadCloser) Close() error {
+	return r.rc.Close()
+}

--- a/internal/pipeline/http_message_test.go
+++ b/internal/pipeline/http_message_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package pipeline
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPMessageFromRequestFallbackIsBodyless(t *testing.T) {
+	t.Parallel()
+
+	rawURL, err := url.Parse("https://api.example.test/foo?bar=baz")
+	require.NoError(t, err)
+
+	msg, err := HTTPMessageFromRequest(t.Context(), &Request{
+		Method: http.MethodPost,
+		URL: &URL{
+			URL: *rawURL,
+		},
+		RequestFunctions: staticRequestFunctions{
+			headers: map[string]string{
+				"Host":         "signed.example.test",
+				"Content-Type": "application/json",
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, http.MethodPost, msg.Method)
+	assert.Equal(t, "signed.example.test", msg.Authority)
+	assert.Equal(t, "https://api.example.test/foo?bar=baz", msg.URL.String())
+	assert.Equal(t, "application/json", msg.Header.Get("Content-Type"))
+
+	body, err := msg.Body()
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.Empty(t, data)
+}
+
+func TestApplyHTTPMessageFinalizersComposesSignatureHeadersInOrder(t *testing.T) {
+	t.Parallel()
+
+	rawURL, err := url.Parse("https://api.example.test/foo")
+	require.NoError(t, err)
+
+	msg := &HTTPMessage{
+		Context:   t.Context(),
+		Method:    http.MethodPost,
+		Authority: rawURL.Host,
+		URL:       rawURL,
+		Header: http.Header{
+			"Content-Type": {"application/json"},
+		},
+		Body: func() (io.ReadCloser, error) { return http.NoBody, nil },
+	}
+
+	first := NewHTTPMessageFinalizer(4, func(msg *HTTPMessage) (http.Header, error) {
+		assert.Equal(t, "application/json", msg.Header.Get("Content-Type"))
+		assert.Empty(t, msg.Header.Values("Signature"))
+
+		header := msg.Header.Clone()
+		header.Add("Signature-Input", `sig-a=("@method" "@authority" "@path")`)
+		header.Add("Signature", "sig-a=:first:")
+
+		return header, nil
+	})
+
+	second := NewHTTPMessageFinalizer(8, func(msg *HTTPMessage) (http.Header, error) {
+		assert.Equal(t, []string{"sig-a=:first:"}, msg.Header.Values("Signature"))
+		assert.Equal(t, []string{`sig-a=("@method" "@authority" "@path")`}, msg.Header.Values("Signature-Input"))
+
+		header := msg.Header.Clone()
+		header.Add("Signature-Input", `sig-b=("@method" "@authority" "@path")`)
+		header.Add("Signature", "sig-b=:second:")
+
+		return header, nil
+	})
+
+	header, err := ApplyHTTPMessageFinalizers(msg, first, second)
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"sig-a=:first:", "sig-b=:second:"}, header.Values("Signature"))
+	assert.Equal(t,
+		[]string{
+			`sig-a=("@method" "@authority" "@path")`,
+			`sig-b=("@method" "@authority" "@path")`,
+		},
+		header.Values("Signature-Input"),
+	)
+	assert.Equal(t, int64(8), MaxHTTPMessageFinalizerBodySize(first, second))
+}
+
+type staticRequestFunctions struct {
+	headers map[string]string
+}
+
+func (f staticRequestFunctions) Header(name string) string {
+	return f.headers[name]
+}
+
+func (staticRequestFunctions) Cookie(string) string {
+	return ""
+}
+
+func (f staticRequestFunctions) Headers() map[string]string {
+	return f.headers
+}
+
+func (staticRequestFunctions) Body() any {
+	return ""
+}

--- a/internal/rules/mechanisms/authenticators/constants.go
+++ b/internal/rules/mechanisms/authenticators/constants.go
@@ -17,12 +17,13 @@
 package authenticators
 
 const (
-	AuthenticatorUnauthorized        = "unauthorized"
-	AuthenticatorBasicAuth           = "basic_auth"
-	AuthenticatorAnonymous           = "anonymous"
-	AuthenticatorOAuth2Introspection = "oauth2_introspection"
-	AuthenticatorJWT                 = "jwt"
-	AuthenticatorGeneric             = "generic"
+	AuthenticatorUnauthorized          = "unauthorized"
+	AuthenticatorBasicAuth             = "basic_auth"
+	AuthenticatorAnonymous             = "anonymous"
+	AuthenticatorOAuth2Introspection   = "oauth2_introspection"
+	AuthenticatorJWT                   = "jwt"
+	AuthenticatorGeneric               = "generic"
+	AuthenticatorHTTPMessageSignatures = "http_message_signatures"
 )
 
 const (

--- a/internal/rules/mechanisms/authenticators/http_message_signatures_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/http_message_signatures_authenticator.go
@@ -1,0 +1,571 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package authenticators
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ccoveille/go-safecast/v2"
+	"github.com/dadrus/httpsig"
+	"github.com/goccy/go-json"
+	"github.com/inhies/go-bytesize"
+	"github.com/rs/zerolog"
+
+	"github.com/dadrus/heimdall/internal/app"
+	"github.com/dadrus/heimdall/internal/config"
+	"github.com/dadrus/heimdall/internal/pipeline"
+	"github.com/dadrus/heimdall/internal/rules/mechanisms/registry"
+	"github.com/dadrus/heimdall/internal/rules/mechanisms/template"
+	"github.com/dadrus/heimdall/internal/rules/mechanisms/types"
+	"github.com/dadrus/heimdall/internal/secrets"
+	"github.com/dadrus/heimdall/internal/x"
+	"github.com/dadrus/heimdall/internal/x/errorchain"
+)
+
+const (
+	defaultHTTPMessageSignaturesMaxAge      = 30 * time.Second
+	defaultHTTPMessageSignaturesMaxBodySize = 1 * bytesize.MB
+)
+
+// by intention. Used only during application bootstrap
+//
+//nolint:gochecknoinits
+func init() {
+	registry.Register(
+		types.KindAuthenticator,
+		AuthenticatorHTTPMessageSignatures,
+		registry.FactoryFunc(newHTTPMessageSignaturesAuthenticator),
+	)
+}
+
+type httpMessageSignaturesConfig struct {
+	KeyStore                 config.Secret      `mapstructure:"key_store"                  validate:"required"`
+	RequiredComponents       []string           `mapstructure:"required_components"        validate:"gt=0,dive,required"`
+	Tag                      string             `mapstructure:"tag"`
+	MaxAge                   *time.Duration     `mapstructure:"max_age"`
+	AllowedTimeSkew          *time.Duration     `mapstructure:"allowed_time_skew"`
+	MaxBodySize              *bytesize.ByteSize `mapstructure:"max_body_size"              validate:"omitempty,gt=0"`
+	CreatedTimestampRequired *bool              `mapstructure:"created_timestamp_required"`
+	ExpiresTimestampRequired *bool              `mapstructure:"expires_timestamp_required"`
+	ValidateAllSignatures    *bool              `mapstructure:"validate_all_signatures"`
+	PrincipalInfo            PrincipalInfo      `mapstructure:"principal"                  validate:"-"`
+	ErrorSignaling           struct {
+		Enabled *bool `mapstructure:"enabled"`
+	} `mapstructure:"error_signaling"`
+}
+
+type httpMessageSignaturesAuthenticator struct {
+	name                     string
+	id                       string
+	principalName            string
+	app                      app.Context
+	keyStore                 config.Secret
+	requiredComponents       []string
+	tag                      string
+	maxAge                   time.Duration
+	allowedTimeSkew          time.Duration
+	maxBodySize              bytesize.ByteSize
+	createdTimestampRequired *bool
+	expiresTimestampRequired *bool
+	validateAllSignatures    bool
+	sf                       PrincipalFactory
+	errorSignalingEnabled    bool
+	informer                 *secrets.SecretSetInformer[[]httpsig.Key]
+}
+
+func newHTTPMessageSignaturesAuthenticator(
+	app app.Context,
+	name string,
+	rawConfig map[string]any,
+) (types.Mechanism, error) {
+	logger := app.Logger()
+	logger.Info().
+		Str("_type", AuthenticatorHTTPMessageSignatures).
+		Str("_name", name).
+		Msg("Creating authenticator")
+
+	conf, err := decodeHTTPMessageSignaturesConfig(app, name, rawConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	informer, err := newHTTPMessageSignaturesKeyInformer(app.SecretResolver(), conf.KeyStore)
+	if err != nil {
+		return nil, errorchain.NewWithMessage(
+			pipeline.ErrConfiguration,
+			"failed creating http message signatures key informer",
+		).CausedBy(err)
+	}
+
+	return newHTTPMessageSignaturesAuthenticatorFromConfig(app, name, name, DefaultPrincipalName, conf, informer), nil
+}
+
+func decodeHTTPMessageSignaturesConfig(
+	app app.Context,
+	name string,
+	rawConfig map[string]any,
+) (*httpMessageSignaturesConfig, error) {
+	var conf httpMessageSignaturesConfig
+	if err := decodeConfig(app, rawConfig, &conf,
+		template.WithName("authenticator."+AuthenticatorHTTPMessageSignatures+"."+name),
+		template.WithSecretResolver(app.SecretResolver()),
+	); err != nil {
+		return nil, errorchain.NewWithMessagef(
+			pipeline.ErrConfiguration,
+			"failed decoding config for %s authenticator '%s'", AuthenticatorHTTPMessageSignatures, name,
+		).CausedBy(err)
+	}
+
+	if len(conf.PrincipalInfo.IDFrom) == 0 {
+		conf.PrincipalInfo.IDFrom = "key_id"
+	}
+
+	if conf.ValidateAllSignatures != nil && !*conf.ValidateAllSignatures && len(conf.Tag) == 0 {
+		return nil, errorchain.NewWithMessage(
+			pipeline.ErrConfiguration,
+			"http message signatures authenticator requires a tag when validate_all_signatures is disabled",
+		)
+	}
+
+	for _, component := range conf.RequiredComponents {
+		if strings.EqualFold(httpMessageSignatureComponentIdentifier(component), "host") {
+			return nil, errorchain.NewWithMessage(
+				pipeline.ErrConfiguration,
+				"http message signatures authenticator requires @authority instead of host in required_components",
+			)
+		}
+	}
+
+	return &conf, nil
+}
+
+func httpMessageSignatureComponentIdentifier(component string) string {
+	identifier, _, _ := strings.Cut(component, ";")
+
+	return strings.TrimSpace(identifier)
+}
+
+func newHTTPMessageSignaturesAuthenticatorFromConfig(
+	app app.Context,
+	name, id, principalName string,
+	conf *httpMessageSignaturesConfig,
+	informer *secrets.SecretSetInformer[[]httpsig.Key],
+) *httpMessageSignaturesAuthenticator {
+	return &httpMessageSignaturesAuthenticator{
+		name:               name,
+		id:                 id,
+		principalName:      principalName,
+		app:                app,
+		keyStore:           conf.KeyStore,
+		requiredComponents: conf.RequiredComponents,
+		tag:                conf.Tag,
+		maxAge: x.IfThenElseExec(
+			conf.MaxAge != nil,
+			func() time.Duration { return *conf.MaxAge },
+			func() time.Duration { return defaultHTTPMessageSignaturesMaxAge },
+		),
+		allowedTimeSkew: x.IfThenElseExec(
+			conf.AllowedTimeSkew != nil,
+			func() time.Duration { return *conf.AllowedTimeSkew },
+			func() time.Duration { return 0 },
+		),
+		maxBodySize: x.IfThenElseExec(
+			conf.MaxBodySize != nil,
+			func() bytesize.ByteSize { return *conf.MaxBodySize },
+			func() bytesize.ByteSize { return defaultHTTPMessageSignaturesMaxBodySize },
+		),
+		createdTimestampRequired: conf.CreatedTimestampRequired,
+		expiresTimestampRequired: conf.ExpiresTimestampRequired,
+		validateAllSignatures: x.IfThenElseExec(
+			conf.ValidateAllSignatures != nil,
+			func() bool { return *conf.ValidateAllSignatures },
+			func() bool { return len(conf.Tag) == 0 },
+		),
+		sf:                    &conf.PrincipalInfo,
+		errorSignalingEnabled: conf.ErrorSignaling.Enabled != nil && *conf.ErrorSignaling.Enabled,
+		informer:              informer,
+	}
+}
+
+func newHTTPMessageSignaturesKeyInformer(
+	resolver secrets.Resolver,
+	keyStore config.Secret,
+) (*secrets.SecretSetInformer[[]httpsig.Key], error) {
+	return secrets.NewSecretSetInformer(
+		resolver,
+		secrets.Reference{Source: keyStore.Source, Selector: keyStore.Selector},
+		secrets.WithConverter(toHTTPSigVerificationKeys),
+	)
+}
+
+func (a *httpMessageSignaturesAuthenticator) Accept(visitor pipeline.Visitor) {
+	visitor.VisitInsecure(a)
+	visitor.VisitPrincipalNamer(a)
+}
+
+func (a *httpMessageSignaturesAuthenticator) Execute(ctx pipeline.Context, sub pipeline.Subject) error {
+	logger := zerolog.Ctx(ctx.Context())
+	logger.Debug().
+		Str("_type", AuthenticatorHTTPMessageSignatures).
+		Str("_name", a.name).
+		Str("_id", a.id).
+		Msg("Executing authenticator")
+
+	keys, ok := a.informer.Get()
+	if !ok {
+		return errorchain.NewWithMessage(
+			pipeline.ErrConfiguration,
+			"http message signature verification keys are not available",
+		)
+	}
+
+	resolver := &recordingHTTPSigKeyResolver{keys: keys}
+
+	verifier, err := httpsig.NewVerifier(resolver, a.verifierOptions(a.errorSignalingEnabled)...)
+	if err != nil {
+		return errorchain.NewWithMessage(
+			pipeline.ErrConfiguration,
+			"failed creating http message signatures verifier",
+		).CausedBy(err)
+	}
+
+	msg, err := toHTTPMessageSignatureMessage(ctx, a.maxBodySize)
+	if err != nil {
+		return errorchain.NewWithMessage(
+			pipeline.ErrAuthentication,
+			"failed creating http message signature verification request",
+		).WithAspects(a).CausedBy(err)
+	}
+
+	if err = verifier.Verify(msg); err != nil {
+		return errorchain.NewWithMessage(
+			pipeline.ErrAuthentication,
+			"http message signature verification failed",
+		).WithAspects(a).CausedBy(err)
+	}
+
+	principal, err := a.sf.CreatePrincipal(resolver.principalData())
+	if err != nil {
+		return errorchain.NewWithMessage(
+			pipeline.ErrAuthentication,
+			"failed creating principal from verified http message signature",
+		).WithAspects(a).CausedBy(err)
+	}
+
+	sub[a.principalName] = principal
+
+	return nil
+}
+
+func toHTTPMessageSignatureMessage(ctx pipeline.Context, maxBodySize bytesize.ByteSize) (*httpsig.Message, error) {
+	msg, err := pipeline.HTTPMessageFromRequest(
+		ctx.Context(),
+		ctx.Request(),
+		pipeline.WithMaxHTTPMessageBodySize(safecast.MustConvert[int64](uint64(maxBodySize))),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &httpsig.Message{
+		Context:   msg.Context,
+		Method:    msg.Method,
+		Authority: msg.Authority,
+		URL:       msg.URL,
+		Header:    msg.Header.Clone(),
+		Body: pipeline.HTTPMessageBodyWithMaxSize(
+			msg.Body,
+			safecast.MustConvert[int64](uint64(maxBodySize)),
+		),
+		IsRequest: true,
+	}, nil
+}
+
+func (a *httpMessageSignaturesAuthenticator) CreateStep(
+	resolver secrets.Resolver,
+	def types.StepDefinition,
+) (pipeline.Step, error) {
+	if def.IsEmpty() {
+		return a, nil
+	}
+
+	if len(def.Config) == 0 {
+		auth := *a
+		auth.id = x.IfThenElse(len(def.ID) == 0, a.id, def.ID)
+		auth.principalName = x.IfThenElse(len(def.Principal) == 0, a.principalName, def.Principal)
+
+		return &auth, nil
+	}
+
+	conf, err := decodeHTTPMessageSignaturesConfig(a.app, a.name, def.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	informer, err := newHTTPMessageSignaturesKeyInformer(resolver, conf.KeyStore)
+	if err != nil {
+		return nil, errorchain.NewWithMessage(
+			pipeline.ErrConfiguration,
+			"failed creating http message signatures key informer",
+		).CausedBy(err)
+	}
+
+	return newHTTPMessageSignaturesAuthenticatorFromConfig(
+		a.app,
+		a.name,
+		x.IfThenElse(len(def.ID) == 0, a.id, def.ID),
+		x.IfThenElse(len(def.Principal) == 0, a.principalName, def.Principal),
+		conf,
+		informer,
+	), nil
+}
+
+func (a *httpMessageSignaturesAuthenticator) DecorateErrorResponse(err error, er *pipeline.ErrorResponse) {
+	if !a.errorSignalingEnabled {
+		return
+	}
+
+	var noApplicableSignature *httpsig.NoApplicableSignatureError
+	if !errors.As(err, &noApplicableSignature) {
+		return
+	}
+
+	er.Code = http.StatusUnauthorized
+
+	header := http.Header{}
+	noApplicableSignature.Negotiate(header)
+
+	for name, values := range header {
+		for _, value := range values {
+			er.AddHeader(name, value)
+		}
+	}
+}
+
+func (a *httpMessageSignaturesAuthenticator) Name() string          { return a.name }
+func (a *httpMessageSignaturesAuthenticator) ID() string            { return a.id }
+func (a *httpMessageSignaturesAuthenticator) Type() string          { return a.name }
+func (a *httpMessageSignaturesAuthenticator) PrincipalName() string { return a.principalName }
+func (*httpMessageSignaturesAuthenticator) Kind() types.Kind        { return types.KindAuthenticator }
+func (*httpMessageSignaturesAuthenticator) IsInsecure() bool        { return false }
+
+func (a *httpMessageSignaturesAuthenticator) verifierOptions(negotiate bool) []httpsig.VerifierOption {
+	reqOpts := []httpsig.VerifierOption{
+		httpsig.WithRequiredComponents(a.requiredComponents...),
+		httpsig.WithMaxAge(a.maxAge),
+		httpsig.WithValidityTolerance(a.allowedTimeSkew),
+	}
+
+	if a.createdTimestampRequired != nil {
+		reqOpts = append(reqOpts, httpsig.WithCreatedTimestampRequired(*a.createdTimestampRequired))
+	}
+
+	if a.expiresTimestampRequired != nil {
+		reqOpts = append(reqOpts, httpsig.WithExpiredTimestampRequired(*a.expiresTimestampRequired))
+	}
+
+	if negotiate && len(a.tag) != 0 {
+		reqOpts = append(reqOpts, httpsig.WithSignatureNegotiation())
+	}
+
+	if len(a.tag) != 0 {
+		return []httpsig.VerifierOption{httpsig.WithRequiredTag(a.tag, reqOpts...)}
+	}
+
+	opts := reqOpts
+	if a.validateAllSignatures {
+		opts = append(opts, httpsig.WithValidateAllSignatures())
+	}
+
+	return opts
+}
+
+type recordingHTTPSigKeyResolver struct {
+	keys       []httpsig.Key
+	resolvedID string
+}
+
+func (r *recordingHTTPSigKeyResolver) ResolveKey(_ context.Context, keyID string) (httpsig.Key, error) {
+	for _, key := range r.keys {
+		if key.KeyID == keyID {
+			r.resolvedID = keyID
+
+			return key, nil
+		}
+	}
+
+	return httpsig.Key{}, errorchain.NewWithMessagef(
+		pipeline.ErrAuthentication,
+		"no http message signature verification key found for key id '%s'", keyID,
+	)
+}
+
+func (r *recordingHTTPSigKeyResolver) principalData() []byte {
+	data, _ := json.Marshal(map[string]any{"key_id": r.resolvedID})
+
+	return data
+}
+
+func toHTTPSigVerificationKeys(secretSet []secrets.Secret) ([]httpsig.Key, error) {
+	keys := make([]httpsig.Key, 0, len(secretSet))
+
+	for _, secret := range secretSet {
+		switch key := secret.(type) {
+		case secrets.AsymmetricKeySecret:
+			httpSigKey, err := asymmetricSecretToHTTPSigVerificationKey(key)
+			if err != nil {
+				return nil, err
+			}
+
+			keys = append(keys, httpSigKey)
+		case secrets.SymmetricKeySecret:
+			httpSigKey, err := symmetricSecretToHTTPSigVerificationKey(key)
+			if err != nil {
+				return nil, err
+			}
+
+			keys = append(keys, httpSigKey)
+		default:
+			return nil, errorchain.NewWithMessagef(
+				pipeline.ErrConfiguration,
+				"resolved secret '%s' is not suitable for http message signature verification",
+				secret.Selector(),
+			)
+		}
+	}
+
+	if len(keys) == 0 {
+		return nil, errorchain.NewWithMessage(
+			pipeline.ErrConfiguration,
+			"no http message signature verification keys configured",
+		)
+	}
+
+	return keys, nil
+}
+
+func asymmetricSecretToHTTPSigVerificationKey(secret secrets.AsymmetricKeySecret) (httpsig.Key, error) {
+	privateKey := secret.PrivateKey()
+	if privateKey == nil {
+		return httpsig.Key{}, errorchain.NewWithMessagef(
+			pipeline.ErrConfiguration,
+			"resolved asymmetric secret '%s' does not contain private key material",
+			secret.Selector(),
+		)
+	}
+
+	publicKey := privateKey.Public()
+
+	alg, err := signatureAlgorithm(publicKey)
+	if err != nil {
+		return httpsig.Key{}, err
+	}
+
+	return httpsig.Key{
+		KeyID:     secret.KeyID(),
+		Algorithm: alg,
+		Key:       publicKey,
+	}, nil
+}
+
+func symmetricSecretToHTTPSigVerificationKey(secret secrets.SymmetricKeySecret) (httpsig.Key, error) {
+	alg, err := hmacSignatureAlgorithm(secret.Algorithm())
+	if err != nil {
+		return httpsig.Key{}, err
+	}
+
+	return httpsig.Key{
+		KeyID:     secret.KeyID(),
+		Algorithm: alg,
+		Key:       secret.Key(),
+	}, nil
+}
+
+func signatureAlgorithm(publicKey any) (httpsig.SignatureAlgorithm, error) {
+	switch key := publicKey.(type) {
+	case *rsa.PublicKey:
+		return rsaSignatureAlgorithm(key.Size() * 8) //nolint:mnd
+	case *ecdsa.PublicKey:
+		return ecdsaSignatureAlgorithm(key.Params().BitSize)
+	case ed25519.PublicKey:
+		return httpsig.Ed25519, nil
+	default:
+		return "", errorchain.NewWithMessagef(
+			pipeline.ErrConfiguration,
+			"unsupported http message signature verification key type: %T",
+			publicKey,
+		)
+	}
+}
+
+func rsaSignatureAlgorithm(keySize int) (httpsig.SignatureAlgorithm, error) {
+	switch keySize {
+	case 2048: //nolint:mnd
+		return httpsig.RsaPssSha256, nil
+	case 3072: //nolint:mnd
+		return httpsig.RsaPssSha384, nil
+	case 4096: //nolint:mnd
+		return httpsig.RsaPssSha512, nil
+	default:
+		return "", errorchain.NewWithMessagef(
+			pipeline.ErrConfiguration,
+			"unsupported RSA key size for http message signature verification: %d",
+			keySize,
+		)
+	}
+}
+
+func ecdsaSignatureAlgorithm(keySize int) (httpsig.SignatureAlgorithm, error) {
+	switch keySize {
+	case 256: //nolint:mnd
+		return httpsig.EcdsaP256Sha256, nil
+	case 384: //nolint:mnd
+		return httpsig.EcdsaP384Sha384, nil
+	case 521: //nolint:mnd
+		return httpsig.EcdsaP521Sha512, nil
+	default:
+		return "", errorchain.NewWithMessagef(
+			pipeline.ErrConfiguration,
+			"unsupported ECDSA key size for http message signature verification: %d",
+			keySize,
+		)
+	}
+}
+
+func hmacSignatureAlgorithm(alg string) (httpsig.SignatureAlgorithm, error) {
+	switch alg {
+	case string(httpsig.HmacSha256), "HS256":
+		return httpsig.HmacSha256, nil
+	case string(httpsig.HmacSha384), "HS384":
+		return httpsig.HmacSha384, nil
+	case string(httpsig.HmacSha512), "HS512":
+		return httpsig.HmacSha512, nil
+	default:
+		return "", errorchain.NewWithMessagef(
+			pipeline.ErrConfiguration,
+			"unsupported HMAC algorithm for http message signature verification: %s",
+			alg,
+		)
+	}
+}

--- a/internal/rules/mechanisms/authenticators/http_message_signatures_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/http_message_signatures_authenticator_test.go
@@ -1,0 +1,484 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package authenticators
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+
+	"github.com/dadrus/httpsig"
+	"github.com/inhies/go-bytesize"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dadrus/heimdall/internal/app"
+	"github.com/dadrus/heimdall/internal/config"
+	"github.com/dadrus/heimdall/internal/encoding"
+	"github.com/dadrus/heimdall/internal/handler/requestcontext"
+	"github.com/dadrus/heimdall/internal/pipeline"
+	"github.com/dadrus/heimdall/internal/secrets"
+	secretsmocks "github.com/dadrus/heimdall/internal/secrets/mocks"
+	secrettypes "github.com/dadrus/heimdall/internal/secrets/types"
+	"github.com/dadrus/heimdall/internal/validation"
+)
+
+func TestHTTPMessageSignaturesAuthenticatorExecute(t *testing.T) {
+	t.Parallel()
+
+	privateKey := newTestEd25519PrivateKey(t)
+	auth := newTestHTTPMessageSignaturesAuthenticator(t, privateKey, true)
+	req := newSignedHMSRequest(t, privateKey)
+
+	ctx := requestcontext.New()
+	ctx.Init(req)
+	t.Cleanup(ctx.Reset)
+
+	sub := make(pipeline.Subject)
+	err := auth.Execute(ctx, sub)
+
+	require.NoError(t, err)
+	require.Contains(t, sub, DefaultPrincipalName)
+	assert.Equal(t, "test-key", sub[DefaultPrincipalName].ID)
+	assert.Equal(t, "test-key", sub[DefaultPrincipalName].Attributes["key_id"])
+}
+
+func TestHTTPMessageSignaturesAuthenticatorExecuteWithContentDigest(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"message":"hello"}`)
+	privateKey := newTestEd25519PrivateKey(t)
+	auth := newTestHTTPMessageSignaturesAuthenticatorWithComponents(
+		t,
+		privateKey,
+		true,
+		[]string{"@method", "@authority", "@path", "content-digest", "content-length", "content-type"},
+	)
+	req := newSignedHMSRequestWithBody(t, privateKey, body)
+
+	ctx := requestcontext.New()
+	ctx.Init(req)
+	t.Cleanup(ctx.Reset)
+
+	originalMethod := req.Method
+	originalURL := req.URL.String()
+	originalHost := req.Host
+
+	err := auth.Execute(ctx, make(pipeline.Subject))
+
+	require.NoError(t, err)
+	assert.Equal(t, originalMethod, req.Method)
+	assert.Equal(t, originalURL, req.URL.String())
+	assert.Equal(t, originalHost, req.Host)
+
+	restoredBody, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	assert.Equal(t, body, restoredBody)
+}
+
+func TestHTTPMessageSignaturesAuthenticatorRejectsBodyOverMaxBodySize(t *testing.T) {
+	t.Parallel()
+
+	body := bytes.Repeat([]byte("a"), 64*1024)
+	privateKey := newTestEd25519PrivateKey(t)
+	auth := newTestHTTPMessageSignaturesAuthenticatorWithComponents(
+		t,
+		privateKey,
+		true,
+		[]string{"@method", "@authority", "@path", "content-digest", "content-length", "content-type"},
+	)
+	auth.maxBodySize = 18 * bytesize.B
+	req := newSignedHMSRequestWithBody(t, privateKey, body)
+	bodyReader := &readLimitAssertingReadCloser{
+		reader:  bytes.NewReader(body),
+		maxRead: 19,
+	}
+	req.Body = bodyReader
+
+	ctx := requestcontext.New()
+	ctx.Init(req)
+	t.Cleanup(ctx.Reset)
+
+	err := auth.Execute(ctx, make(pipeline.Subject))
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, pipeline.ErrAuthentication)
+	require.ErrorContains(t, err, "exceeds configured maximum size")
+	assert.LessOrEqual(t, bodyReader.read, int64(19))
+}
+
+func TestHTTPMessageSignaturesAuthenticatorUsesNormalizedAuthority(t *testing.T) {
+	t.Parallel()
+
+	privateKey := newTestEd25519PrivateKey(t)
+	auth := newTestHTTPMessageSignaturesAuthenticator(t, privateKey, true)
+	req := newSignedHMSRequestForAuthority(t, privateKey, "api.example.test")
+	req.Host = "heimdall.internal"
+	req.Header.Set("X-Forwarded-Host", "api.example.test")
+
+	ctx := requestcontext.New()
+	ctx.Init(req)
+	t.Cleanup(ctx.Reset)
+
+	err := auth.Execute(ctx, make(pipeline.Subject))
+
+	require.NoError(t, err)
+}
+
+func TestHTTPMessageSignaturesAuthenticatorExecuteWithMissingSignature(t *testing.T) {
+	t.Parallel()
+
+	auth, ctx := newUnsignedHMSExecution(t, true)
+
+	err := auth.Execute(ctx, make(pipeline.Subject))
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, pipeline.ErrAuthentication)
+
+	response := pipeline.NewResponseError(err).Response()
+	assert.Equal(t, http.StatusUnauthorized, response.Code)
+	assert.Contains(t, response.Headers, "Accept-Signature")
+	assert.NotEmpty(t, response.Headers["Accept-Signature"])
+}
+
+func TestHTTPMessageSignaturesAuthenticatorDecorateErrorResponseDisabled(t *testing.T) {
+	t.Parallel()
+
+	auth, ctx := newUnsignedHMSExecution(t, false)
+
+	err := auth.Execute(ctx, make(pipeline.Subject))
+
+	require.Error(t, err)
+
+	response := pipeline.NewResponseError(err).Response()
+	assert.NotEqual(t, http.StatusUnauthorized, response.Code)
+	assert.NotContains(t, response.Headers, "Accept-Signature")
+}
+
+func TestHTTPMessageSignaturesAuthenticatorWithoutTagDoesNotNegotiate(t *testing.T) {
+	t.Parallel()
+
+	auth, ctx := newUnsignedHMSExecution(t, true)
+	auth.tag = ""
+	auth.validateAllSignatures = true
+
+	err := auth.Execute(ctx, make(pipeline.Subject))
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, pipeline.ErrAuthentication)
+
+	response := pipeline.NewResponseError(err).Response()
+	assert.NotEqual(t, http.StatusInternalServerError, response.Code)
+	assert.NotContains(t, response.Headers, "Accept-Signature")
+}
+
+func TestNewHTTPMessageSignaturesAuthenticator(t *testing.T) {
+	t.Parallel()
+
+	auth := newTestHTTPMessageSignaturesAuthenticator(t, newTestEd25519PrivateKey(t), true)
+
+	assert.Equal(t, AuthenticatorHTTPMessageSignatures, auth.Name())
+	assert.Equal(t, AuthenticatorHTTPMessageSignatures, auth.ID())
+	assert.Equal(t, AuthenticatorHTTPMessageSignatures, auth.Type())
+	assert.Equal(t, DefaultPrincipalName, auth.PrincipalName())
+	assert.False(t, auth.IsInsecure())
+	assert.Equal(t, []string{"@method", "@authority", "@path"}, auth.requiredComponents)
+	assert.Equal(t, "hms", auth.tag)
+	assert.True(t, auth.errorSignalingEnabled)
+}
+
+func TestNewHTTPMessageSignaturesAuthenticatorWithoutTagRequiresValidateAllSignatures(t *testing.T) {
+	t.Parallel()
+
+	appCtx := newTestAppContext(t)
+	mechanism, err := newHTTPMessageSignaturesAuthenticator(appCtx, AuthenticatorHTTPMessageSignatures, config.MechanismConfig{
+		"key_store": map[string]any{
+			"source":   "hms_keys",
+			"selector": "clients",
+		},
+		"required_components":     []any{"@method", "@authority", "@path"},
+		"validate_all_signatures": false,
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, mechanism)
+	require.ErrorIs(t, err, pipeline.ErrConfiguration)
+	assert.ErrorContains(t, err, "requires a tag")
+}
+
+func TestNewHTTPMessageSignaturesAuthenticatorRejectsHostRequiredComponent(t *testing.T) {
+	t.Parallel()
+
+	appCtx := newTestAppContext(t)
+	mechanism, err := newHTTPMessageSignaturesAuthenticator(appCtx, AuthenticatorHTTPMessageSignatures, config.MechanismConfig{
+		"key_store": map[string]any{
+			"source":   "hms_keys",
+			"selector": "clients",
+		},
+		"required_components": []any{"@method", "Host;sf", "@path"},
+		"tag":                 "hms",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, mechanism)
+	require.ErrorIs(t, err, pipeline.ErrConfiguration)
+	assert.ErrorContains(t, err, "requires @authority instead of host")
+}
+
+func TestToHTTPSigVerificationKeysRejectsAsymmetricSecretWithoutPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	keys, err := toHTTPSigVerificationKeys([]secrets.Secret{
+		secrettypes.NewAsymmetricKeySecret("test-key", "test-key", nil, nil),
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, keys)
+	require.ErrorIs(t, err, pipeline.ErrConfiguration)
+	assert.ErrorContains(t, err, "does not contain private key material")
+}
+
+func newTestEd25519PrivateKey(t *testing.T) ed25519.PrivateKey {
+	t.Helper()
+
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	return privateKey
+}
+
+func newUnsignedHMSExecution(
+	t *testing.T,
+	errorSignalingEnabled bool,
+) (*httpMessageSignaturesAuthenticator, *requestcontext.RequestContext) {
+	t.Helper()
+
+	auth := newTestHTTPMessageSignaturesAuthenticator(t, newTestEd25519PrivateKey(t), errorSignalingEnabled)
+	req := httptest.NewRequest(http.MethodGet, "https://api.example.test/foo", nil)
+	ctx := requestcontext.New()
+	ctx.Init(req)
+	t.Cleanup(ctx.Reset)
+
+	return auth, ctx
+}
+
+func newTestHTTPMessageSignaturesAuthenticator(
+	t *testing.T,
+	privateKey ed25519.PrivateKey,
+	errorSignalingEnabled bool,
+) *httpMessageSignaturesAuthenticator {
+	t.Helper()
+
+	return newTestHTTPMessageSignaturesAuthenticatorWithComponents(
+		t,
+		privateKey,
+		errorSignalingEnabled,
+		[]string{"@method", "@authority", "@path"},
+	)
+}
+
+func newTestHTTPMessageSignaturesAuthenticatorWithComponents(
+	t *testing.T,
+	privateKey ed25519.PrivateKey,
+	errorSignalingEnabled bool,
+	requiredComponents []string,
+) *httpMessageSignaturesAuthenticator {
+	t.Helper()
+
+	validator, err := validation.NewValidator()
+	require.NoError(t, err)
+
+	resolver := secretsmocks.NewResolverMock(t)
+	handle := secretsmocks.NewSecretSetHandleMock(t)
+
+	resolver.EXPECT().
+		SecretSet(secrets.Reference{Source: "hms_keys", Selector: "clients"}).
+		Return(handle, nil)
+
+	handle.EXPECT().
+		OnUpdate(mock.MatchedBy(func(cb secrets.UpdateFunc[[]secrets.Secret]) bool {
+			err := cb(t.Context(), []secrets.Secret{
+				secrettypes.NewAsymmetricKeySecret("test-key", "test-key", privateKey, nil),
+			})
+			require.NoError(t, err)
+
+			return true
+		}))
+
+	appCtx := app.NewContextMock(t)
+	appCtx.EXPECT().Logger().Return(log.Logger)
+	appCtx.EXPECT().SecretResolver().Maybe().Return(resolver)
+	appCtx.EXPECT().
+		DecoderFactory().
+		Return(encoding.NewDecoderFactory(encoding.ValidatorFunc(validator.ValidateStruct)))
+
+	rawComponents := make([]any, 0, len(requiredComponents))
+	for _, component := range requiredComponents {
+		rawComponents = append(rawComponents, component)
+	}
+
+	mechanism, err := newHTTPMessageSignaturesAuthenticator(appCtx, AuthenticatorHTTPMessageSignatures, config.MechanismConfig{
+		"key_store": map[string]any{
+			"source":   "hms_keys",
+			"selector": "clients",
+		},
+		"required_components": rawComponents,
+		"tag":                 "hms",
+		"principal": map[string]any{
+			"id": "key_id",
+		},
+		"error_signaling": map[string]any{
+			"enabled": errorSignalingEnabled,
+		},
+	})
+	require.NoError(t, err)
+
+	auth, ok := mechanism.(*httpMessageSignaturesAuthenticator)
+	require.True(t, ok)
+
+	return auth
+}
+
+func newTestAppContext(t *testing.T) app.Context {
+	t.Helper()
+
+	validator, err := validation.NewValidator()
+	require.NoError(t, err)
+
+	appCtx := app.NewContextMock(t)
+	appCtx.EXPECT().Logger().Return(log.Logger)
+	appCtx.EXPECT().SecretResolver().Maybe().Return(secretsmocks.NewResolverMock(t))
+	appCtx.EXPECT().
+		DecoderFactory().
+		Return(encoding.NewDecoderFactory(encoding.ValidatorFunc(validator.ValidateStruct)))
+
+	return appCtx
+}
+
+func newSignedHMSRequest(t *testing.T, privateKey ed25519.PrivateKey) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "https://api.example.test/foo", nil)
+
+	signer, err := httpsig.NewSigner(
+		httpsig.Key{KeyID: "test-key", Algorithm: httpsig.Ed25519, Key: privateKey},
+		httpsig.WithComponents("@method", "@authority", "@path"),
+		httpsig.WithTag("hms"),
+	)
+	require.NoError(t, err)
+
+	headers, err := signer.Sign(httpsig.MessageFromRequest(req))
+	require.NoError(t, err)
+
+	req.Header = headers
+
+	return req
+}
+
+func newSignedHMSRequestWithBody(t *testing.T, privateKey ed25519.PrivateKey, body []byte) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "https://api.example.test/foo", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+
+	signer, err := httpsig.NewSigner(
+		httpsig.Key{KeyID: "test-key", Algorithm: httpsig.Ed25519, Key: privateKey},
+		httpsig.WithComponents("@method", "@authority", "@path", "content-digest", "content-length", "content-type"),
+		httpsig.WithTag("hms"),
+	)
+	require.NoError(t, err)
+
+	headers, err := signer.Sign(httpsig.MessageFromRequest(req))
+	require.NoError(t, err)
+
+	req.Header = headers
+	req.Body = io.NopCloser(bytes.NewReader(body))
+
+	return req
+}
+
+func newSignedHMSRequestForAuthority(
+	t *testing.T,
+	privateKey ed25519.PrivateKey,
+	authority string,
+) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "https://heimdall.internal/foo", nil)
+	msgURL := &url.URL{
+		Scheme: "https",
+		Host:   authority,
+		Path:   "/foo",
+	}
+
+	signer, err := httpsig.NewSigner(
+		httpsig.Key{KeyID: "test-key", Algorithm: httpsig.Ed25519, Key: privateKey},
+		httpsig.WithComponents("@method", "@authority", "@path"),
+		httpsig.WithTag("hms"),
+	)
+	require.NoError(t, err)
+
+	headers, err := signer.Sign(&httpsig.Message{
+		Context:   req.Context(),
+		Method:    req.Method,
+		Authority: authority,
+		URL:       msgURL,
+		Header:    req.Header.Clone(),
+		Body:      func() (io.ReadCloser, error) { return http.NoBody, nil },
+		IsRequest: true,
+	})
+	require.NoError(t, err)
+
+	req.Header = headers
+
+	return req
+}
+
+type readLimitAssertingReadCloser struct {
+	reader  *bytes.Reader
+	maxRead int64
+	read    int64
+}
+
+func (r *readLimitAssertingReadCloser) Read(data []byte) (int, error) {
+	if r.read >= r.maxRead {
+		return 0, assert.AnError
+	}
+
+	remaining := r.maxRead - r.read
+	if int64(len(data)) > remaining {
+		data = data[:remaining]
+	}
+
+	n, err := r.reader.Read(data)
+	r.read += int64(n)
+
+	return n, err
+}
+
+func (*readLimitAssertingReadCloser) Close() error {
+	return nil
+}

--- a/internal/rules/mechanisms/finalizers/constants.go
+++ b/internal/rules/mechanisms/finalizers/constants.go
@@ -22,4 +22,5 @@ const (
 	FinalizerHeader                  = "header"
 	FinalizerCookie                  = "cookie"
 	FinalizerOAuth2ClientCredentials = "oauth2_client_credentials" // nolint: gosec
+	FinalizerHTTPMessageSignatures   = "http_message_signatures"
 )

--- a/internal/rules/mechanisms/finalizers/http_message_signatures_finalizer.go
+++ b/internal/rules/mechanisms/finalizers/http_message_signatures_finalizer.go
@@ -1,0 +1,516 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package finalizers
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/x509"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ccoveille/go-safecast/v2"
+	"github.com/dadrus/httpsig"
+	"github.com/inhies/go-bytesize"
+	"github.com/rs/zerolog"
+
+	"github.com/dadrus/heimdall/internal/app"
+	"github.com/dadrus/heimdall/internal/keyregistry"
+	"github.com/dadrus/heimdall/internal/pipeline"
+	"github.com/dadrus/heimdall/internal/rules/mechanisms/registry"
+	"github.com/dadrus/heimdall/internal/rules/mechanisms/template"
+	"github.com/dadrus/heimdall/internal/rules/mechanisms/types"
+	"github.com/dadrus/heimdall/internal/secrets"
+	"github.com/dadrus/heimdall/internal/x"
+	"github.com/dadrus/heimdall/internal/x/errorchain"
+	"github.com/dadrus/heimdall/internal/x/pkix"
+)
+
+const (
+	defaultHTTPMessageSignaturesTTL         = time.Minute
+	defaultHTTPMessageSignaturesMaxBodySize = bytesize.MB
+)
+
+// by intention. Used only during application bootstrap
+//
+//nolint:gochecknoinits
+func init() {
+	registry.Register(
+		types.KindFinalizer,
+		FinalizerHTTPMessageSignatures,
+		registry.FactoryFunc(newHTTPMessageSignaturesFinalizer),
+	)
+}
+
+type httpMessageSignaturesFinalizerConfig struct {
+	Signer      SignerConfig       `mapstructure:"signer"        validate:"required"`
+	Components  []string           `mapstructure:"components"    validate:"gt=0,dive,required"`
+	TTL         *time.Duration     `mapstructure:"ttl"           validate:"omitempty,gt=0"`
+	Label       string             `mapstructure:"label"`
+	MaxBodySize *bytesize.ByteSize `mapstructure:"max_body_size" validate:"omitempty,gt=0"`
+}
+
+type httpMessageSignaturesFinalizer struct {
+	name        string
+	id          string
+	app         app.Context
+	signer      *httpMessageSignaturesSigner
+	components  []string
+	ttl         time.Duration
+	label       string
+	maxBodySize bytesize.ByteSize
+}
+
+func newHTTPMessageSignaturesFinalizer(
+	app app.Context,
+	name string,
+	rawConfig map[string]any,
+) (types.Mechanism, error) {
+	logger := app.Logger()
+	logger.Info().
+		Str("_type", FinalizerHTTPMessageSignatures).
+		Str("_name", name).
+		Msg("Creating finalizer")
+
+	conf, err := decodeHTTPMessageSignaturesFinalizerConfig(app, name, rawConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	signer, err := newHTTPMessageSignaturesSigner(
+		&conf.Signer,
+		app.SecretResolver(),
+		app.KeyRegistry(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return newHTTPMessageSignaturesFinalizerFromConfig(app, name, name, conf, signer), nil
+}
+
+func decodeHTTPMessageSignaturesFinalizerConfig(
+	app app.Context,
+	name string,
+	rawConfig map[string]any,
+) (*httpMessageSignaturesFinalizerConfig, error) {
+	var conf httpMessageSignaturesFinalizerConfig
+	if err := decodeConfig(app, rawConfig, &conf,
+		template.WithName("finalizer."+FinalizerHTTPMessageSignatures+"."+name),
+		template.WithSecretResolver(app.SecretResolver()),
+	); err != nil {
+		return nil, errorchain.NewWithMessagef(
+			pipeline.ErrConfiguration,
+			"failed decoding config for %s finalizer '%s'", FinalizerHTTPMessageSignatures, name,
+		).CausedBy(err)
+	}
+
+	if err := validateHTTPMessageSignatureComponents(conf.Components); err != nil {
+		return nil, err
+	}
+
+	return &conf, nil
+}
+
+func validateHTTPMessageSignatureComponents(components []string) error {
+	for _, component := range components {
+		if strings.EqualFold(httpMessageSignatureComponentIdentifier(component), "host") {
+			return errorchain.NewWithMessage(
+				pipeline.ErrConfiguration,
+				"http message signatures finalizer requires @authority instead of host in components",
+			)
+		}
+	}
+
+	return nil
+}
+
+func httpMessageSignatureComponentIdentifier(component string) string {
+	identifier, _, _ := strings.Cut(component, ";")
+
+	return strings.TrimSpace(identifier)
+}
+
+func newHTTPMessageSignaturesFinalizerFromConfig(
+	app app.Context,
+	name, id string,
+	conf *httpMessageSignaturesFinalizerConfig,
+	signer *httpMessageSignaturesSigner,
+) *httpMessageSignaturesFinalizer {
+	return &httpMessageSignaturesFinalizer{
+		name:       name,
+		id:         id,
+		app:        app,
+		signer:     signer,
+		components: conf.Components,
+		ttl: x.IfThenElseExec(conf.TTL != nil,
+			func() time.Duration { return *conf.TTL },
+			func() time.Duration { return defaultHTTPMessageSignaturesTTL }),
+		label: x.IfThenElseExec(len(conf.Label) != 0,
+			func() string { return conf.Label },
+			func() string { return "sig" }),
+		maxBodySize: x.IfThenElseExec(conf.MaxBodySize != nil,
+			func() bytesize.ByteSize { return *conf.MaxBodySize },
+			func() bytesize.ByteSize { return defaultHTTPMessageSignaturesMaxBodySize }),
+	}
+}
+
+func (f *httpMessageSignaturesFinalizer) Execute(ctx pipeline.Context, _ pipeline.Subject) error {
+	logger := zerolog.Ctx(ctx.Context())
+	logger.Debug().
+		Str("_type", FinalizerHTTPMessageSignatures).
+		Str("_name", f.name).
+		Str("_id", f.id).
+		Msg("Executing finalizer")
+
+	registry, ok := ctx.(pipeline.HTTPMessageFinalizerRegistry)
+	if !ok {
+		return errorchain.NewWithMessage(
+			pipeline.ErrInternal,
+			"request context does not support http message finalization",
+		).WithAspects(f)
+	}
+
+	registry.AddHTTPMessageFinalizerForUpstream(
+		pipeline.NewHTTPMessageFinalizer(
+			safecast.MustConvert[int64](uint64(f.maxBodySize)),
+			f.sign,
+		),
+	)
+
+	return nil
+}
+
+func (f *httpMessageSignaturesFinalizer) CreateStep(
+	resolver secrets.Resolver,
+	def types.StepDefinition,
+) (pipeline.Step, error) {
+	if def.IsEmpty() {
+		return f, nil
+	}
+
+	if len(def.Config) == 0 {
+		fin := *f
+		fin.id = x.IfThenElse(len(def.ID) == 0, f.id, def.ID)
+
+		return &fin, nil
+	}
+
+	type Config struct {
+		Signer      *SignerConfig      `mapstructure:"signer"        validate:"not_allowed"`
+		Components  []string           `mapstructure:"components"    validate:"omitempty,dive,required"`
+		TTL         *time.Duration     `mapstructure:"ttl"           validate:"omitempty,gt=0"`
+		Label       string             `mapstructure:"label"`
+		MaxBodySize *bytesize.ByteSize `mapstructure:"max_body_size" validate:"omitempty,gt=0"`
+	}
+
+	var conf Config
+	if err := decodeConfig(f.app, def.Config, &conf,
+		template.WithName("finalizer."+FinalizerHTTPMessageSignatures+"."+f.name),
+		template.WithSecretResolver(resolver),
+	); err != nil {
+		return nil, errorchain.NewWithMessagef(
+			pipeline.ErrConfiguration,
+			"failed decoding config for %s finalizer '%s'", FinalizerHTTPMessageSignatures, f.name,
+		).CausedBy(err)
+	}
+
+	if len(conf.Components) != 0 {
+		if err := validateHTTPMessageSignatureComponents(conf.Components); err != nil {
+			return nil, err
+		}
+	}
+
+	return &httpMessageSignaturesFinalizer{
+		name:   f.name,
+		id:     x.IfThenElse(len(def.ID) == 0, f.id, def.ID),
+		app:    f.app,
+		signer: f.signer,
+		components: x.IfThenElseExec(len(conf.Components) != 0,
+			func() []string { return conf.Components },
+			func() []string { return f.components }),
+		ttl: x.IfThenElseExec(conf.TTL != nil,
+			func() time.Duration { return *conf.TTL },
+			func() time.Duration { return f.ttl }),
+		label: x.IfThenElseExec(len(conf.Label) != 0,
+			func() string { return conf.Label },
+			func() string { return f.label }),
+		maxBodySize: x.IfThenElseExec(conf.MaxBodySize != nil,
+			func() bytesize.ByteSize { return *conf.MaxBodySize },
+			func() bytesize.ByteSize { return f.maxBodySize }),
+	}, nil
+}
+
+func (f *httpMessageSignaturesFinalizer) Name() string            { return f.name }
+func (f *httpMessageSignaturesFinalizer) ID() string              { return f.id }
+func (f *httpMessageSignaturesFinalizer) Type() string            { return f.name }
+func (*httpMessageSignaturesFinalizer) Accept(_ pipeline.Visitor) {}
+func (*httpMessageSignaturesFinalizer) Kind() types.Kind          { return types.KindFinalizer }
+
+func (f *httpMessageSignaturesFinalizer) sign(msg *pipeline.HTTPMessage) (http.Header, error) {
+	header, err := f.signer.Sign(msg, f.components, f.ttl, f.label, f.maxBodySize)
+	if err != nil {
+		return nil, errorchain.NewWithMessage(
+			pipeline.ErrInternal,
+			"failed signing http message",
+		).WithAspects(f).CausedBy(err)
+	}
+
+	return header, nil
+}
+
+type httpMessageSignaturesSigner struct {
+	tag      string
+	ref      secrets.Reference
+	informer *secrets.SecretInformer[httpsig.Key]
+	ko       keyregistry.KeyObserver
+}
+
+func newHTTPMessageSignaturesSigner(
+	conf *SignerConfig,
+	resolver secrets.Resolver,
+	ko keyregistry.KeyObserver,
+) (*httpMessageSignaturesSigner, error) {
+	signer := &httpMessageSignaturesSigner{
+		tag: x.IfThenElse(len(conf.Name) == 0, "heimdall", conf.Name),
+		ref: secrets.Reference{
+			Source:   conf.Secret.Source,
+			Selector: conf.Secret.Selector,
+		},
+		ko: ko,
+	}
+
+	var err error
+
+	signer.informer, err = secrets.NewSecretInformer(
+		resolver,
+		signer.ref,
+		secrets.WithConverter(toHTTPSigSigningKey),
+		secrets.WithUpdateCallback(signer.onSecretUpdated),
+	)
+	if err != nil {
+		return nil, errorchain.NewWithMessage(
+			pipeline.ErrConfiguration,
+			"failed creating secret informer for http message signing material",
+		).CausedBy(err)
+	}
+
+	return signer, nil
+}
+
+func (s *httpMessageSignaturesSigner) Sign(
+	msg *pipeline.HTTPMessage,
+	components []string,
+	ttl time.Duration,
+	label string,
+	maxBodySize bytesize.ByteSize,
+) (http.Header, error) {
+	key, ok := s.informer.Get()
+	if !ok {
+		return nil, errorchain.NewWithMessage(
+			pipeline.ErrConfiguration,
+			"http message signing material is not available",
+		)
+	}
+
+	signer, err := httpsig.NewSigner(
+		key,
+		httpsig.WithComponents(components...),
+		httpsig.WithTTL(ttl),
+		httpsig.WithLabel(label),
+		httpsig.WithTag(s.tag),
+	)
+	if err != nil {
+		return nil, errorchain.NewWithMessage(
+			pipeline.ErrConfiguration,
+			"failed creating http message signer",
+		).CausedBy(err)
+	}
+
+	return signer.Sign(&httpsig.Message{
+		Context:   msg.Context,
+		Method:    msg.Method,
+		Authority: msg.Authority,
+		URL:       msg.URL,
+		Header:    msg.Header.Clone(),
+		Body: pipeline.HTTPMessageBodyWithMaxSize(
+			msg.Body,
+			safecast.MustConvert[int64](uint64(maxBodySize)),
+		),
+		IsRequest: true,
+	})
+}
+
+func (s *httpMessageSignaturesSigner) onSecretUpdated(_ context.Context, secret secrets.Secret, _ httpsig.Key) error {
+	if _, ok := secret.(secrets.AsymmetricKeySecret); ok && s.ko != nil {
+		s.ko.Notify(s.ref)
+	}
+
+	return nil
+}
+
+func toHTTPSigSigningKey(secret secrets.Secret) (httpsig.Key, error) {
+	switch key := secret.(type) {
+	case secrets.AsymmetricKeySecret:
+		return asymmetricSecretToHTTPSigSigningKey(key)
+	case secrets.SymmetricKeySecret:
+		return symmetricSecretToHTTPSigSigningKey(key)
+	default:
+		return httpsig.Key{}, errorchain.NewWithMessagef(
+			pipeline.ErrConfiguration,
+			"resolved secret '%s' is not suitable for http message signing",
+			secret.Selector(),
+		)
+	}
+}
+
+func asymmetricSecretToHTTPSigSigningKey(secret secrets.AsymmetricKeySecret) (httpsig.Key, error) {
+	privateKey := secret.PrivateKey()
+	if privateKey == nil {
+		return httpsig.Key{}, errorchain.NewWithMessagef(
+			pipeline.ErrConfiguration,
+			"resolved asymmetric secret '%s' does not contain private key material",
+			secret.Selector(),
+		)
+	}
+
+	if err := validateHTTPMessageSigningCertificate(secret); err != nil {
+		return httpsig.Key{}, err
+	}
+
+	alg, err := signingAlgorithm(privateKey.Public())
+	if err != nil {
+		return httpsig.Key{}, err
+	}
+
+	return httpsig.Key{
+		KeyID:     secret.KeyID(),
+		Algorithm: alg,
+		Key:       privateKey,
+	}, nil
+}
+
+func symmetricSecretToHTTPSigSigningKey(secret secrets.SymmetricKeySecret) (httpsig.Key, error) {
+	alg, err := hmacSigningAlgorithm(secret.Algorithm())
+	if err != nil {
+		return httpsig.Key{}, err
+	}
+
+	return httpsig.Key{
+		KeyID:     secret.KeyID(),
+		Algorithm: alg,
+		Key:       secret.Key(),
+	}, nil
+}
+
+func signingAlgorithm(publicKey crypto.PublicKey) (httpsig.SignatureAlgorithm, error) {
+	switch key := publicKey.(type) {
+	case *rsa.PublicKey:
+		return rsaSigningAlgorithm(key.Size() * 8) //nolint:mnd
+	case *ecdsa.PublicKey:
+		return ecdsaSigningAlgorithm(key.Params().BitSize)
+	case ed25519.PublicKey:
+		return httpsig.Ed25519, nil
+	default:
+		return "", errorchain.NewWithMessagef(
+			pipeline.ErrConfiguration,
+			"unsupported http message signing key type: %T",
+			publicKey,
+		)
+	}
+}
+
+func rsaSigningAlgorithm(keySize int) (httpsig.SignatureAlgorithm, error) {
+	switch keySize {
+	case 2048: //nolint:mnd
+		return httpsig.RsaPssSha256, nil
+	case 3072: //nolint:mnd
+		return httpsig.RsaPssSha384, nil
+	case 4096: //nolint:mnd
+		return httpsig.RsaPssSha512, nil
+	default:
+		return "", errorchain.NewWithMessagef(
+			pipeline.ErrConfiguration,
+			"unsupported RSA key size for http message signing: %d",
+			keySize,
+		)
+	}
+}
+
+func ecdsaSigningAlgorithm(keySize int) (httpsig.SignatureAlgorithm, error) {
+	switch keySize {
+	case 256: //nolint:mnd
+		return httpsig.EcdsaP256Sha256, nil
+	case 384: //nolint:mnd
+		return httpsig.EcdsaP384Sha384, nil
+	case 521: //nolint:mnd
+		return httpsig.EcdsaP521Sha512, nil
+	default:
+		return "", errorchain.NewWithMessagef(
+			pipeline.ErrConfiguration,
+			"unsupported ECDSA key size for http message signing: %d",
+			keySize,
+		)
+	}
+}
+
+func hmacSigningAlgorithm(alg string) (httpsig.SignatureAlgorithm, error) {
+	switch alg {
+	case string(httpsig.HmacSha256), "HS256":
+		return httpsig.HmacSha256, nil
+	case string(httpsig.HmacSha384), "HS384":
+		return httpsig.HmacSha384, nil
+	case string(httpsig.HmacSha512), "HS512":
+		return httpsig.HmacSha512, nil
+	default:
+		return "", errorchain.NewWithMessagef(
+			pipeline.ErrConfiguration,
+			"unsupported HMAC algorithm for http message signing: %s",
+			alg,
+		)
+	}
+}
+
+func validateHTTPMessageSigningCertificate(secret secrets.AsymmetricKeySecret) error {
+	chain := secret.CertChain()
+	if len(chain) == 0 {
+		return nil
+	}
+
+	opts := []pkix.ValidationOption{
+		pkix.WithKeyUsage(x509.KeyUsageDigitalSignature), //nolint:gosec
+		pkix.WithRootCACertificates([]*x509.Certificate{chain[len(chain)-1]}),
+		pkix.WithCurrentTime(time.Now()),
+	}
+
+	if len(chain) > 2 { //nolint:mnd
+		opts = append(opts, pkix.WithIntermediateCACertificates(chain[1:len(chain)-1]))
+	}
+
+	if err := pkix.ValidateCertificate(chain[0], opts...); err != nil {
+		return errorchain.NewWithMessage(
+			pipeline.ErrConfiguration,
+			"configured certificate cannot be used for http message signing purposes",
+		).CausedBy(err)
+	}
+
+	return nil
+}

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -1479,6 +1479,18 @@
         }
       }
     },
+    "httpMessageSignaturesErrorSignaling": {
+      "description": "Configures HTTP Message Signatures negotiation using the Accept-Signature response header.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Enables or disables HTTP Message Signatures error signaling.",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
     "authenticatorAnonymous": {
       "description": "Anonymous Authenticator",
       "type": "object",
@@ -1751,6 +1763,106 @@
             },
             "error_signaling": {
               "$ref": "#/definitions/basicAuthErrorSignaling"
+            }
+          }
+        }
+      }
+    },
+    "authenticatorHTTPMessageSignatures": {
+      "description": "HTTP Message Signatures Authenticator",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "const": "http_message_signatures"
+        },
+        "id": {
+          "description": "The unique id of the authenticator to be used in the rule definition",
+          "type": "string"
+        },
+        "config": {
+          "description": "HTTP Message Signatures Authenticator Configuration",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "key_store",
+            "required_components"
+          ],
+          "anyOf": [
+            {
+              "not": {
+                "required": ["validate_all_signatures"],
+                "properties": {
+                  "validate_all_signatures": { "const": false }
+                }
+              }
+            },
+            {
+              "required": ["tag"],
+              "properties": {
+                "tag": { "minLength": 1 }
+              }
+            }
+          ],
+          "properties": {
+            "key_store": {
+              "description": "The secret set containing verification keys.",
+              "$ref": "#/definitions/secretReference"
+            },
+            "required_components": {
+              "description": "The HTTP message components that must be covered by the signature.",
+              "type": "array",
+              "additionalItems": false,
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "not": {
+                  "pattern": "^\\s*[Hh][Oo][Ss][Tt](\\s*;.*)?$"
+                }
+              }
+            },
+            "tag": {
+              "description": "The required HTTP Message Signatures tag parameter.",
+              "type": "string"
+            },
+            "max_age": {
+              "type": "string",
+              "description": "Maximum accepted age of a signature.",
+              "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
+              "default": "30s"
+            },
+            "allowed_time_skew": {
+              "type": "string",
+              "description": "Allowed clock skew for created and expires signature parameters.",
+              "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
+              "default": "0s"
+            },
+            "max_body_size": {
+              "type": "string",
+              "description": "Maximum request body size that can be read while verifying signature components such as content-digest.",
+              "pattern": "^[0-9]+(B|KB|MB)$",
+              "default": "1MB"
+            },
+            "created_timestamp_required": {
+              "type": "boolean",
+              "description": "Whether the created signature parameter is required.",
+              "default": true
+            },
+            "expires_timestamp_required": {
+              "type": "boolean",
+              "description": "Whether the expires signature parameter is required.",
+              "default": true
+            },
+            "validate_all_signatures": {
+              "type": "boolean",
+              "description": "Whether all signatures should be validated when no tag is configured.",
+              "default": true
+            },
+            "principal": {
+              "$ref": "#/definitions/principalConfiguration"
+            },
+            "error_signaling": {
+              "$ref": "#/definitions/httpMessageSignaturesErrorSignaling"
             }
           }
         }
@@ -2134,6 +2246,85 @@
                 "type": "string"
               },
               "uniqueItems": true
+            }
+          }
+        }
+      }
+    },
+    "finalizerHTTPMessageSignatures": {
+      "description": "Signs the upstream HTTP request using HTTP Message Signatures",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "type",
+        "config"
+      ],
+      "properties": {
+        "type": {
+          "const": "http_message_signatures"
+        },
+        "id": {
+          "description": "The unique id of the finalizer to be used in the rule definition",
+          "type": "string"
+        },
+        "config": {
+          "description": "HTTP Message Signatures finalizer configuration",
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "signer",
+            "components"
+          ],
+          "properties": {
+            "signer": {
+              "description": "Configures signing key material and the signature tag.",
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "secret"
+              ],
+              "properties": {
+                "name": {
+                  "description": "The signer name used as the HTTP Message Signatures tag.",
+                  "type": "string",
+                  "default": "heimdall"
+                },
+                "secret": {
+                  "description": "Reference to a secret in the secret store to sign the HTTP message with.",
+                  "$ref": "#/definitions/secretReference"
+                }
+              }
+            },
+            "components": {
+              "description": "HTTP message components to cover with the signature. Use @authority for request authority coverage; host is rejected.",
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string"
+              }
+            },
+            "ttl": {
+              "description": "Sets the validity duration of the signature.",
+              "type": "string",
+              "pattern": "^[0-9]+(ns|us|ms|s|m|h)$",
+              "default": "1m",
+              "examples": [
+                "1h",
+                "1m",
+                "30s"
+              ]
+            },
+            "label": {
+              "description": "The signature label used in Signature and Signature-Input.",
+              "type": "string",
+              "default": "sig"
+            },
+            "max_body_size": {
+              "description": "Maximum request body size that can be read while signing components such as content-digest.",
+              "type": "string",
+              "pattern": "^\\d+(\\.\\d+)?\\s*(b|B|kb|kB|Kb|KB|mb|mB|Mb|MB|gb|gB|Gb|GB|tb|tB|Tb|TB|pb|pB|Pb|PB)$",
+              "default": "1MB"
             }
           }
         }
@@ -2557,6 +2748,13 @@
                   "properties": { "type": { "const": "basic_auth" } }
                 },
                 "then": { "$ref": "#/definitions/authenticatorBasicAuth" }
+              },
+              {
+                "if": {
+                  "required": ["type"],
+                  "properties": { "type": { "const": "http_message_signatures" } }
+                },
+                "then": { "$ref": "#/definitions/authenticatorHTTPMessageSignatures" }
               }
             ],
             "properties": {
@@ -2567,7 +2765,8 @@
                   "generic",
                   "oauth2_introspection",
                   "jwt",
-                  "basic_auth"
+                  "basic_auth",
+                  "http_message_signatures"
                 ]
               }
             }
@@ -2659,7 +2858,7 @@
             "required": ["type"],
             "properties": {
               "type": {
-                "enum": ["noop", "jwt", "header", "cookie", "oauth2_client_credentials"]
+                "enum": ["noop", "jwt", "header", "cookie", "oauth2_client_credentials", "http_message_signatures"]
               }
             },
             "allOf": [
@@ -2697,6 +2896,13 @@
                   "properties": { "type": { "const": "oauth2_client_credentials" } }
                 },
                 "then": { "$ref": "#/definitions/finalizerClientCredentials" }
+              },
+              {
+                "if": {
+                  "required": ["type"],
+                  "properties": { "type": { "const": "http_message_signatures" } }
+                },
+                "then": { "$ref": "#/definitions/finalizerHTTPMessageSignatures" }
               }
             ]
           }


### PR DESCRIPTION
## Summary

- add HTTP Message Signatures authentication support
- add HTTP Message Signatures finalizer support for decision and proxy mode
- add shared pipeline HTTP message finalization helpers with bounded body handling
- document the new authenticator/finalizer configuration and update the config schema

## Details

This implements RFC 9421 HTTP Message Signatures as both an authenticator and a finalizer.

For authentication, Heimdall can verify signed inbound requests and negotiate signature requirements through the existing authentication error decoration path.

For finalization, Heimdall can defer request signing until the final upstream message is known. This lets decision mode emit signature headers for the upstream request representation and lets proxy mode sign after `forward_to` rewriting but before the request is sent upstream.

Closes #2120.
Related to #2677.

## Verification

- `go test ./...`
- `golangci-lint run ./...`
- `git diff --check`
- `jq empty schema/config.schema.json`
