### PR TITLE
refactor!: Rule `match` configuration restructured for protocol-specific matching

### DIFF
--- a/charts/heimdall/templates/crds/ruleset.yaml
+++ b/charts/heimdall/templates/crds/ruleset.yaml
@@ -131,7 +131,7 @@ spec:
                                       description: The path to match
                                       type: string
                                       maxLength: 512
-                                    path_params:
+                                    captures:
                                       description: Optional matching definitions for the captured wildcard
                                       type: array
                                       items:

--- a/charts/heimdall/templates/crds/ruleset.yaml
+++ b/charts/heimdall/templates/crds/ruleset.yaml
@@ -115,10 +115,10 @@ spec:
                             description: HTTP-specific matching criteria
                             type: object
                             required:
-                              - routes
+                              - paths
                             properties:
-                              routes:
-                                description: Routes to match
+                              paths:
+                                description: Paths to match
                                 type: array
                                 minItems: 1
                                 items:

--- a/charts/heimdall/templates/crds/ruleset.yaml
+++ b/charts/heimdall/templates/crds/ruleset.yaml
@@ -122,7 +122,7 @@ spec:
                                 type: array
                                 minItems: 1
                                 items:
-                                  description: Definition of a single route
+                                  description: Definition of a single path matcher
                                   type: object
                                   required:
                                     - path

--- a/charts/heimdall/templates/crds/ruleset.yaml
+++ b/charts/heimdall/templates/crds/ruleset.yaml
@@ -109,87 +109,93 @@ spec:
                         description: How to match the rule
                         type: object
                         required:
-                          - routes
+                          - http
                         properties:
-                          routes:
-                            description: Routes to match
-                            type: array
-                            minItems: 1
-                            items:
-                              description: Definition of a single route
-                              type: object
-                              required:
-                                - path
-                              properties:
-                                path:
-                                  description: The path to match
+                          http:
+                            description: HTTP-specific matching criteria
+                            type: object
+                            required:
+                              - routes
+                            properties:
+                              routes:
+                                description: Routes to match
+                                type: array
+                                minItems: 1
+                                items:
+                                  description: Definition of a single route
+                                  type: object
+                                  required:
+                                    - path
+                                  properties:
+                                    path:
+                                      description: The path to match
+                                      type: string
+                                      maxLength: 512
+                                    path_params:
+                                      description: Optional matching definitions for the captured wildcard
+                                      type: array
+                                      items:
+                                        description: Matching definition for a single wildcard
+                                        type: object
+                                        required:
+                                          - name
+                                          - type
+                                          - value
+                                        properties:
+                                          name:
+                                            description: The name of a wildcard
+                                            type: string
+                                            maxLength: 64
+                                          type:
+                                            description: The type of the matching expression
+                                            type: string
+                                            maxLength: 5
+                                            enum:
+                                              - "exact"
+                                              - "glob"
+                                              - "regex"
+                                          value:
+                                            description: The actual matching expression
+                                            type: string
+                                            maxLength: 256
+                              methods:
+                                description: The HTTP methods to match
+                                type: array
+                                minItems: 1
+                                items:
                                   type: string
-                                  maxLength: 512
-                                path_params:
-                                  description: Optional matching definitions for the captured wildcard
-                                  type: array
-                                  items:
-                                    description: Matching definition for a single wildcard
-                                    type: object
-                                    required:
-                                      - name
-                                      - type
-                                      - value
-                                    properties:
-                                      name:
-                                        description: The name of a wildcard
-                                        type: string
-                                        maxLength: 64
-                                      type:
-                                        description: The type of the matching expression
-                                        type: string
-                                        maxLength: 5
-                                        enum:
-                                          - "exact"
-                                          - "glob"
-                                          - "regex"
-                                      value:
-                                        description: The actual matching expression
-                                        type: string
-                                        maxLength: 256
-                          methods:
-                            description: The HTTP methods to match
-                            type: array
-                            minItems: 1
-                            items:
-                              type: string
-                              maxLength: 16
-                              enum:
-                                - "CONNECT"
-                                - "!CONNECT"
-                                - "DELETE"
-                                - "!DELETE"
-                                - "GET"
-                                - "!GET"
-                                - "HEAD"
-                                - "!HEAD"
-                                - "OPTIONS"
-                                - "!OPTIONS"
-                                - "PATCH"
-                                - "!PATCH"
-                                - "POST"
-                                - "!POST"
-                                - "PUT"
-                                - "!PUT"
-                                - "TRACE"
-                                - "!TRACE"
-                                - "ALL"
-                          scheme:
-                            description: The HTTP scheme, which should be matched. If not set, http and https are matched
-                            type: string
-                            maxLength: 5
-                          hosts:
-                            description: Optional expressions to match the host if required. If not set, all hosts are matched.
-                            type: array
-                            items:
-                              description: Expression to match a host
-                              type: string
-                              maxLength: 256
+                                  maxLength: 16
+                                  enum:
+                                    - "CONNECT"
+                                    - "!CONNECT"
+                                    - "DELETE"
+                                    - "!DELETE"
+                                    - "GET"
+                                    - "!GET"
+                                    - "HEAD"
+                                    - "!HEAD"
+                                    - "OPTIONS"
+                                    - "!OPTIONS"
+                                    - "PATCH"
+                                    - "!PATCH"
+                                    - "POST"
+                                    - "!POST"
+                                    - "PUT"
+                                    - "!PUT"
+                                    - "TRACE"
+                                    - "!TRACE"
+                                    - "ALL"
+                              scheme:
+                                description: The HTTP scheme, which should be matched. If not set, http and https are matched
+                                type: string
+                                maxLength: 5
+                              hosts:
+                                description: Optional expressions to match the host if required. If not set, all hosts are matched.
+                                type: array
+                                items:
+                                  description: Expression to match a host
+                                  type: string
+                                  maxLength: 256
                       forward_to:
                         description: Where to forward the request to. Required only if heimdall is used in proxy operation mode.
                         type: object

--- a/cmd/convert/ruleset.go
+++ b/cmd/convert/ruleset.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/dadrus/heimdall/internal/config"
+	"github.com/dadrus/heimdall/internal/encoding"
 	"github.com/dadrus/heimdall/internal/rules/converter"
+	"github.com/dadrus/heimdall/internal/validation"
 	"github.com/dadrus/heimdall/internal/x"
 )
 
@@ -42,13 +45,23 @@ $ cat ruleset.yaml | heimdall convert ruleset --desired-version 1beta1 > convert
 }
 
 func convertRuleSet(cmd *cobra.Command, args []string) error {
+	es := config.EnforcementSettings{}
+
+	validator, err := validation.NewValidator(
+		validation.WithTagValidator(es),
+		validation.WithErrorTranslator(es),
+	)
+	if err != nil {
+		return err
+	}
+
 	inputFileName := x.IfThenElseExec(len(args) != 0,
 		func() string { return args[0] },
 		func() string { return "" },
 	)
 	outputFileName, _ := cmd.Flags().GetString(convertRuleSetFlagOutputFile)
 	targetVersion, _ := cmd.Flags().GetString(convertRuleSetFlagDesiredVersion)
-	conv := converter.New(targetVersion)
+	conv := converter.New(targetVersion, encoding.ValidatorFunc(validator.ValidateStruct))
 
 	var in io.Reader
 	if len(inputFileName) == 0 {

--- a/cmd/convert/ruleset.go
+++ b/cmd/convert/ruleset.go
@@ -2,6 +2,7 @@ package convert
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 
@@ -18,6 +19,8 @@ const (
 	convertRuleSetFlagDesiredVersion = "desired-version"
 	convertRuleSetFlagOutputFile     = "out"
 )
+
+var ErrEmptyRuleset = errors.New("ruleset must not be empty")
 
 // NewConvertRulesCommand represents the "convert rules" command.
 func NewConvertRulesCommand() *cobra.Command {
@@ -83,11 +86,16 @@ func convertRuleSet(cmd *cobra.Command, args []string) error {
 	}
 
 	contents = bytes.TrimSpace(contents)
+	if len(contents) == 0 {
+		return ErrEmptyRuleset
+	}
 
-	result, err := conv.Convert(
-		contents,
-		x.IfThenElse(contents[0] == '{', "application/json", "application/yaml"),
-	)
+	contentType := "application/yaml"
+	if len(contents) != 0 && contents[0] == '{' {
+		contentType = "application/json"
+	}
+
+	result, err := conv.Convert(contents, contentType)
 	if err != nil {
 		return err
 	}

--- a/cmd/convert/ruleset_test.go
+++ b/cmd/convert/ruleset_test.go
@@ -81,7 +81,7 @@ rules:
     backtracking_enabled: true
     scheme: http
     hosts:
-      - type: glob
+      - type: exact
         value: foo.bar
     methods: [GET, POST]
   forward_to:
@@ -129,7 +129,7 @@ rules:
       "backtracking_enabled": true,
       "scheme": "http",
       "hosts": [
-        { "type": "glob", "value": "foo.bar" } 
+        { "type": "exact", "value": "foo.bar" } 
       ],
       "methods": ["GET", "POST"]
     },
@@ -185,7 +185,7 @@ rules:
     backtracking_enabled: true
     scheme: http
     hosts:
-      - type: glob
+      - type: exact
         value: foo.bar
     methods: [GET, POST]
   forward_to:
@@ -253,7 +253,7 @@ rules:
     backtracking_enabled: true
     scheme: http
     hosts:
-      - type: glob
+      - type: exact
         value: foo.bar
     methods: [GET, POST]
   forward_to:
@@ -300,7 +300,7 @@ rules:
     backtracking_enabled: true
     scheme: http
     hosts:
-      - type: glob
+      - type: exact
         value: foo.bar
     methods: [GET, POST]
   forward_to:

--- a/cmd/convert/ruleset_test.go
+++ b/cmd/convert/ruleset_test.go
@@ -76,15 +76,14 @@ name: test-rule-set
 rules:
 - id: rule:foo
   match:
-    http:
-      paths:
-        - path: /**
-      backtracking_enabled: true
-      scheme: http
-      hosts:
-        - type: glob
-          value: foo.bar
-      methods: [GET, POST]
+    routes:
+      - path: /**
+    backtracking_enabled: true
+    scheme: http
+    hosts:
+      - type: glob
+        value: foo.bar
+    methods: [GET, POST]
   forward_to:
     host: bar.foo
     rewrite:
@@ -181,15 +180,14 @@ name: test-rule-set
 rules:
 - id: rule:foo
   match:
-    http:
-      paths:
-        - path: /**
-      backtracking_enabled: true
-      scheme: http
-      hosts:
-        - type: glob
-          value: foo.bar
-      methods: [GET, POST]
+    routes:
+      - path: /**
+    backtracking_enabled: true
+    scheme: http
+    hosts:
+      - type: glob
+        value: foo.bar
+    methods: [GET, POST]
   forward_to:
     host: bar.foo
     rewrite:
@@ -246,15 +244,18 @@ name: test-rule-set
 rules:
 - id: rule:foo
   match:
-    http:
-      paths:
-        - path: /**
-      backtracking_enabled: true
-      scheme: http
-      hosts:
-        - type: glob
-          value: foo.bar
-      methods: [GET, POST]
+    routes:
+      - path: /*foo
+        path_params:
+          - name: foo
+            type: glob
+            value: "{bar,baz}"
+    backtracking_enabled: true
+    scheme: http
+    hosts:
+      - type: glob
+        value: foo.bar
+    methods: [GET, POST]
   forward_to:
     host: bar.foo
     rewrite:
@@ -294,15 +295,14 @@ name: test-rule-set
 rules:
 - id: rule:foo
   match:
-    http:
-      paths:
-        - path: /**
-      backtracking_enabled: true
-      scheme: http
-      hosts:
-        - type: glob
-          value: foo.bar
-      methods: [GET, POST]
+    routes:
+      - path: /**
+    backtracking_enabled: true
+    scheme: http
+    hosts:
+      - type: glob
+        value: foo.bar
+    methods: [GET, POST]
   forward_to:
     host: bar.foo
     rewrite:

--- a/cmd/convert/ruleset_test.go
+++ b/cmd/convert/ruleset_test.go
@@ -76,14 +76,15 @@ name: test-rule-set
 rules:
 - id: rule:foo
   match:
-    routes:
-      - path: /**
-    backtracking_enabled: true
-    scheme: http
-    hosts:
-      - type: glob
-        value: foo.bar
-    methods: [GET, POST]
+    http:
+      routes:
+        - path: /**
+      backtracking_enabled: true
+      scheme: http
+      hosts:
+        - type: glob
+          value: foo.bar
+      methods: [GET, POST]
   forward_to:
     host: bar.foo
     rewrite:
@@ -180,14 +181,15 @@ name: test-rule-set
 rules:
 - id: rule:foo
   match:
-    routes:
-      - path: /**
-    backtracking_enabled: true
-    scheme: http
-    hosts:
-      - type: glob
-        value: foo.bar
-    methods: [GET, POST]
+    http:
+      routes:
+        - path: /**
+      backtracking_enabled: true
+      scheme: http
+      hosts:
+        - type: glob
+          value: foo.bar
+      methods: [GET, POST]
   forward_to:
     host: bar.foo
     rewrite:
@@ -244,14 +246,15 @@ name: test-rule-set
 rules:
 - id: rule:foo
   match:
-    routes:
-      - path: /**
-    backtracking_enabled: true
-    scheme: http
-    hosts:
-      - type: glob
-        value: foo.bar
-    methods: [GET, POST]
+    http:
+      routes:
+        - path: /**
+      backtracking_enabled: true
+      scheme: http
+      hosts:
+        - type: glob
+          value: foo.bar
+      methods: [GET, POST]
   forward_to:
     host: bar.foo
     rewrite:
@@ -291,14 +294,15 @@ name: test-rule-set
 rules:
 - id: rule:foo
   match:
-    routes:
-      - path: /**
-    backtracking_enabled: true
-    scheme: http
-    hosts:
-      - type: glob
-        value: foo.bar
-    methods: [GET, POST]
+    http:
+      routes:
+        - path: /**
+      backtracking_enabled: true
+      scheme: http
+      hosts:
+        - type: glob
+          value: foo.bar
+      methods: [GET, POST]
   forward_to:
     host: bar.foo
     rewrite:

--- a/cmd/convert/ruleset_test.go
+++ b/cmd/convert/ruleset_test.go
@@ -77,7 +77,7 @@ rules:
 - id: rule:foo
   match:
     http:
-      routes:
+      paths:
         - path: /**
       backtracking_enabled: true
       scheme: http
@@ -182,7 +182,7 @@ rules:
 - id: rule:foo
   match:
     http:
-      routes:
+      paths:
         - path: /**
       backtracking_enabled: true
       scheme: http
@@ -247,7 +247,7 @@ rules:
 - id: rule:foo
   match:
     http:
-      routes:
+      paths:
         - path: /**
       backtracking_enabled: true
       scheme: http
@@ -295,7 +295,7 @@ rules:
 - id: rule:foo
   match:
     http:
-      routes:
+      paths:
         - path: /**
       backtracking_enabled: true
       scheme: http

--- a/cmd/convert/ruleset_test.go
+++ b/cmd/convert/ruleset_test.go
@@ -331,6 +331,27 @@ rules:
 				assert.Contains(t, result, "version: 1beta1")
 			},
 		},
+		"conversion of an empty ruleset": {
+			args: func(t *testing.T, _ io.Writer) []string {
+				t.Helper()
+
+				rulesetFile := filepath.Join(t.TempDir(), "ruleset.yaml")
+				err := os.WriteFile(rulesetFile, []byte(" \n\t"), 0o600)
+				require.NoError(t, err)
+
+				return []string{
+					"--" + convertRuleSetFlagDesiredVersion,
+					"1beta1",
+					rulesetFile,
+				}
+			},
+			assert: func(t *testing.T, err error, _ string) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrEmptyRuleset)
+			},
+		},
 	} {
 		t.Run(uc, func(t *testing.T) {
 			// GIVEN

--- a/cmd/validate/test_data/ruleset-invalid-for-proxy-usage.yaml
+++ b/cmd/validate/test_data/ruleset-invalid-for-proxy-usage.yaml
@@ -4,7 +4,7 @@ rules:
 - id: rule:foo
   match:
     http:
-      routes:
+      paths:
         - path: /**
       scheme: http
       hosts:

--- a/cmd/validate/test_data/ruleset-invalid-for-proxy-usage.yaml
+++ b/cmd/validate/test_data/ruleset-invalid-for-proxy-usage.yaml
@@ -3,12 +3,13 @@ name: test-rule-set
 rules:
 - id: rule:foo
   match:
-    routes:
-      - path: /**
-    scheme: http
-    hosts:
-      - foo.bar
-    methods: [ GET, POST ]
+    http:
+      routes:
+        - path: /**
+      scheme: http
+      hosts:
+        - foo.bar
+      methods: [ GET, POST ]
   execute:
     - authenticator: unauthorized_authenticator
     - authenticator: jwt_authenticator1

--- a/cmd/validate/test_data/ruleset-no-https-for-upstream.yaml
+++ b/cmd/validate/test_data/ruleset-no-https-for-upstream.yaml
@@ -3,12 +3,13 @@ name: test-rule-set
 rules:
 - id: rule:foo
   match:
-    routes:
-      - path: /**
-    scheme: http
-    hosts:
-      - "*.foo.bar"
-    methods: [ GET, POST ]
+    http:
+      routes:
+        - path: /**
+      scheme: http
+      hosts:
+        - "*.foo.bar"
+      methods: [ GET, POST ]
   forward_to:
     host: bar.foo
     rewrite:

--- a/cmd/validate/test_data/ruleset-no-https-for-upstream.yaml
+++ b/cmd/validate/test_data/ruleset-no-https-for-upstream.yaml
@@ -4,7 +4,7 @@ rules:
 - id: rule:foo
   match:
     http:
-      routes:
+      paths:
         - path: /**
       scheme: http
       hosts:

--- a/cmd/validate/test_data/ruleset-only-custom-principals.yaml
+++ b/cmd/validate/test_data/ruleset-only-custom-principals.yaml
@@ -4,7 +4,7 @@ rules:
 - id: rule:foo
   match:
     http:
-      routes:
+      paths:
         - path: /**
       scheme: http
       hosts:

--- a/cmd/validate/test_data/ruleset-only-custom-principals.yaml
+++ b/cmd/validate/test_data/ruleset-only-custom-principals.yaml
@@ -3,14 +3,15 @@ name: test-rule-set
 rules:
 - id: rule:foo
   match:
-    routes:
-      - path: /**
-    scheme: http
-    hosts:
-      - foo.bar
-    methods:
-      - POST
-      - PUT
+    http:
+      routes:
+        - path: /**
+      scheme: http
+      hosts:
+        - foo.bar
+      methods:
+        - POST
+        - PUT
   forward_to:
     host: bar.foo
     rewrite:

--- a/cmd/validate/test_data/ruleset-valid-with-default-and-custom-principals.yaml
+++ b/cmd/validate/test_data/ruleset-valid-with-default-and-custom-principals.yaml
@@ -4,7 +4,7 @@ rules:
 - id: rule:foo
   match:
     http:
-      routes:
+      paths:
         - path: /**
       scheme: http
       hosts:

--- a/cmd/validate/test_data/ruleset-valid-with-default-and-custom-principals.yaml
+++ b/cmd/validate/test_data/ruleset-valid-with-default-and-custom-principals.yaml
@@ -3,14 +3,15 @@ name: test-rule-set
 rules:
 - id: rule:foo
   match:
-    routes:
-      - path: /**
-    scheme: http
-    hosts:
-      - foo.bar
-    methods:
-      - POST
-      - PUT
+    http:
+      routes:
+        - path: /**
+      scheme: http
+      hosts:
+        - foo.bar
+      methods:
+        - POST
+        - PUT
   forward_to:
     host: bar.foo
     rewrite:

--- a/cmd/validate/test_data/ruleset-valid-without-specifying-principals.yaml
+++ b/cmd/validate/test_data/ruleset-valid-without-specifying-principals.yaml
@@ -4,7 +4,7 @@ rules:
 - id: rule:foo
   match:
     http:
-      routes:
+      paths:
         - path: /**
       scheme: http
       hosts:

--- a/cmd/validate/test_data/ruleset-valid-without-specifying-principals.yaml
+++ b/cmd/validate/test_data/ruleset-valid-without-specifying-principals.yaml
@@ -3,14 +3,15 @@ name: test-rule-set
 rules:
 - id: rule:foo
   match:
-    routes:
-      - path: /**
-    scheme: http
-    hosts:
-      - foo.bar
-    methods:
-      - POST
-      - PUT
+    http:
+      routes:
+        - path: /**
+      scheme: http
+      hosts:
+        - foo.bar
+      methods:
+        - POST
+        - PUT
   forward_to:
     host: bar.foo
     rewrite:

--- a/docs/content/_index.adoc
+++ b/docs/content/_index.adoc
@@ -23,11 +23,12 @@ spec:
   rules:
     - id: my_api_rule
       match:
-        routes:
-          - path: /api/**
-        scheme: http
-        hosts:
-          - 127.0.0.1:9090
+        http:
+          routes:
+            - path: /api/**
+          scheme: http
+          hosts:
+            - 127.0.0.1:9090
       execute:
         - authenticator: keycloak
         - authorizer: opa

--- a/docs/content/_index.adoc
+++ b/docs/content/_index.adoc
@@ -24,7 +24,7 @@ spec:
     - id: my_api_rule
       match:
         http:
-          routes:
+          paths:
             - path: /api/**
           scheme: http
           hosts:

--- a/docs/content/docs/concepts/operating_modes.adoc
+++ b/docs/content/docs/concepts/operating_modes.adoc
@@ -77,7 +77,7 @@ And there is a rule, which allows anonymous requests and sets a `X-User-ID` head
 id: rule:my-service:anonymous-api-access
 match:
   http:
-    routes:
+    paths:
       - path: /my-service/api
     scheme: http
     hosts:
@@ -150,7 +150,7 @@ And there is a rule, which allows anonymous requests and sets a `X-User-ID` head
 id: rule:my-service:anonymous-api-access
 match:
   http:
-    routes:
+    paths:
       - path: /my-service/api
     methods:
       - GET

--- a/docs/content/docs/concepts/operating_modes.adoc
+++ b/docs/content/docs/concepts/operating_modes.adoc
@@ -76,13 +76,14 @@ And there is a rule, which allows anonymous requests and sets a `X-User-ID` head
 ----
 id: rule:my-service:anonymous-api-access
 match:
-  routes:
-    - path: /my-service/api
-  scheme: http
-  hosts:
-    - my-backend-service
-  methods:
-    - GET
+  http:
+    routes:
+      - path: /my-service/api
+    scheme: http
+    hosts:
+      - my-backend-service
+    methods:
+      - GET
 execute:
   - authenticator: anonymous-authn
   - finalizer: id-header
@@ -148,10 +149,11 @@ And there is a rule, which allows anonymous requests and sets a `X-User-ID` head
 ----
 id: rule:my-service:anonymous-api-access
 match:
-  routes:
-    - path: /my-service/api
-  methods:
-    - GET
+  http:
+    routes:
+      - path: /my-service/api
+    methods:
+      - GET
 forward_to:
   host: my-backend-service:8888
 execute:

--- a/docs/content/docs/getting_started/protect_an_app.adoc
+++ b/docs/content/docs/getting_started/protect_an_app.adoc
@@ -148,7 +148,7 @@ rules:
 - id: demo:public  # <1>
   match:
     http:
-      routes:
+      paths:
         - path: /public
   forward_to:
     host: upstream:8081
@@ -159,7 +159,7 @@ rules:
 - id: demo:protected  # <2>
   match:
     http:
-      routes:
+      paths:
         - path: /:user
           path_params:
             - name: user

--- a/docs/content/docs/getting_started/protect_an_app.adoc
+++ b/docs/content/docs/getting_started/protect_an_app.adoc
@@ -147,8 +147,9 @@ version: "1beta1"
 rules:
 - id: demo:public  # <1>
   match:
-    routes:
-      - path: /public
+    http:
+      routes:
+        - path: /public
   forward_to:
     host: upstream:8081
   execute:
@@ -157,12 +158,13 @@ rules:
 
 - id: demo:protected  # <2>
   match:
-    routes:
-      - path: /:user
-        path_params:
-          - name: user
-            type: glob
-            value: "{user,admin}"
+    http:
+      routes:
+        - path: /:user
+          path_params:
+            - name: user
+              type: glob
+              value: "{user,admin}"
   forward_to:
     host: upstream:8081
   execute:

--- a/docs/content/docs/getting_started/protect_an_app.adoc
+++ b/docs/content/docs/getting_started/protect_an_app.adoc
@@ -161,7 +161,7 @@ rules:
     http:
       paths:
         - path: /:user
-          path_params:
+          captures:
             - name: user
               type: glob
               value: "{user,admin}"

--- a/docs/content/docs/operations/migration.adoc
+++ b/docs/content/docs/operations/migration.adoc
@@ -25,6 +25,13 @@ Starting with v0.18.0, this issue is addressed through:
 * A new `convert` CLI command that allows conversion of existing `RuleSet` definitions.
 * A conversion controller for Kubernetes, registered with the API server through the `RuleSet` CRD.
 
+[CAUTION]
+====
+Automatic conversion covers structural changes to the `RuleSet` schema, such as renamed, moved, or restructured properties. It cannot, however, migrate settings that were deprecated and later removed without a well-defined, unambiguous mapping to their replacement. Such settings must be adjusted manually before conversion is attempted.
+
+For example, v0.17.0 deprecated the `regex` and `glob` `hosts[].type` values in favor of `exact` and `wildcard`, and v0.18.0 removed support for `regex` and `glob` entirely, while also simplifying the host matcher configuration itself. Conversion therefore migrates `exact` and `wildcard` entries automatically, but fails with an error if a `RuleSet` still uses `regex` or `glob` host types, rather than silently dropping or misconverting them. Such `RuleSets` must be migrated manually first — as described in the release notes of the version that removed the deprecated value — before conversion can succeed.
+====
+
 The following sections describe both the legacy and the new automated upgrade and migration procedures for heimdall releases introducing breaking changes to existing `RuleSets`, for installations inside and outside Kubernetes.
 
 NOTE: The following upgrade and migration steps are described in an imperative way for the sake of clarity and to remain product-neutral. However, all steps can be easily adapted to declarative, GitOps-based workflows using tools such as Flux, ArgoCD, or similar.

--- a/docs/content/docs/rules/default_rule.adoc
+++ b/docs/content/docs/rules/default_rule.adoc
@@ -57,8 +57,9 @@ Obviously, the authentication & authorization pipeline (defined in the `execute`
 ----
 id: rule:my-service:protected-api
 match:
-  routes:
-    - path: /foo
+  http:
+    routes:
+      - path: /foo
 execute:
   - authorizer: allow_all_requests_authz
 ----

--- a/docs/content/docs/rules/default_rule.adoc
+++ b/docs/content/docs/rules/default_rule.adoc
@@ -58,7 +58,7 @@ Obviously, the authentication & authorization pipeline (defined in the `execute`
 id: rule:my-service:protected-api
 match:
   http:
-    routes:
+    paths:
       - path: /foo
 execute:
   - authorizer: allow_all_requests_authz

--- a/docs/content/docs/rules/providers.adoc
+++ b/docs/content/docs/rules/providers.adoc
@@ -49,11 +49,12 @@ name: my-rule-set
 rules:
 - id: rule:1
   match:
-    routes:
-      - path: /**
-    hosts:
-      - my-service1.local
-    methods: [ "GET" ]
+    http:
+      routes:
+        - path: /**
+      hosts:
+        - my-service1.local
+      methods: [ "GET" ]
   forward_to:
     host: ${UPSTREAM_HOST:="default-backend:8080"}
   execute:

--- a/docs/content/docs/rules/providers.adoc
+++ b/docs/content/docs/rules/providers.adoc
@@ -50,7 +50,7 @@ rules:
 - id: rule:1
   match:
     http:
-      routes:
+      paths:
         - path: /**
       hosts:
         - my-service1.local

--- a/docs/content/docs/rules/regular_rule.adoc
+++ b/docs/content/docs/rules/regular_rule.adoc
@@ -145,16 +145,17 @@ Specifies error handling mechanisms if the pipeline defined by the `execute` pro
 ----
 id: rule:foo:bar
 match:
-  routes:
-    - path: /some/:identifier/followed/by/**
-      path_params:
-        - name: identifier
-          type: glob
-          value: "[a-z]"
-  scheme: https
-  hosts:
-    - my-service.local
-  methods:
+  http:
+    routes:
+      - path: /some/:identifier/followed/by/**
+        path_params:
+          - name: identifier
+            type: glob
+            value: "[a-z]"
+    scheme: https
+    hosts:
+      - my-service.local
+    methods:
       - GET
       - POST
 forward_to:
@@ -210,10 +211,11 @@ Here is an example demonstrating the usage of a single named wildcard:
 ----
 id: rule:1
 match:
-  routes:
-    - path: /files/:uuid/delete
-  hosts:
-    - hosty.mchostface
+  http:
+    routes:
+      - path: /files/:uuid/delete
+    hosts:
+      - hosty.mchostface
   execute:
     - authorizer: openfga_check
       config:
@@ -249,19 +251,21 @@ Consider a rule set with the following rules
 ----
 - id: rule1
   match:
-    routes:
-      - path: /files/**
+    http:
+      routes:
+        - path: /files/**
   execute:
     - <pipeline definition>
 
 - id: rule2
   match:
-    routes:
-      - path: /files/:team/:name
-        path_params:
-          - name: team
-            type: regex
-            value: "(team1|team2)"
+    http:
+      routes:
+        - path: /files/:team/:name
+          path_params:
+            - name: team
+              type: regex
+              value: "(team1|team2)"
     methods:
       - GET
   execute:
@@ -269,19 +273,21 @@ Consider a rule set with the following rules
 
 - id: rule3
   match:
-    routes:
-      - path: /files/:team/:name
-        path_params:
-          - name: team
-            type: regex
-            value: "(team1|team2)"
+    http:
+      routes:
+        - path: /files/:team/:name
+          path_params:
+            - name: team
+              type: regex
+              value: "(team1|team2)"
   execute:
     - <pipeline definition>
 
 - id: rule4
   match:
-    routes:
-      - path: /files/team3/:name
+    http:
+      routes:
+        - path: /files/team3/:name
   execute:
     - <pipeline definition>
 ----
@@ -303,15 +309,17 @@ Here’s another example:
 ----
 - id: rule1
   match:
-    routes:
-      - path: /foo/**
+    http:
+      routes:
+        - path: /foo/**
   execute:
     - <pipeline definition>
 
 - id: rule2
   match:
-    routes:
-      - path: /foo/bar/:name
+    http:
+      routes:
+        - path: /foo/bar/:name
   execute:
     - <pipeline definition>
 ----

--- a/docs/content/docs/rules/regular_rule.adoc
+++ b/docs/content/docs/rules/regular_rule.adoc
@@ -122,11 +122,11 @@ on_error:
 ----
 ====
 
-== Request Matching
+=== Request Matching
 
 A rule is matched against an incoming request using the protocol matcher configured in its `match` property. Exactly one protocol matcher must be configured. Each matcher defines its own, protocol-specific set of matching criteria, described in the following sections.
 
-=== HTTP Matcher
+==== HTTP Matcher
 
 The `http` matcher evaluates matching criteria against HTTP requests. It supports the following properties:
 
@@ -251,15 +251,15 @@ match:
       - path: /files/:uuid/delete
     hosts:
       - hosty.mchostface
-  execute:
-    - authorizer: openfga_check
-      config:
-        payload: |
-          {
-            "user": "{{ .Subject.ID }}",
-            "relation": "can_delete",
-            "object": "file:{{ .Request.URL.Captures.uuid }}"
-          }
+execute:
+  - authorizer: openfga_check
+    config:
+      payload: |
+        {
+          "user": "{{ .Subject.ID }}",
+          "relation": "can_delete",
+          "object": "file:{{ .Request.URL.Captures.uuid }}"
+        }
 ----
 
 == Rule Matching Specificity & Backtracking
@@ -478,7 +478,7 @@ This example uses
 
 == Error Pipeline
 
-Compared to the link:{{< relref "#_authentication_authorization_pipeline" >}}[Authentication & Authorization Pipeline], the error pipeline is pretty simple. It is also a list of mechanism references, but all referenced types are link:{{< relref "/docs/mechanisms/error_handlers.adoc" >}}[error handler types]. Thus, each entry in this list must have `error_handler` as key, followed by the `ìd` of the required error handler previously defined in the link:{{< relref "/docs/mechanisms/catalogue.adoc" >}}[mechanism catalogue].
+Compared to the link:{{< relref "#_authentication_authorization_pipeline" >}}[Authentication & Authorization Pipeline], the error pipeline is pretty simple. It is also a list of mechanism references, but all referenced types are link:{{< relref "/docs/mechanisms/error_handlers.adoc" >}}[error handler types]. Thus, each entry in this list must have `error_handler` as key, followed by the `id` of the required error handler previously defined in the link:{{< relref "/docs/mechanisms/catalogue.adoc" >}}[mechanism catalogue].
 
 Execution of the error handlers should happen conditionally by making use of a https://github.com/google/cel-spec[CEL] expression in an `if` clause, which has access to the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_error" >}}[`Error`] and the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_request" >}}[`Request`] objects. Otherwise, the first error handler will be executed and the error pipeline will exit.
 

--- a/docs/content/docs/rules/regular_rule.adoc
+++ b/docs/content/docs/rules/regular_rule.adoc
@@ -151,7 +151,7 @@ The name of the wildcard.
 The type of expression used to match the captured wildcard's value. The supported types are:
 
 **** `glob`: to use a https://github.com/gobwas/glob[glob expression] to match the captured value (`/` is used as a delimiter, so `*` matches anything until the next `/`).
-**** `regex` to use a regular expression to match the captured value.
+**** `regex`: to use a regular expression to match the captured value.
 
 *** *`value`*: _string_ (mandatory)
 +
@@ -301,8 +301,8 @@ Consider a rule set with the following rules
             - name: team
               type: regex
               value: "(team1|team2)"
-    methods:
-      - GET
+      methods:
+        - GET
   execute:
     - <pipeline definition>
 

--- a/docs/content/docs/rules/regular_rule.adoc
+++ b/docs/content/docs/rules/regular_rule.adoc
@@ -136,11 +136,11 @@ Specifies path conditions for matching the rule to incoming HTTP requests with e
 
 ** *`path`*: _string_ (mandatory)
 +
-The link:{{< relref "#_capture_expressions" >}}[Capture Expression] describing the request path this rule should match. It supports both simple and free (named) wildcards.
+The link:{{< relref "#_capture_expressions" >}}[Capture Expression] describing the request path this rule should match. It supports both single and free (named) wildcards.
 
 ** *`captures`*: _CaptureConditions_ (optional)
 +
-Additional conditions which must be met for the values captured by named wildcards in the path expression. All defined conditions must succeed for the request path to be considered a match. Each entry supports the following properties:
+Additional conditions that must be met for the values captured by named wildcards in the path expression. All defined conditions must succeed for the request path to be considered a match. Each entry supports the following properties:
 
 *** *`name`*: _string_ (mandatory)
 +
@@ -217,7 +217,7 @@ When specifying these, you can make use of two types of wildcards:
 * free wildcard, which can be defined using `*` and
 * single wildcard, which can be defined using `:`
 
-Both can be named and unnamed, with named wildcards allowing accessing of the matched segments in the pipeline of the rule using the defined name as a key on the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_url_captures" >}}[`Request.URL.Captures`] object. Unnamed free wildcard is defined as `\**` and unnamed single wildcard is defined as `:*`. A named wildcard uses some identifier instead of the `*`, so like `*name` for free wildcard and `:name` for single wildcard.
+Both can be named and unnamed, with named wildcards allowing accessing of the matched segments in the pipeline of the rule using the defined name as a key on the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_url_captures" >}}[`Request.URL.Captures`] object. An unnamed free wildcard is defined as `\**` and unnamed single wildcard is defined as `:*`. A named wildcard uses some identifier instead of the `*`, so like `*name` for free wildcard and `:name` for single wildcard.
 
 The value of the matched segment, respectively segments available via the wildcard name is decoded. E.g. if you define the to be matched expression in a rule as `/file/:name`, and the actual request path is `/file/%5Bid%5D`, you'll get `[id]` when accessing the captured segment via the `name` key. Not every encoded value is decoded though. Decoding of encoded slashes happens only if `allow_encoded_slashes` was set to `on`.
 

--- a/docs/content/docs/rules/regular_rule.adoc
+++ b/docs/content/docs/rules/regular_rule.adoc
@@ -24,64 +24,11 @@ The unique identifier of the rule. It must be unique across all rules loaded by 
 
 * *`match`*: _RuleMatcher_ (mandatory)
 +
-Defines the matching criteria for a rule, with the following properties:
+Defines the protocol-specific criteria used to match an incoming request against the rule. Exactly one protocol matcher must be configured. The following protocol matchers are supported:
 
-** *`routes`*: _RouteMatcher array_ (mandatory)
+** *`http`*: link:{{< relref "#_http_matcher" >}}[_HTTP Matcher_] (mandatory)
 +
-Specifies route conditions for matching the rule to incoming HTTP requests with each entry having the following properties:
-
-*** *`path`*: _string_ (mandatory)
-+
-The link:{{< relref "#_path_expression" >}}[Path Expression] describing the request path this rule should match. It supports both simple and free (named) wildcards.
-
-*** *`captures`*: _CaptureConditions_ (optional)
-+
-Additional conditions which must be met for the values captured by named wildcards in the path expression. All defined conditions must succeed for the request path to be considered a match. Each entry supports the following properties:
-
-**** *`name`*: _string_ (mandatory)
-+
-The name of the wildcard.
-
-**** *`type`*: _string_ (mandatory)
-+
-The type of expression used to match the captured wildcard's value. The supported types are:
-
-***** `glob`: to use a https://github.com/gobwas/glob[glob expression] to match the captured value (`/` is used as a delimiter, so `*` matches anything until the next `/`).
-***** `regex` to use a regular expression to match the captured value.
-
-**** *`value`*: _string_ (mandatory)
-+
-The actual expression based on the given `type`.
-
-** *`hosts`*: _string array_ (optional)
-+
-Defines a set of hosts to match against the HTTP `Host` header. These conditions are "OR" conditions, meaning that at least one must match for a successful match. If not defined, any host will be matched. Each entry can define an exact host, or be a wildcard expression (e.g., `\*.example.com` matches all subdomains under `example.com`). The `*` can only appear once at the start of the expression, and `*` alone matches any host.
-+
-NOTE: As required by https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2[RFC 3986, Section 3.2.2], the host matching happens case-insensitive.
-
-** *`scheme`*: _string_ (optional)
-+
-The expected HTTP scheme. If not specified, both http and https are accepted.
-
-** *`methods`*: _string array_ (optional)
-+
-Specifies the allowed HTTP methods (`GET`, `POST`, `PATCH`, etc). If not specified, all methods are allowed. To allow all methods except specific ones, use `ALL` and prefix the methods to exclude with `!`. For example:
-+
-[source, yaml]
-----
-# Methods list which effectively expands to all HTTP methods
-methods:
-  - ALL
-----
-+
-[source, yaml]
-----
-# Methods list consisting of all HTTP methods without `TRACE` and `OPTIONS`
-methods:
-  - ALL
-  - "!TRACE"
-  - "!OPTIONS"
-----
+Defines matching criteria for HTTP requests.
 
 * *`allow_encoded_slashes`*: _string_ (optional)
 +
@@ -175,16 +122,104 @@ on_error:
 ----
 ====
 
-== Path Expression
+== Request Matching
 
-Path expressions are used to match the incoming requests. When specifying these, you can make use of two types of wildcards:
+A rule is matched against an incoming request using the protocol matcher configured in its `match` property. Exactly one protocol matcher must be configured. Each matcher defines its own, protocol-specific set of matching criteria, described in the following sections.
+
+=== HTTP Matcher
+
+The `http` matcher evaluates matching criteria against HTTP requests. It supports the following properties:
+
+* *`paths`*: _PathMatcher array_ (mandatory)
++
+Specifies path conditions for matching the rule to incoming HTTP requests with each entry having the following properties:
+
+** *`path`*: _string_ (mandatory)
++
+The link:{{< relref "#_capture_expressions" >}}[Capture Expression] describing the request path this rule should match. It supports both simple and free (named) wildcards.
+
+** *`captures`*: _CaptureConditions_ (optional)
++
+Additional conditions which must be met for the values captured by named wildcards in the path expression. All defined conditions must succeed for the request path to be considered a match. Each entry supports the following properties:
+
+*** *`name`*: _string_ (mandatory)
++
+The name of the wildcard.
+
+*** *`type`*: _string_ (mandatory)
++
+The type of expression used to match the captured wildcard's value. The supported types are:
+
+**** `glob`: to use a https://github.com/gobwas/glob[glob expression] to match the captured value (`/` is used as a delimiter, so `*` matches anything until the next `/`).
+**** `regex` to use a regular expression to match the captured value.
+
+*** *`value`*: _string_ (mandatory)
++
+The actual expression based on the given `type`.
+
+* *`hosts`*: _string array_ (optional)
++
+Defines a set of hosts to match against the HTTP `Host` header. These conditions are "OR" conditions, meaning that at least one must match for a successful match. If not defined, any host will be matched. Each entry can define an exact host, or be a wildcard expression (e.g., `\*.example.com` matches all subdomains under `example.com`). The `*` can only appear once at the start of the expression, and `*` alone matches any host.
++
+NOTE: As required by https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2[RFC 3986, Section 3.2.2], the host matching happens case-insensitive.
+
+* *`scheme`*: _string_ (optional)
++
+The expected HTTP scheme. If not specified, both http and https are accepted.
+
+* *`methods`*: _string array_ (optional)
++
+Specifies the allowed HTTP methods (`GET`, `POST`, `PATCH`, etc). If not specified, all methods are allowed. To allow all methods except specific ones, use `ALL` and prefix the methods to exclude with `!`. For example:
++
+[source, yaml]
+----
+# Methods list which effectively expands to all HTTP methods
+methods:
+  - ALL
+----
++
+[source, yaml]
+----
+# Methods list consisting of all HTTP methods without `TRACE` and `OPTIONS`
+methods:
+  - ALL
+  - "!TRACE"
+  - "!OPTIONS"
+----
+
+.An example HTTP matcher
+====
+[source, yaml]
+----
+match:
+  http:
+    paths:
+      - path: /some/:identifier/followed/by/**
+        captures:
+          - name: identifier
+            type: glob
+            value: "[a-z]"
+    scheme: https
+    hosts:
+      - my-service.local
+    methods:
+      - GET
+      - POST
+----
+====
+
+== Capture Expressions
+
+Capture expressions define the wildcard syntax used by protocol matchers to match parts of an incoming request — e.g. the request path in the HTTP matcher's `path` property — and, if named, make the matched values available for use in a rule's pipeline via wildcards.
+
+When specifying these, you can make use of two types of wildcards:
 
 * free wildcard, which can be defined using `*` and
 * single wildcard, which can be defined using `:`
 
 Both can be named and unnamed, with named wildcards allowing accessing of the matched segments in the pipeline of the rule using the defined name as a key on the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_url_captures" >}}[`Request.URL.Captures`] object. Unnamed free wildcard is defined as `\**` and unnamed single wildcard is defined as `:*`. A named wildcard uses some identifier instead of the `*`, so like `*name` for free wildcard and `:name` for single wildcard.
 
-The value of the path segment, respectively path segments available via the wildcard name is decoded. E.g. if you define the to be matched path in a rule as `/file/:name`, and the actual path of the request is `/file/%5Bid%5D`, you'll get `[id]` when accessing the captured path segment via the `name` key. Not every path encoded value is decoded though. Decoding of encoded slashes happens only if `allow_encoded_slashes` was set to `on`.
+The value of the matched segment, respectively segments available via the wildcard name is decoded. E.g. if you define the to be matched expression in a rule as `/file/:name`, and the actual request path is `/file/%5Bid%5D`, you'll get `[id]` when accessing the captured segment via the `name` key. Not every encoded value is decoded though. Decoding of encoded slashes happens only if `allow_encoded_slashes` was set to `on`.
 
 There are some simple rules, which must be followed while using wildcards:
 
@@ -193,19 +228,19 @@ There are some simple rules, which must be followed while using wildcards:
 - No segments are allowed after a free (named) wildcard
 - If a regular segment must start with `:` or `*`, but should not be considered as a wildcard, it must be escaped with `\`.
 
-Here some path examples:
+Here some examples:
 
 - `/apples/and/bananas` - Matches exactly the given path
-- `/apples/and/:something` - Matches `/apples/and/bananas`, `/apples/and/oranges` and alike, but not `/apples/and/bananas/andmore` or `/apples/or/bananas`. Since a named single wildcard is used, the actual value of the path segment matched by `:something` can be accessed in the rule pipeline using `something` as a key.
+- `/apples/and/:something` - Matches `/apples/and/bananas`, `/apples/and/oranges` and alike, but not `/apples/and/bananas/andmore` or `/apples/or/bananas`. Since a named single wildcard is used, the actual value of the segment matched by `:something` can be accessed in the rule pipeline using `something` as a key.
 - `/apples/:junction/:something` - Similar to above. But will also match `/apples/or/bananas` in addition to `/apples/and/bananas` and `/apples/and/oranges`.
 - `/apples/and/some:thing` - Matches exactly `/apples/and/some:thing`
 - `/apples/and/some*\*` -  Matches exactly `/apples/and/some**`
-- `/apples/**` - Matches any path starting with `/apples/`, like `/apples/and/bananas` but not `/apples/`.
+- `/apples/**` - Matches any expression starting with `/apples/`, like `/apples/and/bananas` but not `/apples/`.
 - `/apples/*remainingpath` - Same as above, but uses a named free wildcard
-- `/apples/**/bananas` - Is invalid, as there is a path segment after a free wildcard
+- `/apples/**/bananas` - Is invalid, as there is a segment after a free wildcard
 - `/apples/\*remainingpath` - Matches exactly `/apples/*remainingpath`
 
-Here is an example demonstrating the usage of a single named wildcard:
+Here is an example demonstrating the usage of a single named wildcard within the HTTP matcher's `path` property:
 
 [source, yaml]
 ----

--- a/docs/content/docs/rules/regular_rule.adoc
+++ b/docs/content/docs/rules/regular_rule.adoc
@@ -53,7 +53,7 @@ Specifies the host (and port) to which the request should be forwarded. If no `r
 +
 Controls whether the `Host` header is forwarded to the upstream. Defaults to `true`.
 +
-**Note:** If a link:{{< relref "/docs/mechanisms/finalizers.adoc#_header" >}}[header finalizer] sets the `Host` header in the `execute` pipeline, its value takes precedence over this setting.
+NOTE: If a link:{{< relref "/docs/mechanisms/finalizers.adoc#_header" >}}[header finalizer] sets the `Host` header in the `execute` pipeline, its value takes precedence over this setting.
 
 ** *`rewrite`*: _OriginalURLRewriter_ (optional)
 +
@@ -68,7 +68,7 @@ NOTE: Unless heimdall is started with the `--insecure-skip-upstream-tls-enforcem
 
 *** *`strip_path_prefix`*: _string_ (optional)
 +
-This middleware strips the specified prefix from the original URL path before forwarding. E.g. if the path of the original url is `/api/v1/something` and the value of this property is set to `/api/v1`, the request to the upstream will have the url path set to `/something`.
+This middleware strips the specified prefix from the original URL path before forwarding. E.g. if the path of the original URL is `/api/v1/something` and the value of this property is set to `/api/v1`, the request to the upstream will have the URL path set to `/something`.
 
 *** *`add_path_prefix`*: _string_ (optional)
 +
@@ -76,7 +76,7 @@ This middleware is applied after the execution of the `strip_path_prefix` middle
 
 *** *`strip_query_parameters`*: _string array_ (optional)
 +
-Removes specified query parameters from the original URL before forwarding. E.g. if the query parameters part of the original URL is `foo=bar&bar=baz` and the value of this property is set to `["foo"]`, the query part of the request to the upstream will be set to `bar=baz`
+Removes specified query parameters from the original URL before forwarding. E.g. if the query parameters part of the original URL is `foo=bar&bar=baz` and the value of this property is set to `["foo"]`, the query part of the request to the upstream will be set to `bar=baz`.
 
 * *`execute`*: _link:{{< relref "#_authentication_authorization_pipeline" >}}[Authentication & Authorization Pipeline]_ (mandatory)
 +
@@ -210,35 +210,35 @@ match:
 
 == Capture Expressions
 
-Capture expressions define the wildcard syntax used by protocol matchers to match parts of an incoming request — e.g. the request path in the HTTP matcher's `path` property — and, if named, make the matched values available for use in a rule's pipeline via wildcards.
+Capture expressions define the wildcard syntax used by protocol matchers to match parts of an incoming request — e.g. the request path in the HTTP matcher's `path` property — and, if named, make the matched values available for use in a rule's pipeline.
 
 When specifying these, you can make use of two types of wildcards:
 
 * free wildcard, which can be defined using `*` and
 * single wildcard, which can be defined using `:`
 
-Both can be named and unnamed, with named wildcards allowing accessing of the matched segments in the pipeline of the rule using the defined name as a key on the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_url_captures" >}}[`Request.URL.Captures`] object. An unnamed free wildcard is defined as `\**` and unnamed single wildcard is defined as `:*`. A named wildcard uses some identifier instead of the `*`, so like `*name` for free wildcard and `:name` for single wildcard.
+Both can be named and unnamed, with named wildcards allowing access to the matched segments in the pipeline of the rule using the defined name as a key on the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_url_captures" >}}[`Request.URL.Captures`] object. An unnamed free wildcard is defined as `\**` and an unnamed single wildcard is defined as `:*`. A named wildcard uses some identifier instead of the `*`, such as `*name` for free wildcard and `:name` for single wildcard.
 
-The value of the matched segment, respectively segments available via the wildcard name is decoded. E.g. if you define the to be matched expression in a rule as `/file/:name`, and the actual request path is `/file/%5Bid%5D`, you'll get `[id]` when accessing the captured segment via the `name` key. Not every encoded value is decoded though. Decoding of encoded slashes happens only if `allow_encoded_slashes` was set to `on`.
+The value of the matched segment, respectively segments available via the wildcard name is decoded. E.g. if you define the expression to be matched in a rule as `/file/:name`, and the actual request path is `/file/%5Bid%5D`, you'll get `[id]` when accessing the captured segment via the `name` key. Not every encoded value is decoded though. Decoding of encoded slashes happens only if `allow_encoded_slashes` was set to `on`.
 
 There are some simple rules, which must be followed while using wildcards:
 
-- One can use as many single wildcards, as needed in any segment
-- A segment must start with `:` or `*` to define a wildcard
-- No segments are allowed after a free (named) wildcard
+- One can use as many single wildcards, as needed in any segment.
+- A segment must start with `:` or `*` to define a wildcard.
+- No segments are allowed after a free (named) wildcard.
 - If a regular segment must start with `:` or `*`, but should not be considered as a wildcard, it must be escaped with `\`.
 
 Here some examples:
 
-- `/apples/and/bananas` - Matches exactly the given path
+- `/apples/and/bananas` - Matches exactly the given path.
 - `/apples/and/:something` - Matches `/apples/and/bananas`, `/apples/and/oranges` and alike, but not `/apples/and/bananas/andmore` or `/apples/or/bananas`. Since a named single wildcard is used, the actual value of the segment matched by `:something` can be accessed in the rule pipeline using `something` as a key.
 - `/apples/:junction/:something` - Similar to above. But will also match `/apples/or/bananas` in addition to `/apples/and/bananas` and `/apples/and/oranges`.
-- `/apples/and/some:thing` - Matches exactly `/apples/and/some:thing`
-- `/apples/and/some*\*` -  Matches exactly `/apples/and/some**`
+- `/apples/and/some:thing` - Matches exactly `/apples/and/some:thing`.
+- `/apples/and/some*\*` - Matches exactly `/apples/and/some**`.
 - `/apples/**` - Matches any expression starting with `/apples/`, like `/apples/and/bananas` but not `/apples/`.
-- `/apples/*remainingpath` - Same as above, but uses a named free wildcard
-- `/apples/**/bananas` - Is invalid, as there is a segment after a free wildcard
-- `/apples/\*remainingpath` - Matches exactly `/apples/*remainingpath`
+- `/apples/*remainingpath` - Same as above, but uses a named free wildcard.
+- `/apples/**/bananas` - Is invalid, as there is a segment after a free wildcard.
+- `/apples/\*remainingpath` - Matches exactly `/apples/*remainingpath`.
 
 Here is an example demonstrating the usage of a single named wildcard within the HTTP matcher's `path` property:
 
@@ -278,9 +278,9 @@ If a rule matches on host and path but fails due to unmet conditions, the proces
 * a less specific rule fails and
 * no further candidate rules remain in the given rule set
 
-The following examples illustrate these principles:
+The following examples illustrate these principles.
 
-Consider a rule set with the following rules
+Consider a rule set with the following rules:
 
 [source, yaml]
 ----
@@ -331,11 +331,11 @@ An HTTP GET request to `/files/team1/document.pdf` will be matched by `rule2`, a
 
 NOTE: If `rule2` had appeared after `rule3` in the rule set, `rule3` would have matched and taken precedence — highlighting the importance of rule order when specificity and match conditions are equal.
 
-An HTTP POST request to `/files/team1/document.pdf` will be matched by `rule3`, as it is more specific than `rule1` and the `methods` constraints in the `rule2` failed. So its pipeline is executed.
+An HTTP POST request to `/files/team1/document.pdf` will be matched by `rule3`, as it is more specific than `rule1` and the `methods` constraints in `rule2` failed. So its pipeline is executed.
 
 An HTTP GET request to `/files/team3/document.pdf` will be matched by `rule4`, which is more specific than all other rules. Its pipeline is executed.
 
-However, even though a request to `/files/team4/document.pdf` matches the path expression defined in `rule2`, respectively `rule3`, the regular expression `(team1|team2)` used in the `captures` for the `team` parameter will not match. Backtracking occurs, and the request falls back to `rule1`, which does match. Thus, the pipeline of `rule1` is executed.
+However, even though a request to `/files/team4/document.pdf` matches the path expression defined in `rule2` or `rule3`, the regular expression `(team1|team2)` used in the `captures` for the `team` parameter will not match. Backtracking occurs, and the request falls back to `rule1`, which does match. Thus, the pipeline of `rule1` is executed.
 
 
 Here’s another example:
@@ -377,7 +377,7 @@ To express which principal an authenticator step should create, the `principal` 
 +
 [NOTE]
 ====
-Some authenticators rely on the same sources to obtain the subject authentication object. For example, both the `jwt` and `oauth2_introspection` authenticators retrieve tokens from the `Authorization` header by default. When such authenticators are used in the same fallback chain, it's best to configure the more specific ones before the more general ones to optimize performance. In this case, the `jwt` authenticator is more specific since it only processes tokens in JWT format. In contrast, the `oauth2_introspection` authenticator is more general - it doesn’t depend on the token format and will attempt to handle any request containing a bearer token.
+Some authenticators rely on the same sources to obtain the subject authentication object. For example, both the `jwt` and `oauth2_introspection` authenticators retrieve tokens from the `Authorization` header by default. When such authenticators are used in the same fallback chain, it's best to configure the more specific ones before the more general ones to optimize performance. In this case, the `jwt` authenticator is more specific since it only processes tokens in JWT format. In contrast, the `oauth2_introspection` authenticator is more general — it doesn’t depend on the token format and will attempt to handle any request containing a bearer token.
 ====
 ** The overall evaluation follows a conjunctive (CNF-like) composition model (see also examples below).
 +
@@ -418,12 +418,12 @@ Both steps establish the `default` principal, with `B` acting as fallback if `A`
 ====
 
 
-* **Authorization Stage:** List of link:{{< relref "/docs/mechanisms/contextualizers.adoc" >}}[contextualizer] and link:{{< relref "/docs/mechanisms/authorizers.adoc" >}}[authorizer] references in any order (optional). Can also be mixed. As with authenticators, the list definition happens using either `contextualizer` or `authorizer` as key, followed by the required `id`. All mechanism steps in this list are executed in the order, they are defined. If any of these fails, the entire pipeline fails, which leads to the execution of the link:{{< relref "#_error_pipeline" >}}[error pipeline]. This list is optional.
+* **Authorization Stage:** List of link:{{< relref "/docs/mechanisms/contextualizers.adoc" >}}[contextualizer] and link:{{< relref "/docs/mechanisms/authorizers.adoc" >}}[authorizer] references in any order (optional). Can also be mixed. As with authenticators, the list definition happens using either `contextualizer` or `authorizer` as key, followed by the required `id`. All mechanism steps in this list are executed in the order they are defined. If any of these fails, the entire pipeline fails, which leads to the execution of the link:{{< relref "#_error_pipeline" >}}[error pipeline]. This list is optional.
 * **Finalization Stage:** List of link:{{< relref "/docs/mechanisms/finalizers.adoc" >}}[finalizer] references using `finalizers` as key, followed by the required finalizer `id`. All finalizer steps in this list are executed in the order they are defined. If any of these fail, the entire pipeline fails, which leads to the execution of the link:{{< relref "#_error_pipeline" >}}[error pipeline]. This list is optional. If a link:{{< relref "default_rule.adoc" >}}[default rule] is configured, and no `finalizers` are configured on a specific rule level, the `finalizers` from the default rule are used. If the default rule does not have any `finalizers` configured either, no finalization will take place.
 
-In all cases, the mechanisms used in each step can be partially reconfigured if supported by the corresponding type. Configuration goes into the `config` properties. These reconfigurations are always local to the given rule. With other words, you can adjust your rule specific pipeline as you want without any side effects.
+In all cases, the mechanisms used in each step can be partially reconfigured if supported by the corresponding type. Configuration goes into the `config` properties. These reconfigurations are always local to the given rule. In other words, you can adjust your rule-specific pipeline as you want without any side effects.
 
-Execution of an `contextualizer`, `authorizer`, or `finalizer` mechanisms can optionally happen conditionally by making use of a https://github.com/google/cel-spec[CEL] expression in an `if` clause, which has access to the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_subject" >}}[`Subject`] and the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_request" >}}[`Request`] objects. If the `if` clause is not present, the corresponding mechanism is always executed.
+Execution of a `contextualizer`, `authorizer`, or `finalizer` mechanism can optionally happen conditionally by making use of a https://github.com/google/cel-spec[CEL] expression in an `if` clause, which has access to the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_subject" >}}[`Subject`] and the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_request" >}}[`Request`] objects. If the `if` clause is not present, the corresponding mechanism is always executed.
 
 All steps can optionally define a step `id`. If not configured, its value is set to the `id` of the used mechanism.
 
@@ -469,10 +469,10 @@ All steps can optionally define a step `id`. If not configured, its value is set
 
 This example uses
 
-* two authenticators, with authenticator named `bar` being the fallback for the authenticator named `foo`.
-* multiple contextualizers and authorizers, with first contextualizer having its cache disabled (`cache_ttl` set to 0s) and the last authorizer being of type link:{{< relref "/docs/mechanisms/authorizers.adoc#_local_cel" >}}[cel] as it reconfigures the referenced prototype to use a different authorization expression.
-* two finalizers, with the second one being obviously of type link:{{< relref "/docs/mechanisms/finalizers.adoc#_header" >}}[header], as it defines a `X-User-ID` header set to the value of the subject id and an `X-Some-Data` header, set to the result of the contextualizer step with the id `second`, both to be forwarded to the upstream service.
-* step referring the `bar` contextualizer with the `id` set to `first` is only executed if the authenticated subject is not anonymous.
+* two authenticators, with the authenticator named `bar` being the fallback for the authenticator named `foo`.
+* multiple contextualizers and authorizers, with the first contextualizer having its cache disabled (`cache_ttl` set to 0s) and the last authorizer being of type link:{{< relref "/docs/mechanisms/authorizers.adoc#_local_cel" >}}[cel] as it reconfigures the referenced prototype to use a different authorization expression.
+* two finalizers, with the second one being obviously of type link:{{< relref "/docs/mechanisms/finalizers.adoc#_header" >}}[header], as it defines an `X-User-ID` header set to the value of the subject id and an `X-Some-Data` header, set to the result of the contextualizer step with the id `second`, both to be forwarded to the upstream service.
+* the step referring to the `bar` contextualizer with the `id` set to `first` is only executed if the authenticated subject is not anonymous.
 * authorizer `foo` is only executed if the request method is HTTP POST.
 ====
 

--- a/docs/content/docs/rules/regular_rule.adoc
+++ b/docs/content/docs/rules/regular_rule.adoc
@@ -34,7 +34,7 @@ Specifies route conditions for matching the rule to incoming HTTP requests with 
 +
 The link:{{< relref "#_path_expression" >}}[Path Expression] describing the request path this rule should match. It supports both simple and free (named) wildcards.
 
-*** *`path_params`*: _PathParameterConditions_ (optional)
+*** *`captures`*: _CaptureConditions_ (optional)
 +
 Additional conditions which must be met for the values captured by named wildcards in the path expression. All defined conditions must succeed for the request path to be considered a match. Each entry supports the following properties:
 
@@ -148,7 +148,7 @@ match:
   http:
     paths:
       - path: /some/:identifier/followed/by/**
-        path_params:
+        captures:
           - name: identifier
             type: glob
             value: "[a-z]"
@@ -262,7 +262,7 @@ Consider a rule set with the following rules
     http:
       paths:
         - path: /files/:team/:name
-          path_params:
+          captures:
             - name: team
               type: regex
               value: "(team1|team2)"
@@ -276,7 +276,7 @@ Consider a rule set with the following rules
     http:
       paths:
         - path: /files/:team/:name
-          path_params:
+          captures:
             - name: team
               type: regex
               value: "(team1|team2)"
@@ -300,7 +300,7 @@ An HTTP POST request to `/files/team1/document.pdf` will be matched by `rule3`, 
 
 An HTTP GET request to `/files/team3/document.pdf` will be matched by `rule4`, which is more specific than all other rules. Its pipeline is executed.
 
-However, even though a request to `/files/team4/document.pdf` matches the path expression defined in `rule2`, respectively `rule3`, the regular expression `(team1|team2)` used in the `path_params` for the `team` parameter will not match. Backtracking occurs, and the request falls back to `rule1`, which does match. Thus, the pipeline of `rule1` is executed.
+However, even though a request to `/files/team4/document.pdf` matches the path expression defined in `rule2`, respectively `rule3`, the regular expression `(team1|team2)` used in the `captures` for the `team` parameter will not match. Backtracking occurs, and the request falls back to `rule1`, which does match. Thus, the pipeline of `rule1` is executed.
 
 
 Here’s another example:

--- a/docs/content/docs/rules/regular_rule.adoc
+++ b/docs/content/docs/rules/regular_rule.adoc
@@ -146,7 +146,7 @@ Specifies error handling mechanisms if the pipeline defined by the `execute` pro
 id: rule:foo:bar
 match:
   http:
-    routes:
+    paths:
       - path: /some/:identifier/followed/by/**
         path_params:
           - name: identifier
@@ -212,7 +212,7 @@ Here is an example demonstrating the usage of a single named wildcard:
 id: rule:1
 match:
   http:
-    routes:
+    paths:
       - path: /files/:uuid/delete
     hosts:
       - hosty.mchostface
@@ -252,7 +252,7 @@ Consider a rule set with the following rules
 - id: rule1
   match:
     http:
-      routes:
+      paths:
         - path: /files/**
   execute:
     - <pipeline definition>
@@ -260,7 +260,7 @@ Consider a rule set with the following rules
 - id: rule2
   match:
     http:
-      routes:
+      paths:
         - path: /files/:team/:name
           path_params:
             - name: team
@@ -274,7 +274,7 @@ Consider a rule set with the following rules
 - id: rule3
   match:
     http:
-      routes:
+      paths:
         - path: /files/:team/:name
           path_params:
             - name: team
@@ -286,7 +286,7 @@ Consider a rule set with the following rules
 - id: rule4
   match:
     http:
-      routes:
+      paths:
         - path: /files/team3/:name
   execute:
     - <pipeline definition>
@@ -310,7 +310,7 @@ Here’s another example:
 - id: rule1
   match:
     http:
-      routes:
+      paths:
         - path: /foo/**
   execute:
     - <pipeline definition>
@@ -318,7 +318,7 @@ Here’s another example:
 - id: rule2
   match:
     http:
-      routes:
+      paths:
         - path: /foo/bar/:name
   execute:
     - <pipeline definition>

--- a/docs/content/docs/rules/regular_rule.adoc
+++ b/docs/content/docs/rules/regular_rule.adoc
@@ -138,7 +138,7 @@ Specifies path conditions for matching the rule to incoming HTTP requests with e
 +
 The link:{{< relref "#_capture_expressions" >}}[Capture Expression] describing the request path this rule should match. It supports both single and free (named) wildcards.
 
-** *`captures`*: _CaptureConditions_ (optional)
+** *`captures`*: _CaptureCondition array_ (optional)
 +
 Additional conditions that must be met for the values captured by named wildcards in the path expression. All defined conditions must succeed for the request path to be considered a match. Each entry supports the following properties:
 

--- a/docs/content/docs/rules/rule_sets.adoc
+++ b/docs/content/docs/rules/rule_sets.adoc
@@ -50,7 +50,7 @@ rules:
 - id: rule:1
   match:
     http:
-      routes:
+      paths:
         - path: /**
       methods: [ "GET" ]
       scheme: https
@@ -61,7 +61,7 @@ rules:
 - id: rule:2
   match:
     http:
-      routes:
+      paths:
         - path: /**
       scheme: https
       hosts:
@@ -121,7 +121,7 @@ spec:
     - id: "<identifier of a rule 1>"
       match:
         http:
-          routes:
+          paths:
             - path: /foo/**
           scheme: https
           hosts:

--- a/docs/content/docs/rules/rule_sets.adoc
+++ b/docs/content/docs/rules/rule_sets.adoc
@@ -49,22 +49,24 @@ name: my-rule-set
 rules:
 - id: rule:1
   match:
-    routes:
-      - path: /**
-    methods: [ "GET" ]
-    scheme: https
-    hosts:
-      - my-service1.local
+    http:
+      routes:
+        - path: /**
+      methods: [ "GET" ]
+      scheme: https
+      hosts:
+        - my-service1.local
   execute:
     - authorizer: foobar
 - id: rule:2
   match:
-    routes:
-      - path: /**
-    scheme: https
-    hosts:
-      - my-service2.local
-    methods: [ "GET" ]
+    http:
+      routes:
+        - path: /**
+      scheme: https
+      hosts:
+        - my-service2.local
+      methods: [ "GET" ]
   execute:
     - authorizer: barfoo
 ----
@@ -118,11 +120,12 @@ spec:
   rules:
     - id: "<identifier of a rule 1>"
       match:
-        routes:
-          - path: /foo/**
-        scheme: https
-        hosts:
-          - 127.0.0.1:9090
+        http:
+          routes:
+            - path: /foo/**
+          scheme: https
+          hosts:
+            - 127.0.0.1:9090
       execute:
         - authenticator: foo
         - authorizer: bar

--- a/docs/content/guides/authn/dpop_bound_access_tokens.adoc
+++ b/docs/content/guides/authn/dpop_bound_access_tokens.adoc
@@ -178,9 +178,10 @@ version: "1beta1"
 rules:
   - id: upstream:api
     match:
-      routes:
-        - path: /api
-        - path: /api/<**>
+      http:
+        routes:
+          - path: /api
+          - path: /api/<**>
     forward_to:
       host: upstream:8081
     execute:

--- a/docs/content/guides/authn/dpop_bound_access_tokens.adoc
+++ b/docs/content/guides/authn/dpop_bound_access_tokens.adoc
@@ -179,7 +179,7 @@ rules:
   - id: upstream:api
     match:
       http:
-        routes:
+        paths:
           - path: /api
           - path: /api/<**>
     forward_to:

--- a/docs/content/guides/authn/oidc_first_party_auth.adoc
+++ b/docs/content/guides/authn/oidc_first_party_auth.adoc
@@ -158,9 +158,10 @@ version: "1beta1"
 rules:
 - id: upstream:public  # <1>
   match:
-    routes:
-      - path: /
-      - path: /favicon.ico
+    http:
+      routes:
+        - path: /
+        - path: /favicon.ico
   forward_to:
     host: upstream:8081
   execute:
@@ -169,9 +170,10 @@ rules:
 
 - id: upstream:protected  # <2>
   match:
-    routes:
-      - path: /user
-      - path: /admin
+    http:
+      routes:
+        - path: /user
+        - path: /admin
   forward_to:
     host: upstream:8081
   execute:
@@ -205,9 +207,10 @@ version: "1beta1"
 rules:
 - id: oauth2-proxy:public
   match:
-    routes:
-      - path: /oauth2/start
-      - path: /oauth2/callback
+    http:
+      routes:
+        - path: /oauth2/start
+        - path: /oauth2/callback
   forward_to:
     host: oauth2-proxy:4180
   execute:

--- a/docs/content/guides/authn/oidc_first_party_auth.adoc
+++ b/docs/content/guides/authn/oidc_first_party_auth.adoc
@@ -159,7 +159,7 @@ rules:
 - id: upstream:public  # <1>
   match:
     http:
-      routes:
+      paths:
         - path: /
         - path: /favicon.ico
   forward_to:
@@ -171,7 +171,7 @@ rules:
 - id: upstream:protected  # <2>
   match:
     http:
-      routes:
+      paths:
         - path: /user
         - path: /admin
   forward_to:
@@ -208,7 +208,7 @@ rules:
 - id: oauth2-proxy:public
   match:
     http:
-      routes:
+      paths:
         - path: /oauth2/start
         - path: /oauth2/callback
   forward_to:

--- a/docs/content/guides/authz/openfga.adoc
+++ b/docs/content/guides/authz/openfga.adoc
@@ -273,7 +273,7 @@ rules:
 - id: access_document  # <1>
   match:
     http:
-      routes:
+      paths:
         - path: /document/:id # <2>
       methods: [ GET, POST, DELETE ]
   forward_to: # <3>
@@ -298,7 +298,7 @@ rules:
 - id: list_documents  # <11>
   match:
     http:
-      routes:
+      paths:
         - path: /documents # <12>
       methods: [ GET ] # <14>
   forward_to: # <13>

--- a/docs/content/guides/authz/openfga.adoc
+++ b/docs/content/guides/authz/openfga.adoc
@@ -272,9 +272,10 @@ version: "1beta1"
 rules:
 - id: access_document  # <1>
   match:
-    routes:
-      - path: /document/:id # <2>
-    methods: [ GET, POST, DELETE ]
+    http:
+      routes:
+        - path: /document/:id # <2>
+      methods: [ GET, POST, DELETE ]
   forward_to: # <3>
     host: upstream:8081
   execute:
@@ -296,9 +297,10 @@ rules:
 
 - id: list_documents  # <11>
   match:
-    routes:
-      - path: /documents # <12>
-    methods: [ GET ] # <14>
+    http:
+      routes:
+        - path: /documents # <12>
+      methods: [ GET ] # <14>
   forward_to: # <13>
     host: upstream:8081
   execute: # <15>

--- a/docs/openapi/specification.yaml
+++ b/docs/openapi/specification.yaml
@@ -458,7 +458,7 @@ paths:
                   "kind": "RuleSet",
                   "metadata": {
                     "annotations": {
-                      "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"heimdall.dadrus.github.com/v1beta1\",\"kind\":\"RuleSet\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/name\":\"echo-app\"},\"name\":\"echo-app-rules\",\"namespace\":\"quickstarts\"},\"spec\":{\"rules\":[{\"execute\":[{\"authorizer\":\"allow_all_requests\"},{\"finalizer\":\"noop_finalizer\"}],\"forward_to\":{\"host\":\"echo-app.quickstarts.svc.cluster.local:8080\"},\"id\":\"public-access\",\"match\":{\"url\":\"\\u003c**\\u003e://\\u003c**\\u003e/pub/\\u003c**\\u003e\"}},{\"execute\":[{\"authorizer\":\"allow_all_requests\"}],\"forward_to\":{\"host\":\"echo-app.quickstarts.svc.cluster.local:8080\"},\"id\":\"anonymous-access\",\"match\":{\"url\":\"\\u003c**\\u003e://\\u003c**\\u003e/anon/\\u003c**\\u003e\"}},{\"execute\":[{\"authenticator\":\"deny_authenticator\"}],\"forward_to\":{\"host\":\"echo-app.quickstarts.svc.cluster.local:8080\"},\"id\":\"redirect\",\"match\":{\"url\":\"\\u003c**\\u003e://\\u003c**\\u003e/redir/\\u003c**\\u003e\"}}]}}\n"
+                      "kubectl.kubernetes.io/last-applied-configuration": "..."
                     },
                     "creationTimestamp": "2025-08-12T09:15:29Z",
                     "generation": 1,
@@ -630,7 +630,7 @@ paths:
                     "kind": "RuleSet",
                     "metadata": {
                       "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"heimdall.dadrus.github.com/v1beta1\",\"kind\":\"RuleSet\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/name\":\"echo-app\"},\"name\":\"echo-app-rules\",\"namespace\":\"quickstarts\"},\"spec\":{\"rules\":[{\"execute\":[{\"authorizer\":\"allow_all_requests\"},{\"finalizer\":\"noop_finalizer\"}],\"forward_to\":{\"host\":\"echo-app.quickstarts.svc.cluster.local:8080\"},\"id\":\"public-access\",\"match\":{\"url\":\"\\u003c**\\u003e://\\u003c**\\u003e/pub/\\u003c**\\u003e\"}},{\"execute\":[{\"authorizer\":\"allow_all_requests\"}],\"forward_to\":{\"host\":\"echo-app.quickstarts.svc.cluster.local:8080\"},\"id\":\"anonymous-access\",\"match\":{\"url\":\"\\u003c**\\u003e://\\u003c**\\u003e/anon/\\u003c**\\u003e\"}},{\"execute\":[{\"authenticator\":\"deny_authenticator\"}],\"forward_to\":{\"host\":\"echo-app.quickstarts.svc.cluster.local:8080\"},\"id\":\"redirect\",\"match\":{\"url\":\"\\u003c**\\u003e://\\u003c**\\u003e/redir/\\u003c**\\u003e\"}}]}}\n"
+                        "kubectl.kubernetes.io/last-applied-configuration": "..."
                       },
                       "creationTimestamp": "2025-08-12T09:15:29Z",
                       "generation": 1,
@@ -749,7 +749,7 @@ paths:
                       "kind": "RuleSet",
                       "metadata": {
                         "annotations": {
-                          "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"heimdall.dadrus.github.com/v1beta1\",\"kind\":\"RuleSet\",\"metadata\":{\"annotations\":{},\"labels\":{\"app.kubernetes.io/name\":\"echo-app\"},\"name\":\"echo-app-rules\",\"namespace\":\"quickstarts\"},\"spec\":{\"rules\":[{\"execute\":[{\"authorizer\":\"allow_all_requests\"},{\"finalizer\":\"noop_finalizer\"}],\"forward_to\":{\"host\":\"echo-app.quickstarts.svc.cluster.local:8080\"},\"id\":\"public-access\",\"match\":{\"url\":\"\\u003c**\\u003e://\\u003c**\\u003e/pub/\\u003c**\\u003e\"}},{\"execute\":[{\"authorizer\":\"allow_all_requests\"}],\"forward_to\":{\"host\":\"echo-app.quickstarts.svc.cluster.local:8080\"},\"id\":\"anonymous-access\",\"match\":{\"url\":\"\\u003c**\\u003e://\\u003c**\\u003e/anon/\\u003c**\\u003e\"}},{\"execute\":[{\"authenticator\":\"deny_authenticator\"}],\"forward_to\":{\"host\":\"echo-app.quickstarts.svc.cluster.local:8080\"},\"id\":\"redirect\",\"match\":{\"url\":\"\\u003c**\\u003e://\\u003c**\\u003e/redir/\\u003c**\\u003e\"}}]}}\n"
+                          "kubectl.kubernetes.io/last-applied-configuration": "..."
                         },
                         "creationTimestamp": "2025-08-12T09:15:29Z",
                         "generation": 1,

--- a/docs/openapi/specification.yaml
+++ b/docs/openapi/specification.yaml
@@ -512,9 +512,11 @@ paths:
                         },
                         "id": "public-access",
                         "match": {
-                          "routes": [
-                            { "path": "/pub/**" }
-                          ]
+                          "http": {
+                            "paths": [
+                              { "path": "/pub/**" }
+                            ]
+                          }
                         }
                       },
                       {
@@ -528,9 +530,11 @@ paths:
                         },
                         "id": "anonymous-access",
                         "match": {
-                          "routes": [
-                            { "path": "/anon/**" }
-                          ]
+                          "http": {
+                            "paths": [
+                              { "path": "/anon/**" }
+                            ]
+                          }
                         }
                       },
                       {
@@ -677,9 +681,11 @@ paths:
                           ],
                           "id": "public-access",
                           "match": {
-                            "routes": [
-                              { "path": "/public" }
-                            ]
+                            "http": {
+                              "paths": [
+                                { "path": "/public" }
+                              ]
+                            }
                           }
                         },
                         {
@@ -690,9 +696,11 @@ paths:
                           ],
                           "id": "anonymous-access",
                           "match": {
-                            "routes": [
-                              { "path": "/anon/**" }
-                            ]
+                            "http": {
+                              "paths": [
+                                { "path": "/anon/**" }
+                              ]
+                            }
                           }
                         },
                         {
@@ -706,9 +714,11 @@ paths:
                           },
                           "id": "redirect",
                           "match": {
-                            "routes": [
-                              { "path": "/redir/**" }
-                            ]
+                            "http": {
+                              "paths": [
+                                { "path": "/redir/**" }
+                              ]
+                            }
                           }
                         }
                       ]
@@ -790,9 +800,11 @@ paths:
                             ],
                             "id": "public-access",
                             "match": {
-                              "routes": [
-                                { "path": "/public" }
-                              ]
+                              "http": {
+                                "paths": [
+                                  { "path": "/public" }
+                                ]
+                              }
                             }
                           },
                           {
@@ -803,9 +815,11 @@ paths:
                             ],
                             "id": "anonymous-access",
                             "match": {
-                              "routes": [
-                                { "path": "/anon/**" }
-                              ]
+                              "http": {
+                                "paths": [
+                                  { "path": "/anon/**" }
+                                ]
+                              }
                             }
                           },
                           {
@@ -819,9 +833,11 @@ paths:
                             },
                             "id": "redirect",
                             "match": {
-                              "routes": [
-                                { "path": "/redir/**" }
-                              ]
+                              "http": {
+                                "paths": [
+                                  { "path": "/redir/**" }
+                                ]
+                              }
                             }
                           }
                         ]

--- a/example_rules.yaml
+++ b/example_rules.yaml
@@ -3,18 +3,19 @@ name: test-rule-set
 rules:
 - id: rule:foo
   match:
-    routes:
-      - path: /foo/:bar/**
-        path_params:
-          - name: bar
-            type: glob
-            value: "*baz"
-    methods:
-      - GET
-      - POST
-    hosts:
-      - foo.bar
-    scheme: http
+    http:
+      routes:
+        - path: /foo/:bar/**
+          path_params:
+            - name: bar
+              type: glob
+              value: "*baz"
+      methods:
+        - GET
+        - POST
+      hosts:
+        -  foo.bar
+      scheme: http
   forward_to:
     host: bar.foo
   execute:

--- a/example_rules.yaml
+++ b/example_rules.yaml
@@ -4,7 +4,7 @@ rules:
 - id: rule:foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo/:bar/**
           path_params:
             - name: bar

--- a/example_rules.yaml
+++ b/example_rules.yaml
@@ -6,7 +6,7 @@ rules:
     http:
       paths:
         - path: /foo/:bar/**
-          path_params:
+          captures:
             - name: bar
               type: glob
               value: "*baz"

--- a/examples/docker-compose/upstream-rules.yaml
+++ b/examples/docker-compose/upstream-rules.yaml
@@ -2,9 +2,10 @@ version: "1beta1"
 rules:
 - id: demo:public
   match:
-    routes:
-      - path: /public
-    methods: [ GET, POST ]
+    http:
+      routes:
+        - path: /public
+      methods: [ GET, POST ]
   forward_to:
     host: upstream:8081
   execute:
@@ -13,13 +14,14 @@ rules:
 
 - id: demo:protected
   match:
-    routes:
-      - path: /:user
-        path_params:
-          - type: regex
-            name: user
-            value: (user|admin)
-    methods: [ GET, POST ]
+    http:
+      routes:
+        - path: /:user
+          path_params:
+            - type: regex
+              name: user
+              value: (user|admin)
+      methods: [ GET, POST ]
   forward_to:
     host: upstream:8081
   execute:

--- a/examples/docker-compose/upstream-rules.yaml
+++ b/examples/docker-compose/upstream-rules.yaml
@@ -17,7 +17,7 @@ rules:
     http:
       paths:
         - path: /:user
-          path_params:
+          captures:
             - type: regex
               name: user
               value: (user|admin)

--- a/examples/docker-compose/upstream-rules.yaml
+++ b/examples/docker-compose/upstream-rules.yaml
@@ -3,7 +3,7 @@ rules:
 - id: demo:public
   match:
     http:
-      routes:
+      paths:
         - path: /public
       methods: [ GET, POST ]
   forward_to:
@@ -15,7 +15,7 @@ rules:
 - id: demo:protected
   match:
     http:
-      routes:
+      paths:
         - path: /:user
           path_params:
             - type: regex

--- a/examples/kubernetes/modules/echo-app/manifests/rules.yaml
+++ b/examples/kubernetes/modules/echo-app/manifests/rules.yaml
@@ -9,16 +9,18 @@ spec:
   rules:
     - id: public-access
       match:
-        routes:
-          - path: /pub/**
+        http:
+          routes:
+            - path: /pub/**
       forward_to: # only required for proxy operation mode
         host: echo-app.quickstarts.svc.cluster.local:8080
       execute:
         - authorizer: allow_all_requests
     - id: anonymous-access
       match:
-        routes:
-          - path: /anon/**
+        http:
+          routes:
+            - path: /anon/**
       forward_to: # only required for proxy operation mode
         host: echo-app.quickstarts.svc.cluster.local:8080
       execute:
@@ -26,8 +28,9 @@ spec:
         - finalizer: create_jwt
     - id: redirect
       match:
-        routes:
-         - path: /redir/**
+        http:
+          routes:
+            - path: /redir/**
       forward_to: # only required for proxy operation mode
         host: echo-app.quickstarts.svc.cluster.local:8080
       execute:

--- a/examples/kubernetes/modules/echo-app/manifests/rules.yaml
+++ b/examples/kubernetes/modules/echo-app/manifests/rules.yaml
@@ -10,7 +10,7 @@ spec:
     - id: public-access
       match:
         http:
-          routes:
+          paths:
             - path: /pub/**
       forward_to: # only required for proxy operation mode
         host: echo-app.quickstarts.svc.cluster.local:8080
@@ -19,7 +19,7 @@ spec:
     - id: anonymous-access
       match:
         http:
-          routes:
+          paths:
             - path: /anon/**
       forward_to: # only required for proxy operation mode
         host: echo-app.quickstarts.svc.cluster.local:8080
@@ -29,7 +29,7 @@ spec:
     - id: redirect
       match:
         http:
-          routes:
+          paths:
             - path: /redir/**
       forward_to: # only required for proxy operation mode
         host: echo-app.quickstarts.svc.cluster.local:8080

--- a/internal/rules/api/v1alpha4/matcher.go
+++ b/internal/rules/api/v1alpha4/matcher.go
@@ -44,8 +44,8 @@ type ParameterMatcher struct {
 }
 
 type HostMatcher struct {
-	Value string `json:"value" yaml:"value" validate:"required"`                      //nolint:tagalign
-	Type  string `json:"type"  yaml:"type"  validate:"required,oneof=exact wildcard"` //nolint:tagalign
+	Value string `json:"value" yaml:"value" validate:"required"`                                 //nolint:tagalign
+	Type  string `json:"type"  yaml:"type"  validate:"required,oneof=exact wildcard glob regex"` //nolint:tagalign
 }
 
 func (m *Matcher) DeepCopyInto(out *Matcher) {

--- a/internal/rules/api/v1alpha4/matcher.go
+++ b/internal/rules/api/v1alpha4/matcher.go
@@ -19,10 +19,11 @@ package v1alpha4
 import "slices"
 
 type Matcher struct {
-	Routes  []Route       `json:"routes"            yaml:"routes"            validate:"required,dive"`              //nolint:lll,tagalign
-	Scheme  string        `json:"scheme,omitempty"  yaml:"scheme,omitempty"  validate:"omitempty,oneof=http https"` //nolint:lll,tagalign
-	Methods []string      `json:"methods,omitempty" yaml:"methods,omitempty" validate:"omitempty,dive,required"`    //nolint:lll,tagalign
-	Hosts   []HostMatcher `json:"hosts,omitempty"   yaml:"hosts,omitempty"   validate:"omitempty,dive,required"`    //nolint:lll,tagalign
+	Routes              []Route       `json:"routes"                         yaml:"routes"                         validate:"required,dive"`              //nolint:lll,tagalign
+	BacktrackingEnabled *bool         `json:"backtracking_enabled,omitempty" yaml:"backtracking_enabled,omitempty"`                                       //nolint:lll,tagalign
+	Scheme              string        `json:"scheme,omitempty"               yaml:"scheme,omitempty"               validate:"omitempty,oneof=http https"` //nolint:lll,tagalign
+	Methods             []string      `json:"methods,omitempty"              yaml:"methods,omitempty"              validate:"omitempty,dive,required"`    //nolint:lll,tagalign
+	Hosts               []HostMatcher `json:"hosts,omitempty"                yaml:"hosts,omitempty"                validate:"omitempty,dive,required"`    //nolint:lll,tagalign
 }
 
 type Route struct {
@@ -48,7 +49,15 @@ type HostMatcher struct {
 }
 
 func (m *Matcher) DeepCopyInto(out *Matcher) {
+	var withBacktracking *bool
+
+	if m.BacktrackingEnabled != nil {
+		value := *m.BacktrackingEnabled
+		withBacktracking = &value
+	}
+
 	out.Scheme = m.Scheme
+	out.BacktrackingEnabled = withBacktracking
 	out.Methods = slices.Clone(m.Methods)
 	out.Hosts = slices.Clone(m.Hosts)
 

--- a/internal/rules/api/v1beta1/matcher.go
+++ b/internal/rules/api/v1beta1/matcher.go
@@ -18,7 +18,14 @@ package v1beta1
 
 import "slices"
 
+// Matcher contains protocol-specific bindings for rule matching.
+// Currently only HTTP is supported.
 type Matcher struct {
+	HTTP *HTTPMatcher `json:"http" yaml:"http" validate:"required"` //nolint:tagalign
+}
+
+// HTTPMatcher contains all HTTP-specific matching criteria.
+type HTTPMatcher struct {
 	Routes  []Route  `json:"routes"            yaml:"routes"            validate:"required,dive"`              //nolint:lll,tagalign
 	Scheme  string   `json:"scheme,omitempty"  yaml:"scheme,omitempty"  validate:"omitempty,oneof=http https"` //nolint:lll,tagalign
 	Methods []string `json:"methods,omitempty" yaml:"methods,omitempty" validate:"omitempty,dive,required"`    //nolint:lll,tagalign
@@ -42,12 +49,14 @@ type ParameterMatcher struct {
 	Type  string `json:"type"  yaml:"type"  validate:"required,oneof=exact glob regex"` //nolint:tagalign
 }
 
-type HostMatcher struct {
-	Value string `json:"value" yaml:"value" validate:"required"`                      //nolint:tagalign
-	Type  string `json:"type"  yaml:"type"  validate:"required,oneof=exact wildcard"` //nolint:tagalign
+func (m *Matcher) DeepCopyInto(out *Matcher) {
+	if m.HTTP != nil {
+		out.HTTP = new(HTTPMatcher)
+		m.HTTP.DeepCopyInto(out.HTTP)
+	}
 }
 
-func (m *Matcher) DeepCopyInto(out *Matcher) {
+func (m *HTTPMatcher) DeepCopyInto(out *HTTPMatcher) {
 	out.Scheme = m.Scheme
 	out.Methods = slices.Clone(m.Methods)
 	out.Hosts = slices.Clone(m.Hosts)

--- a/internal/rules/api/v1beta1/matcher.go
+++ b/internal/rules/api/v1beta1/matcher.go
@@ -33,17 +33,17 @@ type HTTPMatcher struct {
 }
 
 type Path struct {
-	Path       string             `json:"path"                  yaml:"path"                  validate:"required"`                //nolint:lll,tagalign
-	PathParams []ParameterMatcher `json:"path_params,omitempty" yaml:"path_params,omitempty" validate:"omitempty,dive,required"` //nolint:lll,tagalign
+	Path     string           `json:"path"               yaml:"path"               validate:"required"`                //nolint:lll,tagalign
+	Captures []CaptureMatcher `json:"captures,omitempty" yaml:"captures,omitempty" validate:"omitempty,dive,required"` //nolint:lll,tagalign
 }
 
 func (r *Path) DeepCopyInto(out *Path) {
 	*out = *r
 
-	out.PathParams = slices.Clone(r.PathParams)
+	out.Captures = slices.Clone(r.Captures)
 }
 
-type ParameterMatcher struct {
+type CaptureMatcher struct {
 	Name  string `json:"name"  yaml:"name"  validate:"required,ne=*"`                   //nolint:tagalign
 	Value string `json:"value" yaml:"value" validate:"required"`                        //nolint:tagalign
 	Type  string `json:"type"  yaml:"type"  validate:"required,oneof=exact glob regex"` //nolint:tagalign

--- a/internal/rules/api/v1beta1/matcher.go
+++ b/internal/rules/api/v1beta1/matcher.go
@@ -26,18 +26,18 @@ type Matcher struct {
 
 // HTTPMatcher contains all HTTP-specific matching criteria.
 type HTTPMatcher struct {
-	Routes  []Route  `json:"routes"            yaml:"routes"            validate:"required,dive"`              //nolint:lll,tagalign
+	Paths   []Path   `json:"paths"             yaml:"paths"             validate:"required,dive"`              //nolint:lll,tagalign
 	Scheme  string   `json:"scheme,omitempty"  yaml:"scheme,omitempty"  validate:"omitempty,oneof=http https"` //nolint:lll,tagalign
 	Methods []string `json:"methods,omitempty" yaml:"methods,omitempty" validate:"omitempty,dive,required"`    //nolint:lll,tagalign
 	Hosts   []string `json:"hosts,omitempty"   yaml:"hosts,omitempty"   validate:"omitempty,required"`         //nolint:lll,tagalign
 }
 
-type Route struct {
+type Path struct {
 	Path       string             `json:"path"                  yaml:"path"                  validate:"required"`                //nolint:lll,tagalign
 	PathParams []ParameterMatcher `json:"path_params,omitempty" yaml:"path_params,omitempty" validate:"omitempty,dive,required"` //nolint:lll,tagalign
 }
 
-func (r *Route) DeepCopyInto(out *Route) {
+func (r *Path) DeepCopyInto(out *Path) {
 	*out = *r
 
 	out.PathParams = slices.Clone(r.PathParams)
@@ -61,8 +61,8 @@ func (m *HTTPMatcher) DeepCopyInto(out *HTTPMatcher) {
 	out.Methods = slices.Clone(m.Methods)
 	out.Hosts = slices.Clone(m.Hosts)
 
-	out.Routes = make([]Route, len(m.Routes))
-	for i, route := range m.Routes {
-		route.DeepCopyInto(&out.Routes[i])
+	out.Paths = make([]Path, len(m.Paths))
+	for i, route := range m.Paths {
+		route.DeepCopyInto(&out.Paths[i])
 	}
 }

--- a/internal/rules/api/v1beta1/matcher_test.go
+++ b/internal/rules/api/v1beta1/matcher_test.go
@@ -29,12 +29,12 @@ func TestMatcherDeepCopyInto(t *testing.T) {
 		"nil http binding": {},
 		"single route defining only a path": {
 			HTTP: &HTTPMatcher{
-				Routes: []Route{{Path: "/foo/bar"}},
+				Paths: []Path{{Path: "/foo/bar"}},
 			},
 		},
 		"single route defining path and some path parameters": {
 			HTTP: &HTTPMatcher{
-				Routes: []Route{
+				Paths: []Path{
 					{
 						Path: "/:foo/:bar",
 						PathParams: []ParameterMatcher{
@@ -47,7 +47,7 @@ func TestMatcherDeepCopyInto(t *testing.T) {
 		},
 		"multiple routes and additional constraints": {
 			HTTP: &HTTPMatcher{
-				Routes: []Route{
+				Paths: []Path{
 					{
 						Path: "/:foo/:bar",
 						PathParams: []ParameterMatcher{

--- a/internal/rules/api/v1beta1/matcher_test.go
+++ b/internal/rules/api/v1beta1/matcher_test.go
@@ -26,36 +26,43 @@ func TestMatcherDeepCopyInto(t *testing.T) {
 	t.Parallel()
 
 	for uc, tc := range map[string]*Matcher{
+		"nil http binding": {},
 		"single route defining only a path": {
-			Routes: []Route{{Path: "/foo/bar"}},
+			HTTP: &HTTPMatcher{
+				Routes: []Route{{Path: "/foo/bar"}},
+			},
 		},
 		"single route defining path and some path parameters": {
-			Routes: []Route{
-				{
-					Path: "/:foo/:bar",
-					PathParams: []ParameterMatcher{
-						{Name: "foo", Value: "bar", Type: "glob"},
-						{Name: "bar", Value: "baz", Type: "regex"},
+			HTTP: &HTTPMatcher{
+				Routes: []Route{
+					{
+						Path: "/:foo/:bar",
+						PathParams: []ParameterMatcher{
+							{Name: "foo", Value: "bar", Type: "glob"},
+							{Name: "bar", Value: "baz", Type: "regex"},
+						},
 					},
 				},
 			},
 		},
 		"multiple routes and additional constraints": {
-			Routes: []Route{
-				{
-					Path: "/:foo/:bar",
-					PathParams: []ParameterMatcher{
-						{Name: "foo", Value: "bar", Type: "glob"},
-						{Name: "bar", Value: "baz", Type: "regex"},
+			HTTP: &HTTPMatcher{
+				Routes: []Route{
+					{
+						Path: "/:foo/:bar",
+						PathParams: []ParameterMatcher{
+							{Name: "foo", Value: "bar", Type: "glob"},
+							{Name: "bar", Value: "baz", Type: "regex"},
+						},
+					},
+					{
+						Path: "/some/static/path",
 					},
 				},
-				{
-					Path: "/some/static/path",
-				},
+				Scheme:  "https",
+				Hosts:   []string{"*.example.com"},
+				Methods: []string{"GET", "POST"},
 			},
-			Scheme:  "https",
-			Hosts:   []string{"*.example.com"},
-			Methods: []string{"GET", "POST"},
 		},
 	} {
 		t.Run(uc, func(t *testing.T) {

--- a/internal/rules/api/v1beta1/matcher_test.go
+++ b/internal/rules/api/v1beta1/matcher_test.go
@@ -37,7 +37,7 @@ func TestMatcherDeepCopyInto(t *testing.T) {
 				Paths: []Path{
 					{
 						Path: "/:foo/:bar",
-						PathParams: []ParameterMatcher{
+						Captures: []CaptureMatcher{
 							{Name: "foo", Value: "bar", Type: "glob"},
 							{Name: "bar", Value: "baz", Type: "regex"},
 						},
@@ -50,7 +50,7 @@ func TestMatcherDeepCopyInto(t *testing.T) {
 				Paths: []Path{
 					{
 						Path: "/:foo/:bar",
-						PathParams: []ParameterMatcher{
+						Captures: []CaptureMatcher{
 							{Name: "foo", Value: "bar", Type: "glob"},
 							{Name: "bar", Value: "baz", Type: "regex"},
 						},

--- a/internal/rules/api/v1beta1/rule.go
+++ b/internal/rules/api/v1beta1/rule.go
@@ -26,12 +26,12 @@ import (
 )
 
 type Rule struct {
-	ID                     string                 `json:"id"                    yaml:"id"                    validate:"required"`                         //nolint:lll,tagalign
-	EncodedSlashesHandling EncodedSlashesHandling `json:"allow_encoded_slashes" yaml:"allow_encoded_slashes" validate:"omitempty,oneof=off on no_decode"` //nolint:lll,tagalign
-	Matcher                Matcher                `json:"match"                 yaml:"match"                 validate:"required"`                         //nolint:lll,tagalign
-	Backend                *Backend               `json:"forward_to"            yaml:"forward_to"            validate:"omitnil"`                          //nolint:lll,tagalign
-	Execute                []Step                 `json:"execute"               yaml:"execute"               validate:"gt=0,dive,required"`               //nolint:lll,tagalign
-	ErrorHandler           []Step                 `json:"on_error"              yaml:"on_error"`
+	ID                     string                 `json:"id"                              yaml:"id"                              validate:"required"`                         //nolint:lll,tagalign
+	EncodedSlashesHandling EncodedSlashesHandling `json:"allow_encoded_slashes,omitempty" yaml:"allow_encoded_slashes,omitempty" validate:"omitempty,oneof=off on no_decode"` //nolint:lll,tagalign
+	Matcher                Matcher                `json:"match"                           yaml:"match"                           validate:"required"`                         //nolint:lll,tagalign
+	Backend                *Backend               `json:"forward_to,omitempty"            yaml:"forward_to,omitempty"            validate:"omitnil"`                          //nolint:lll,tagalign
+	Execute                []Step                 `json:"execute"                         yaml:"execute"                         validate:"gt=0,dive,required"`               //nolint:lll,tagalign
+	ErrorHandler           []Step                 `json:"on_error,omitempty"              yaml:"on_error,omitempty"`
 }
 
 func (r *Rule) Hash() ([]byte, error) {

--- a/internal/rules/api/v1beta1/rule_test.go
+++ b/internal/rules/api/v1beta1/rule_test.go
@@ -36,7 +36,7 @@ func TestRuleConfigDeepCopyInto(t *testing.T) {
 				Paths: []Path{
 					{
 						Path: "/:foo/*something",
-						PathParams: []ParameterMatcher{
+						Captures: []CaptureMatcher{
 							{Name: "foo", Value: "bar", Type: "glob"},
 							{Name: "something", Value: ".*\\.css", Type: "regex"},
 						},
@@ -101,7 +101,7 @@ func TestRuleConfigDeepCopy(t *testing.T) {
 				Paths: []Path{
 					{
 						Path: "/:foo/*something",
-						PathParams: []ParameterMatcher{
+						Captures: []CaptureMatcher{
 							{Name: "foo", Value: "bar", Type: "glob"},
 							{Name: "something", Value: ".*\\.css", Type: "regex"},
 						},

--- a/internal/rules/api/v1beta1/rule_test.go
+++ b/internal/rules/api/v1beta1/rule_test.go
@@ -33,7 +33,7 @@ func TestRuleConfigDeepCopyInto(t *testing.T) {
 		ID: "foo",
 		Matcher: Matcher{
 			HTTP: &HTTPMatcher{
-				Routes: []Route{
+				Paths: []Path{
 					{
 						Path: "/:foo/*something",
 						PathParams: []ParameterMatcher{
@@ -98,7 +98,7 @@ func TestRuleConfigDeepCopy(t *testing.T) {
 		ID: "foo",
 		Matcher: Matcher{
 			HTTP: &HTTPMatcher{
-				Routes: []Route{
+				Paths: []Path{
 					{
 						Path: "/:foo/*something",
 						PathParams: []ParameterMatcher{

--- a/internal/rules/api/v1beta1/rule_test.go
+++ b/internal/rules/api/v1beta1/rule_test.go
@@ -32,21 +32,23 @@ func TestRuleConfigDeepCopyInto(t *testing.T) {
 	in := Rule{
 		ID: "foo",
 		Matcher: Matcher{
-			Routes: []Route{
-				{
-					Path: "/:foo/*something",
-					PathParams: []ParameterMatcher{
-						{Name: "foo", Value: "bar", Type: "glob"},
-						{Name: "something", Value: ".*\\.css", Type: "regex"},
+			HTTP: &HTTPMatcher{
+				Routes: []Route{
+					{
+						Path: "/:foo/*something",
+						PathParams: []ParameterMatcher{
+							{Name: "foo", Value: "bar", Type: "glob"},
+							{Name: "something", Value: ".*\\.css", Type: "regex"},
+						},
+					},
+					{
+						Path: "/some/static/path",
 					},
 				},
-				{
-					Path: "/some/static/path",
-				},
+				Scheme:  "https",
+				Hosts:   []string{"*.example.com"},
+				Methods: []string{"GET", "PATCH"},
 			},
-			Scheme:  "https",
-			Hosts:   []string{"*.example.com"},
-			Methods: []string{"GET", "PATCH"},
 		},
 		Backend: &Backend{
 			Host: "baz",
@@ -95,21 +97,23 @@ func TestRuleConfigDeepCopy(t *testing.T) {
 	in := &Rule{
 		ID: "foo",
 		Matcher: Matcher{
-			Routes: []Route{
-				{
-					Path: "/:foo/*something",
-					PathParams: []ParameterMatcher{
-						{Name: "foo", Value: "bar", Type: "glob"},
-						{Name: "something", Value: ".*\\.css", Type: "regex"},
+			HTTP: &HTTPMatcher{
+				Routes: []Route{
+					{
+						Path: "/:foo/*something",
+						PathParams: []ParameterMatcher{
+							{Name: "foo", Value: "bar", Type: "glob"},
+							{Name: "something", Value: ".*\\.css", Type: "regex"},
+						},
+					},
+					{
+						Path: "/some/static/path",
 					},
 				},
-				{
-					Path: "/some/static/path",
-				},
+				Scheme:  "https",
+				Hosts:   []string{"*.example.com"},
+				Methods: []string{"GET", "PATCH"},
 			},
-			Scheme:  "https",
-			Hosts:   []string{"*.example.com"},
-			Methods: []string{"GET", "PATCH"},
 		},
 		Backend: &Backend{
 			Host: "baz",

--- a/internal/rules/converter/converter.go
+++ b/internal/rules/converter/converter.go
@@ -121,8 +121,8 @@ func (c *converter) convertV1Beta1ToV1Alpha4(sourceRs *v1beta1.RuleSet) (*v1alph
 
 		routes := make([]v1alpha4.Route, len(http.Paths))
 		for idx, path := range http.Paths {
-			params := make([]v1alpha4.ParameterMatcher, len(path.PathParams))
-			for idx, param := range path.PathParams {
+			params := make([]v1alpha4.ParameterMatcher, len(path.Captures))
+			for idx, param := range path.Captures {
 				params[idx] = v1alpha4.ParameterMatcher{
 					Name:  param.Name,
 					Type:  param.Type,
@@ -187,9 +187,9 @@ func (c *converter) convertV1Alpha4ToV1Beta1(sourceRs *v1alpha4.RuleSet) (*v1bet
 	for idx, rul := range sourceRs.Rules {
 		paths := make([]v1beta1.Path, len(rul.Matcher.Routes))
 		for idx, path := range rul.Matcher.Routes {
-			params := make([]v1beta1.ParameterMatcher, len(path.PathParams))
+			params := make([]v1beta1.CaptureMatcher, len(path.PathParams))
 			for idx, param := range path.PathParams {
-				params[idx] = v1beta1.ParameterMatcher{
+				params[idx] = v1beta1.CaptureMatcher{
 					Name:  param.Name,
 					Type:  param.Type,
 					Value: param.Value,
@@ -197,8 +197,8 @@ func (c *converter) convertV1Alpha4ToV1Beta1(sourceRs *v1alpha4.RuleSet) (*v1bet
 			}
 
 			paths[idx] = v1beta1.Path{
-				Path:       path.Path,
-				PathParams: params,
+				Path:     path.Path,
+				Captures: params,
 			}
 		}
 

--- a/internal/rules/converter/converter.go
+++ b/internal/rules/converter/converter.go
@@ -117,7 +117,9 @@ func (c *converter) convertV1Beta1ToV1Alpha4(sourceRs *v1beta1.RuleSet) (*v1alph
 	convertedRules := make([]v1alpha4.Rule, len(sourceRs.Rules))
 
 	for idx, rul := range sourceRs.Rules {
-		routes, err := convertObject[[]v1beta1.Route, []v1alpha4.Route](rul.Matcher.Routes)
+		http := rul.Matcher.HTTP
+
+		routes, err := convertObject[[]v1beta1.Route, []v1alpha4.Route](http.Routes)
 		if err != nil {
 			return nil, errorchain.NewWithMessagef(ErrConversion,
 				"failed converting matcher routes for rule %s", rul.ID).CausedBy(err)
@@ -129,8 +131,8 @@ func (c *converter) convertV1Beta1ToV1Alpha4(sourceRs *v1beta1.RuleSet) (*v1alph
 				"failed converting forward_to for rule %s", rul.ID).CausedBy(err)
 		}
 
-		hosts := make([]v1alpha4.HostMatcher, len(rul.Matcher.Hosts))
-		for idx, host := range rul.Matcher.Hosts {
+		hosts := make([]v1alpha4.HostMatcher, len(http.Hosts))
+		for idx, host := range http.Hosts {
 			hosts[idx] = v1alpha4.HostMatcher{Value: host, Type: "wildcard"}
 		}
 
@@ -151,8 +153,8 @@ func (c *converter) convertV1Beta1ToV1Alpha4(sourceRs *v1beta1.RuleSet) (*v1alph
 			EncodedSlashesHandling: v1alpha4.EncodedSlashesHandling(rul.EncodedSlashesHandling),
 			Matcher: v1alpha4.Matcher{
 				Routes:  routes,
-				Scheme:  rul.Matcher.Scheme,
-				Methods: rul.Matcher.Methods,
+				Scheme:  http.Scheme,
+				Methods: http.Methods,
 				Hosts:   hosts,
 			},
 			Backend:      &backend,
@@ -205,10 +207,12 @@ func (c *converter) convertV1Alpha4ToV1Beta1(sourceRs *v1alpha4.RuleSet) (*v1bet
 			ID:                     rul.ID,
 			EncodedSlashesHandling: v1beta1.EncodedSlashesHandling(rul.EncodedSlashesHandling),
 			Matcher: v1beta1.Matcher{
-				Routes:  routes,
-				Scheme:  rul.Matcher.Scheme,
-				Methods: rul.Matcher.Methods,
-				Hosts:   hosts,
+				HTTP: &v1beta1.HTTPMatcher{
+					Routes:  routes,
+					Scheme:  rul.Matcher.Scheme,
+					Methods: rul.Matcher.Methods,
+					Hosts:   hosts,
+				},
 			},
 			Backend:      &backend,
 			Execute:      executePipeline,

--- a/internal/rules/converter/converter.go
+++ b/internal/rules/converter/converter.go
@@ -198,6 +198,7 @@ func (c *converter) convertV1Beta1ToV1Alpha4(sourceRs *v1beta1.RuleSet) (*v1alph
 	}, nil
 }
 
+//nolint:funlen
 func (c *converter) convertV1Alpha4ToV1Beta1(sourceRs *v1alpha4.RuleSet) (*v1beta1.RuleSet, error) {
 	convertedRules := make([]v1beta1.Rule, len(sourceRs.Rules))
 
@@ -231,9 +232,20 @@ func (c *converter) convertV1Alpha4ToV1Beta1(sourceRs *v1alpha4.RuleSet) (*v1bet
 			backend = &be
 		}
 
-		hosts := make([]string, len(rul.Matcher.Hosts))
-		for idx, host := range rul.Matcher.Hosts {
-			hosts[idx] = host.Value
+		hosts := make([]string, 0, len(rul.Matcher.Hosts))
+		for _, host := range rul.Matcher.Hosts {
+			switch host.Type {
+			case "exact", "wildcard":
+				hosts = append(hosts, host.Value)
+
+			case "glob", "regex":
+				return nil, errorchain.NewWithMessagef(
+					ErrConversion,
+					"host matcher of type %q in rule %q cannot be converted automatically; replace it with an exact or wildcard matcher", //nolint:lll
+					host.Type,
+					rul.ID,
+				)
+			}
 		}
 
 		executePipeline, err := convertObject[[]config.MechanismConfig, []v1beta1.Step](rul.Execute)

--- a/internal/rules/converter/converter.go
+++ b/internal/rules/converter/converter.go
@@ -40,12 +40,14 @@ type (
 
 	converter struct {
 		toVersion string
+		validator encoding.Validator
 	}
 )
 
-func New(desiredVersion string) Converter {
+func New(desiredVersion string, validator encoding.Validator) Converter {
 	return &converter{
 		toVersion: desiredVersion,
+		validator: validator,
 	}
 }
 
@@ -56,10 +58,11 @@ func (c *converter) Convert(rawObj []byte, format string) ([]byte, error) { // n
 		converted any
 	)
 
-	dec := encoding.NewDecoder(encoding.WithSourceContentType(format))
+	rawDec := encoding.NewDecoder(encoding.WithSourceContentType(format))
+	typedDec := encoding.NewDecoder(encoding.WithValidator(c.validator))
 	enc := encoding.NewEncoder(encoding.WithTargetContentType(format))
 
-	if err = dec.Decode(&urs, bytes.NewBuffer(rawObj)); err != nil {
+	if err = rawDec.Decode(&urs, bytes.NewBuffer(rawObj)); err != nil {
 		return nil, errorchain.NewWithMessage(ErrConversion,
 			"failed to decode ruleset").CausedBy(err)
 	}
@@ -79,8 +82,12 @@ func (c *converter) Convert(rawObj []byte, format string) ([]byte, error) { // n
 
 		var sourceRs v1alpha4.RuleSet
 
-		// decoding will always succeed, as it was already successful above
-		_ = dec.DecodeMap(&sourceRs, urs)
+		if err = typedDec.DecodeMap(&sourceRs, urs); err != nil {
+			return nil, errorchain.NewWithMessage(
+				ErrConversion,
+				"failed to decode 1alpha4 ruleset",
+			).CausedBy(err)
+		}
 
 		converted, err = c.convertV1Alpha4ToV1Beta1(&sourceRs)
 	case v1beta1.Version:
@@ -91,8 +98,12 @@ func (c *converter) Convert(rawObj []byte, format string) ([]byte, error) { // n
 
 		var sourceRs v1beta1.RuleSet
 
-		// decoding will always succeed, as it was already successful above
-		_ = dec.DecodeMap(&sourceRs, urs)
+		if err = typedDec.DecodeMap(&sourceRs, urs); err != nil {
+			return nil, errorchain.NewWithMessage(
+				ErrConversion,
+				"failed to decode 1beta1 ruleset",
+			).CausedBy(err)
+		}
 
 		converted, err = c.convertV1Beta1ToV1Alpha4(&sourceRs)
 	default:
@@ -136,10 +147,16 @@ func (c *converter) convertV1Beta1ToV1Alpha4(sourceRs *v1beta1.RuleSet) (*v1alph
 			}
 		}
 
-		backend, err := convertObject[v1beta1.Backend, v1alpha4.Backend](*rul.Backend)
-		if err != nil {
-			return nil, errorchain.NewWithMessagef(ErrConversion,
-				"failed converting forward_to for rule %s", rul.ID).CausedBy(err)
+		var backend *v1alpha4.Backend
+
+		if rul.Backend != nil {
+			be, err := convertObject[v1beta1.Backend, v1alpha4.Backend](*rul.Backend)
+			if err != nil {
+				return nil, errorchain.NewWithMessagef(ErrConversion,
+					"failed converting forward_to for rule %s", rul.ID).CausedBy(err)
+			}
+
+			backend = &be
 		}
 
 		hosts := make([]v1alpha4.HostMatcher, len(http.Hosts))
@@ -168,7 +185,7 @@ func (c *converter) convertV1Beta1ToV1Alpha4(sourceRs *v1beta1.RuleSet) (*v1alph
 				Methods: http.Methods,
 				Hosts:   hosts,
 			},
-			Backend:      &backend,
+			Backend:      backend,
 			Execute:      executePipeline,
 			ErrorHandler: errorPipeline,
 		}
@@ -202,10 +219,16 @@ func (c *converter) convertV1Alpha4ToV1Beta1(sourceRs *v1alpha4.RuleSet) (*v1bet
 			}
 		}
 
-		backend, err := convertObject[v1alpha4.Backend, v1beta1.Backend](*rul.Backend)
-		if err != nil {
-			return nil, errorchain.NewWithMessagef(ErrConversion,
-				"failed converting forward_to for rule %s", rul.ID).CausedBy(err)
+		var backend *v1beta1.Backend
+
+		if rul.Backend != nil {
+			be, err := convertObject[v1alpha4.Backend, v1beta1.Backend](*rul.Backend)
+			if err != nil {
+				return nil, errorchain.NewWithMessagef(ErrConversion,
+					"failed converting forward_to for rule %s", rul.ID).CausedBy(err)
+			}
+
+			backend = &be
 		}
 
 		hosts := make([]string, len(rul.Matcher.Hosts))
@@ -236,7 +259,7 @@ func (c *converter) convertV1Alpha4ToV1Beta1(sourceRs *v1alpha4.RuleSet) (*v1bet
 					Hosts:   hosts,
 				},
 			},
-			Backend:      &backend,
+			Backend:      backend,
 			Execute:      executePipeline,
 			ErrorHandler: errorPipeline,
 		}

--- a/internal/rules/converter/converter.go
+++ b/internal/rules/converter/converter.go
@@ -119,10 +119,21 @@ func (c *converter) convertV1Beta1ToV1Alpha4(sourceRs *v1beta1.RuleSet) (*v1alph
 	for idx, rul := range sourceRs.Rules {
 		http := rul.Matcher.HTTP
 
-		routes, err := convertObject[[]v1beta1.Route, []v1alpha4.Route](http.Routes)
-		if err != nil {
-			return nil, errorchain.NewWithMessagef(ErrConversion,
-				"failed converting matcher routes for rule %s", rul.ID).CausedBy(err)
+		routes := make([]v1alpha4.Route, len(http.Paths))
+		for idx, path := range http.Paths {
+			params := make([]v1alpha4.ParameterMatcher, len(path.PathParams))
+			for idx, param := range path.PathParams {
+				params[idx] = v1alpha4.ParameterMatcher{
+					Name:  param.Name,
+					Type:  param.Type,
+					Value: param.Value,
+				}
+			}
+
+			routes[idx] = v1alpha4.Route{
+				Path:       path.Path,
+				PathParams: params,
+			}
 		}
 
 		backend, err := convertObject[v1beta1.Backend, v1alpha4.Backend](*rul.Backend)
@@ -174,10 +185,21 @@ func (c *converter) convertV1Alpha4ToV1Beta1(sourceRs *v1alpha4.RuleSet) (*v1bet
 	convertedRules := make([]v1beta1.Rule, len(sourceRs.Rules))
 
 	for idx, rul := range sourceRs.Rules {
-		routes, err := convertObject[[]v1alpha4.Route, []v1beta1.Route](rul.Matcher.Routes)
-		if err != nil {
-			return nil, errorchain.NewWithMessagef(ErrConversion,
-				"failed converting matcher routes for rule %s", rul.ID).CausedBy(err)
+		paths := make([]v1beta1.Path, len(rul.Matcher.Routes))
+		for idx, path := range rul.Matcher.Routes {
+			params := make([]v1beta1.ParameterMatcher, len(path.PathParams))
+			for idx, param := range path.PathParams {
+				params[idx] = v1beta1.ParameterMatcher{
+					Name:  param.Name,
+					Type:  param.Type,
+					Value: param.Value,
+				}
+			}
+
+			paths[idx] = v1beta1.Path{
+				Path:       path.Path,
+				PathParams: params,
+			}
 		}
 
 		backend, err := convertObject[v1alpha4.Backend, v1beta1.Backend](*rul.Backend)
@@ -208,7 +230,7 @@ func (c *converter) convertV1Alpha4ToV1Beta1(sourceRs *v1alpha4.RuleSet) (*v1bet
 			EncodedSlashesHandling: v1beta1.EncodedSlashesHandling(rul.EncodedSlashesHandling),
 			Matcher: v1beta1.Matcher{
 				HTTP: &v1beta1.HTTPMatcher{
-					Routes:  routes,
+					Paths:   paths,
 					Scheme:  rul.Matcher.Scheme,
 					Methods: rul.Matcher.Methods,
 					Hosts:   hosts,

--- a/internal/rules/converter/converter_test.go
+++ b/internal/rules/converter/converter_test.go
@@ -132,7 +132,7 @@ rules:
       http:
         paths:
           - path: /pub/*baz
-            path_params:
+            captures:
               - name: baz
                 value: "*foo*"
                 type: glob
@@ -160,7 +160,7 @@ rules:
       http:
         paths:
           - path: /pub/*baz
-            path_params:
+            captures:
               - name: baz
                 value: "*foo*"
                 type: glob

--- a/internal/rules/converter/converter_test.go
+++ b/internal/rules/converter/converter_test.go
@@ -30,13 +30,13 @@ func TestConverterConvert(t *testing.T) {
 	t.Parallel()
 
 	for uc, tc := range map[string]struct {
-		date           []byte
+		data           []byte
 		format         string
 		desiredVersion string
 		assert         func(t *testing.T, err error, result []byte)
 	}{
 		"decoding failed": {
-			date: []byte("foo"),
+			data: []byte("foo"),
 			assert: func(t *testing.T, err error, _ []byte) {
 				t.Helper()
 
@@ -46,7 +46,7 @@ func TestConverterConvert(t *testing.T) {
 			},
 		},
 		"ruleset is already in the expected version": {
-			date:           []byte("version: 1alpha4"),
+			data:           []byte("version: 1alpha4"),
 			format:         "application/yaml",
 			desiredVersion: "1alpha4",
 			assert: func(t *testing.T, err error, _ []byte) {
@@ -58,7 +58,7 @@ func TestConverterConvert(t *testing.T) {
 			},
 		},
 		"cannot convert from v1alpha4 to v1alpha3": {
-			date:           []byte("version: 1alpha4"),
+			data:           []byte("version: 1alpha4"),
 			format:         "application/yaml",
 			desiredVersion: "v1alpha3",
 			assert: func(t *testing.T, err error, _ []byte) {
@@ -70,7 +70,7 @@ func TestConverterConvert(t *testing.T) {
 			},
 		},
 		"cannot convert from v1beta1 to v1alpha3": {
-			date:           []byte("version: 1beta1"),
+			data:           []byte("version: 1beta1"),
 			format:         "application/yaml",
 			desiredVersion: "v1alpha3",
 			assert: func(t *testing.T, err error, _ []byte) {
@@ -82,7 +82,7 @@ func TestConverterConvert(t *testing.T) {
 			},
 		},
 		"unexpected source version": {
-			date:           []byte("version: foo"),
+			data:           []byte("version: foo"),
 			format:         "application/yaml",
 			desiredVersion: "v1alpha4",
 			assert: func(t *testing.T, err error, _ []byte) {
@@ -93,8 +93,27 @@ func TestConverterConvert(t *testing.T) {
 				require.ErrorContains(t, err, "unexpected source ruleset version: foo")
 			},
 		},
+		"v1beta1 ruleset without HTTP matcher cannot be converted": {
+			data: []byte(`
+version: 1beta1
+rules:
+  - id: public-access
+    match: {}
+    execute:
+      - authorizer: allow_all_requests
+`),
+			format:         "application/yaml",
+			desiredVersion: "1alpha4",
+			assert: func(t *testing.T, err error, _ []byte) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrConversion)
+				require.ErrorContains(t, err, "failed to decode 1beta1 ruleset")
+			},
+		},
 		"successful conversion from v1alpha4 to v1beta1": {
-			date: []byte(`
+			data: []byte(`
 version: 1alpha4
 rules:
   - id: public-access
@@ -153,8 +172,38 @@ rules:
 `, string(result))
 			},
 		},
+		"successful conversion from v1alpha4 to v1beta1 without backend": {
+			data: []byte(`
+version: 1alpha4
+rules:
+  - id: public-access
+    match:
+      routes:
+        - path: /pub/**
+    execute:
+      - authorizer: allow_all_requests
+`),
+			format:         "application/yaml",
+			desiredVersion: "1beta1",
+			assert: func(t *testing.T, err error, result []byte) {
+				t.Helper()
+
+				require.NoError(t, err)
+				assert.YAMLEq(t, `
+version: 1beta1
+rules:
+  - id: public-access
+    match:
+      http:
+        paths:
+          - path: /pub/**
+    execute:
+      - authorizer: allow_all_requests
+`, string(result))
+			},
+		},
 		"successful conversion from v1beta1 to v1alpha4": {
-			date: []byte(`
+			data: []byte(`
 version: 1beta1
 rules:
   - id: public-access
@@ -213,6 +262,36 @@ rules:
 `, string(result))
 			},
 		},
+		"successful conversion from v1beta1 to v1alpha4 without backend": {
+			data: []byte(`
+version: 1beta1
+rules:
+  - id: public-access
+    match:
+      http:
+        paths:
+          - path: /pub/**
+    execute:
+      - authorizer: allow_all_requests
+`),
+			format:         "application/yaml",
+			desiredVersion: "1alpha4",
+			assert: func(t *testing.T, err error, result []byte) {
+				t.Helper()
+
+				require.NoError(t, err)
+				assert.YAMLEq(t, `
+version: 1alpha4
+rules:
+  - id: public-access
+    match:
+      routes:
+        - path: /pub/**
+    execute:
+      - authorizer: allow_all_requests
+`, string(result))
+			},
+		},
 	} {
 		t.Run(uc, func(t *testing.T) {
 			// GIVEN
@@ -222,10 +301,17 @@ rules:
 			conv := New(tc.desiredVersion, encoding.ValidatorFunc(validator.ValidateStruct))
 
 			// WHEN
-			res, err := conv.Convert(tc.date, tc.format)
+			var (
+				res           []byte
+				conversionErr error
+			)
+
+			require.NotPanics(t, func() {
+				res, conversionErr = conv.Convert(tc.data, tc.format)
+			})
 
 			// THEN
-			tc.assert(t, err, res)
+			tc.assert(t, conversionErr, res)
 		})
 	}
 }

--- a/internal/rules/converter/converter_test.go
+++ b/internal/rules/converter/converter_test.go
@@ -96,7 +96,7 @@ version: 1alpha4
 rules:
   - id: public-access
     allow_encoded_slashes: on
-    match: 
+    match:
       routes:
         - path: /pub/*baz
           path_params:
@@ -128,18 +128,19 @@ version: 1beta1
 rules:
   - id: public-access
     allow_encoded_slashes: on
-    match: 
-      routes:
-        - path: /pub/*baz
-          path_params:
-            - name: baz
-              value: "*foo*"
-              type: glob
-      methods: [GET, POST]
-      hosts:
-        - foo.bar
-        - "*.foo"
-      scheme: https
+    match:
+      http:
+        routes:
+          - path: /pub/*baz
+            path_params:
+              - name: baz
+                value: "*foo*"
+                type: glob
+        methods: [GET, POST]
+        hosts:
+          - foo.bar
+          - "*.foo"
+        scheme: https
     forward_to:
       host: foo-app.local:8080
     execute:
@@ -155,18 +156,19 @@ version: 1beta1
 rules:
   - id: public-access
     allow_encoded_slashes: on
-    match: 
-      routes:
-        - path: /pub/*baz
-          path_params:
-            - name: baz
-              value: "*foo*"
-              type: glob
-      methods: [GET, POST]
-      hosts:
-        - foo.bar
-        - "*.foo"
-      scheme: https
+    match:
+      http:
+        routes:
+          - path: /pub/*baz
+            path_params:
+              - name: baz
+                value: "*foo*"
+                type: glob
+        methods: [GET, POST]
+        hosts:
+          - foo.bar
+          - "*.foo"
+        scheme: https
     forward_to:
       host: foo-app.local:8080
     execute:
@@ -185,7 +187,7 @@ version: 1alpha4
 rules:
   - id: public-access
     allow_encoded_slashes: on
-    match: 
+    match:
       routes:
         - path: /pub/*baz
           path_params:

--- a/internal/rules/converter/converter_test.go
+++ b/internal/rules/converter/converter_test.go
@@ -130,7 +130,7 @@ rules:
     allow_encoded_slashes: on
     match:
       http:
-        routes:
+        paths:
           - path: /pub/*baz
             path_params:
               - name: baz
@@ -158,7 +158,7 @@ rules:
     allow_encoded_slashes: on
     match:
       http:
-        routes:
+        paths:
           - path: /pub/*baz
             path_params:
               - name: baz

--- a/internal/rules/converter/converter_test.go
+++ b/internal/rules/converter/converter_test.go
@@ -112,6 +112,58 @@ rules:
 				require.ErrorContains(t, err, "failed to decode 1beta1 ruleset")
 			},
 		},
+		"v1alpha4 ruleset with glob host matcher cannot be converted": {
+			data: []byte(`
+version: 1alpha4
+rules:
+  - id: public-access
+    match:
+      routes:
+        - path: /pub/**
+      hosts:
+        - value: "*.foo"
+          type: glob
+    execute:
+      - authorizer: allow_all_requests
+`),
+			format:         "application/yaml",
+			desiredVersion: "1beta1",
+			assert: func(t *testing.T, err error, _ []byte) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrConversion)
+				require.ErrorContains(t, err, `host matcher of type "glob"`)
+				require.ErrorContains(t, err, `rule "public-access"`)
+				require.ErrorContains(t, err, "cannot be converted automatically")
+			},
+		},
+		"v1alpha4 ruleset with regex host matcher cannot be converted": {
+			data: []byte(`
+version: 1alpha4
+rules:
+  - id: public-access
+    match:
+      routes:
+        - path: /pub/**
+      hosts:
+        - value: "^api[0-9]+[.]example[.]com$"
+          type: regex
+    execute:
+      - authorizer: allow_all_requests
+`),
+			format:         "application/yaml",
+			desiredVersion: "1beta1",
+			assert: func(t *testing.T, err error, _ []byte) {
+				t.Helper()
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrConversion)
+				require.ErrorContains(t, err, `host matcher of type "regex"`)
+				require.ErrorContains(t, err, `rule "public-access"`)
+				require.ErrorContains(t, err, "cannot be converted automatically")
+			},
+		},
 		"successful conversion from v1alpha4 to v1beta1": {
 			data: []byte(`
 version: 1alpha4

--- a/internal/rules/converter/converter_test.go
+++ b/internal/rules/converter/converter_test.go
@@ -21,6 +21,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dadrus/heimdall/internal/encoding"
+	"github.com/dadrus/heimdall/internal/validation"
 )
 
 func TestConverterConvert(t *testing.T) {
@@ -213,7 +216,10 @@ rules:
 	} {
 		t.Run(uc, func(t *testing.T) {
 			// GIVEN
-			conv := New(tc.desiredVersion)
+			validator, err := validation.NewValidator()
+			require.NoError(t, err)
+
+			conv := New(tc.desiredVersion, encoding.ValidatorFunc(validator.ValidateStruct))
 
 			// WHEN
 			res, err := conv.Convert(tc.date, tc.format)

--- a/internal/rules/provider/cloudblob/provider_test.go
+++ b/internal/rules/provider/cloudblob/provider_test.go
@@ -251,8 +251,9 @@ name: test
 rules:
 - id: foo
   match:
-    routes:
-      - path: /foo
+    http:
+      routes:
+        - path: /foo
   execute:
     - authenticator: test
 `
@@ -301,8 +302,9 @@ name: test
 rules:
 - id: foo
   match:
-    routes:
-      - path: /foo
+    http:
+      routes:
+        - path: /foo
   execute:
     - authenticator: test
 `
@@ -356,8 +358,9 @@ name: test
 rules:
 - id: foo
   match:
-    routes:
-      - path: /foo
+    http:
+      routes:
+        - path: /foo
   execute:
     - authenticator: test
 `
@@ -375,8 +378,9 @@ name: test
 rules:
 - id: bar
   match:
-    routes:
-      - path: /bar
+    http:
+      routes:
+        - path: /bar
   execute:
     - authenticator: test
 `
@@ -454,8 +458,9 @@ name: test
 rules:
 - id: foo
   match:
-    routes:
-      - path: /foo
+    http:
+      routes:
+        - path: /foo
   execute:
     - authenticator: test
 `
@@ -470,8 +475,9 @@ name: test
 rules:
 - id: bar
   match:
-    routes:
-      - path: /bar
+    http:
+      routes:
+        - path: /bar
   execute:
     - authenticator: test
 `
@@ -486,8 +492,9 @@ name: test
 rules:
 - id: baz
   match:
-    routes:
-      - path: /baz
+    http:
+      routes:
+        - path: /baz
   execute:
     - authenticator: test
 `

--- a/internal/rules/provider/cloudblob/provider_test.go
+++ b/internal/rules/provider/cloudblob/provider_test.go
@@ -252,7 +252,7 @@ rules:
 - id: foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo
   execute:
     - authenticator: test
@@ -303,7 +303,7 @@ rules:
 - id: foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo
   execute:
     - authenticator: test
@@ -359,7 +359,7 @@ rules:
 - id: foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo
   execute:
     - authenticator: test
@@ -379,7 +379,7 @@ rules:
 - id: bar
   match:
     http:
-      routes:
+      paths:
         - path: /bar
   execute:
     - authenticator: test
@@ -459,7 +459,7 @@ rules:
 - id: foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo
   execute:
     - authenticator: test
@@ -476,7 +476,7 @@ rules:
 - id: bar
   match:
     http:
-      routes:
+      paths:
         - path: /bar
   execute:
     - authenticator: test
@@ -493,7 +493,7 @@ rules:
 - id: baz
   match:
     http:
-      routes:
+      paths:
         - path: /baz
   execute:
     - authenticator: test

--- a/internal/rules/provider/cloudblob/ruleset_endpoint_test.go
+++ b/internal/rules/provider/cloudblob/ruleset_endpoint_test.go
@@ -184,7 +184,7 @@ func TestFetchRuleSets(t *testing.T) {
 		"id": "foobar",
         "match": {
           "http": {
-            "routes": [
+            "paths": [
               { "path": "/foo/bar/api1" }
             ],
             "scheme": "http",
@@ -205,7 +205,7 @@ rules:
 - id: barfoo
   match:
     http:
-      routes:
+      paths:
         - path: /foo/bar/api2
       scheme: http
       hosts:
@@ -263,7 +263,7 @@ rules:
 					"id": "foobar",
                     "match": {
                       "http": {
-                        "routes": [
+                        "paths": [
                            { "path": "/foo/bar/api1" }
                         ],
                         "scheme": "http",
@@ -283,7 +283,7 @@ rules:
 					"id": "barfoo",
                     "match": {
                       "http": {
-                        "routes": [
+                        "paths": [
                           { "path": "/foo/bar/api2" }
                         ],
                         "scheme": "http",
@@ -382,7 +382,7 @@ rules:
 					"id": "foobar",
                     "match": {
                       "http": {
-                        "routes": [
+                        "paths": [
                           { "path": "/foo/bar/api1" }
                         ],
                         "scheme": "http",

--- a/internal/rules/provider/cloudblob/ruleset_endpoint_test.go
+++ b/internal/rules/provider/cloudblob/ruleset_endpoint_test.go
@@ -183,12 +183,14 @@ func TestFetchRuleSets(t *testing.T) {
 	"rules": [{
 		"id": "foobar",
         "match": {
-          "routes": [
-            { "path": "/foo/bar/api1" }
-          ],
-          "scheme": "http",
-          "hosts": [ "*.example.com" ],
-          "methods": ["GET", "POST"]
+          "http": {
+            "routes": [
+              { "path": "/foo/bar/api1" }
+            ],
+            "scheme": "http",
+            "hosts": [ "*.example.com" ],
+            "methods": ["GET", "POST"]
+          }
         },
 		"execute": [
 			{ "authenticator": "foobar" }
@@ -202,14 +204,15 @@ name: test2
 rules:
 - id: barfoo
   match:
-    routes:
-      - path: /foo/bar/api2
-    scheme: http
-    hosts:
-      - "*.example.com"
-    methods: 
-      - GET
-      - POST
+    http:
+      routes:
+        - path: /foo/bar/api2
+      scheme: http
+      hosts:
+        - "*.example.com"
+      methods:
+        - GET
+        - POST
   execute:
   - authenticator: barfoo
 `
@@ -259,12 +262,14 @@ rules:
 				"rules": [{
 					"id": "foobar",
                     "match": {
-                      "routes": [
-                         { "path": "/foo/bar/api1" }
-                      ],
-                      "scheme": "http",
-                      "hosts": ["example.com"],
-                      "methods": ["GET", "POST"]
+                      "http": {
+                        "routes": [
+                           { "path": "/foo/bar/api1" }
+                        ],
+                        "scheme": "http",
+                        "hosts": ["example.com"],
+                        "methods": ["GET", "POST"]
+                      }
                     },
 					"execute": [
 						{ "authenticator": "foobar" }
@@ -277,12 +282,14 @@ rules:
 				"rules": [{
 					"id": "barfoo",
                     "match": {
-                      "routes": [
-                        { "path": "/foo/bar/api2" }
-                      ],
-                      "scheme": "http",
-                      "hosts": [{ "type": "wildcard", "value": "*"}],
-                      "methods": ["GET", "POST"]
+                      "http": {
+                        "routes": [
+                          { "path": "/foo/bar/api2" }
+                        ],
+                        "scheme": "http",
+                        "hosts": ["*"],
+                        "methods": ["GET", "POST"]
+                      }
                     },
 					"execute": [
 						{ "authenticator": "barfoo" }
@@ -374,12 +381,14 @@ rules:
 				"rules": [{
 					"id": "foobar",
                     "match": {
-                      "routes": [
-                        { "path": "/foo/bar/api1" }
-                      ],
-                      "scheme": "http",
-                      "hosts": ["example.com"],
-                      "methods": ["GET", "POST"]
+                      "http": {
+                        "routes": [
+                          { "path": "/foo/bar/api1" }
+                        ],
+                        "scheme": "http",
+                        "hosts": ["example.com"],
+                        "methods": ["GET", "POST"]
+                      }
                     },
 					"execute": [
 						{ "authenticator": "foobar" }

--- a/internal/rules/provider/filesystem/provider_test.go
+++ b/internal/rules/provider/filesystem/provider_test.go
@@ -201,13 +201,14 @@ name: test
 rules:
 - id: foo
   match:
-    routes:
-      - path: /foo/:bar
-        path_params:
-          - name: bar
-            type: glob
-            value: "*baz"
-    methods: [ GET ]
+    http:
+      routes:
+        - path: /foo/:bar
+          path_params:
+            - name: bar
+              type: glob
+              value: "*baz"
+      methods: [ GET ]
   execute:
    - authenticator: test
 `)
@@ -235,13 +236,13 @@ rules:
 				assert.Equal(t, "file_system", ruleSet.Provider)
 				assert.Len(t, ruleSet.Rules, 1)
 				assert.Equal(t, "foo", ruleSet.Rules[0].ID)
-				require.Len(t, ruleSet.Rules[0].Matcher.Routes, 1)
-				assert.Equal(t, "/foo/:bar", ruleSet.Rules[0].Matcher.Routes[0].Path)
-				require.Len(t, ruleSet.Rules[0].Matcher.Routes[0].PathParams, 1)
-				assert.Equal(t, "bar", ruleSet.Rules[0].Matcher.Routes[0].PathParams[0].Name)
-				assert.Equal(t, "glob", ruleSet.Rules[0].Matcher.Routes[0].PathParams[0].Type)
-				assert.Equal(t, "*baz", ruleSet.Rules[0].Matcher.Routes[0].PathParams[0].Value)
-				assert.Equal(t, []string{"GET"}, ruleSet.Rules[0].Matcher.Methods)
+				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Routes, 1)
+				assert.Equal(t, "/foo/:bar", ruleSet.Rules[0].Matcher.HTTP.Routes[0].Path)
+				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams, 1)
+				assert.Equal(t, "bar", ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams[0].Name)
+				assert.Equal(t, "glob", ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams[0].Type)
+				assert.Equal(t, "*baz", ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams[0].Value)
+				assert.Equal(t, []string{"GET"}, ruleSet.Rules[0].Matcher.HTTP.Methods)
 				assert.NotEmpty(t, ruleSet.Hash)
 			},
 		},
@@ -269,8 +270,9 @@ version: "2"
 rules:
 - id: foo
   match:
-    routes:
-      - path: /foo/bar
+    http:
+      routes:
+        - path: /foo/bar
   execute:
     - authenticator: test
 `)
@@ -313,8 +315,9 @@ version: "1"
 rules:
 - id: foo
   match:
-    routes:
-      - path: /foo/bar
+    http:
+      routes:
+        - path: /foo/bar
   execute:
     - authenticator: test
 `)
@@ -349,8 +352,9 @@ version: "1"
 rules:
 - id: foo
   match:
-    routes:
-      - path: /foo/bar
+    http:
+      routes:
+        - path: /foo/bar
   execute:
     - authenticator: test
 `)
@@ -401,8 +405,9 @@ version: "1"
 rules:
 - id: foo
   match:
-    routes:
-      - path: /foo
+    http:
+      routes:
+        - path: /foo
   execute:
     - authenticator: test
 `)
@@ -418,8 +423,9 @@ version: "1"
 rules:
 - id: foo
   match:
-    routes:
-      - path: /foo
+    http:
+      routes:
+        - path: /foo
   execute:
     - authenticator: test
 `)
@@ -435,8 +441,9 @@ version: "2"
 rules:
 - id: bar
   match:
-    routes:
-      - path: /bar
+    http:
+      routes:
+        - path: /bar
   execute:
     - authenticator: test
 `)

--- a/internal/rules/provider/filesystem/provider_test.go
+++ b/internal/rules/provider/filesystem/provider_test.go
@@ -204,7 +204,7 @@ rules:
     http:
       paths:
         - path: /foo/:bar
-          path_params:
+          captures:
             - name: bar
               type: glob
               value: "*baz"
@@ -238,10 +238,10 @@ rules:
 				assert.Equal(t, "foo", ruleSet.Rules[0].ID)
 				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Paths, 1)
 				assert.Equal(t, "/foo/:bar", ruleSet.Rules[0].Matcher.HTTP.Paths[0].Path)
-				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams, 1)
-				assert.Equal(t, "bar", ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams[0].Name)
-				assert.Equal(t, "glob", ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams[0].Type)
-				assert.Equal(t, "*baz", ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams[0].Value)
+				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Paths[0].Captures, 1)
+				assert.Equal(t, "bar", ruleSet.Rules[0].Matcher.HTTP.Paths[0].Captures[0].Name)
+				assert.Equal(t, "glob", ruleSet.Rules[0].Matcher.HTTP.Paths[0].Captures[0].Type)
+				assert.Equal(t, "*baz", ruleSet.Rules[0].Matcher.HTTP.Paths[0].Captures[0].Value)
 				assert.Equal(t, []string{"GET"}, ruleSet.Rules[0].Matcher.HTTP.Methods)
 				assert.NotEmpty(t, ruleSet.Hash)
 			},

--- a/internal/rules/provider/filesystem/provider_test.go
+++ b/internal/rules/provider/filesystem/provider_test.go
@@ -202,7 +202,7 @@ rules:
 - id: foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo/:bar
           path_params:
             - name: bar
@@ -236,12 +236,12 @@ rules:
 				assert.Equal(t, "file_system", ruleSet.Provider)
 				assert.Len(t, ruleSet.Rules, 1)
 				assert.Equal(t, "foo", ruleSet.Rules[0].ID)
-				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Routes, 1)
-				assert.Equal(t, "/foo/:bar", ruleSet.Rules[0].Matcher.HTTP.Routes[0].Path)
-				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams, 1)
-				assert.Equal(t, "bar", ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams[0].Name)
-				assert.Equal(t, "glob", ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams[0].Type)
-				assert.Equal(t, "*baz", ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams[0].Value)
+				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Paths, 1)
+				assert.Equal(t, "/foo/:bar", ruleSet.Rules[0].Matcher.HTTP.Paths[0].Path)
+				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams, 1)
+				assert.Equal(t, "bar", ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams[0].Name)
+				assert.Equal(t, "glob", ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams[0].Type)
+				assert.Equal(t, "*baz", ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams[0].Value)
 				assert.Equal(t, []string{"GET"}, ruleSet.Rules[0].Matcher.HTTP.Methods)
 				assert.NotEmpty(t, ruleSet.Hash)
 			},
@@ -271,7 +271,7 @@ rules:
 - id: foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo/bar
   execute:
     - authenticator: test
@@ -316,7 +316,7 @@ rules:
 - id: foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo/bar
   execute:
     - authenticator: test
@@ -353,7 +353,7 @@ rules:
 - id: foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo/bar
   execute:
     - authenticator: test
@@ -406,7 +406,7 @@ rules:
 - id: foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo
   execute:
     - authenticator: test
@@ -424,7 +424,7 @@ rules:
 - id: foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo
   execute:
     - authenticator: test
@@ -442,7 +442,7 @@ rules:
 - id: bar
   match:
     http:
-      routes:
+      paths:
         - path: /bar
   execute:
     - authenticator: test

--- a/internal/rules/provider/httpendpoint/provider_test.go
+++ b/internal/rules/provider/httpendpoint/provider_test.go
@@ -286,9 +286,10 @@ name: test
 rules:
 - id: foo
   match:
-    routes:
-      - path: /foo
-    methods: [ "GET" ]
+    http:
+      routes:
+        - path: /foo
+      methods: [ "GET" ]
   execute:
     - authenticator: test
 `))
@@ -334,9 +335,10 @@ name: test
 rules:
 - id: bar
   match:
-    routes:
-      - path: /bar
-    methods: [ "GET" ]
+    http:
+      routes:
+        - path: /bar
+      methods: [ "GET" ]
   execute:
     - authenticator: test
 `))
@@ -387,9 +389,10 @@ name: test
 rules:
 - id: foo
   match:
-    routes:
-      - path: /foo
-    methods: [ GET ]
+    http:
+      routes:
+        - path: /foo
+      methods: [ GET ]
   execute:
     - authenticator: test
 `))
@@ -404,9 +407,10 @@ name: test
 rules:
 - id: bar
   match:
-    routes:
-      - path: /bar
-    methods: [ GET ]
+    http:
+      routes:
+        - path: /bar
+      methods: [ GET ]
   execute:
     - authenticator: test
 `))
@@ -477,8 +481,9 @@ name: test
 rules:
 - id: bar
   match:
-    routes:
-      - path: /bar
+    http:
+      routes:
+        - path: /bar
   execute:
     - authenticator: test
 `))
@@ -491,8 +496,9 @@ name: test
 rules:
 - id: baz
   match:
-    routes: 
-      - path: /baz
+    http:
+      routes: 
+        - path: /baz
   execute:
     - authenticator: test
 `))
@@ -505,8 +511,9 @@ name: test
 rules:
 - id: foo
   match:
-    routes:
-      - path: /foo
+    http:
+      routes:
+        - path: /foo
   execute:
     - authenticator: test
 `))
@@ -519,8 +526,9 @@ name: test
 rules:
 - id: foz
   match:
-    routes:
-      - path: /foz
+    http:
+      routes:
+        - path: /foz
   execute:
     - authenticator: test
 `))
@@ -597,8 +605,9 @@ name: test
 rules:
 - id: bar
   match:
-    routes:
-      - path: /bar
+    http:
+      routes:
+        - path: /bar
   execute:
     - authenticator: test
 `))
@@ -647,8 +656,9 @@ name: test
 rules:
 - id: bar
   match:
-    routes:
-      - path: /bar
+    http:
+      routes:
+        - path: /bar
   execute:
     - authenticator: test
 `))
@@ -695,8 +705,9 @@ name: test
 rules:
 - id: foo
   match:
-    routes:
-      - path: /foo
+    http:
+      routes:
+        - path: /foo
   execute:
     - authenticator: test
 `))
@@ -736,8 +747,9 @@ name: test
 rules:
 - id: bar
   match:
-    routes:
-      - path: /bar
+    http:
+      routes:
+        - path: /bar
   execute:
     - authenticator: test
 `))
@@ -750,8 +762,9 @@ name: test
 rules:
 - id: baz
   match:
-    routes:
-      - path: /baz
+    http:
+      routes:
+        - path: /baz
   execute:
     - authenticator: test
 `))
@@ -796,8 +809,9 @@ name: test
 rules:
 - id: bar
   match:
-    routes:
-      - path: /bar
+    http:
+      routes:
+        - path: /bar
   execute:
     - authenticator: test
 `))

--- a/internal/rules/provider/httpendpoint/provider_test.go
+++ b/internal/rules/provider/httpendpoint/provider_test.go
@@ -287,7 +287,7 @@ rules:
 - id: foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo
       methods: [ "GET" ]
   execute:
@@ -336,7 +336,7 @@ rules:
 - id: bar
   match:
     http:
-      routes:
+      paths:
         - path: /bar
       methods: [ "GET" ]
   execute:
@@ -390,7 +390,7 @@ rules:
 - id: foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo
       methods: [ GET ]
   execute:
@@ -408,7 +408,7 @@ rules:
 - id: bar
   match:
     http:
-      routes:
+      paths:
         - path: /bar
       methods: [ GET ]
   execute:
@@ -482,7 +482,7 @@ rules:
 - id: bar
   match:
     http:
-      routes:
+      paths:
         - path: /bar
   execute:
     - authenticator: test
@@ -497,7 +497,7 @@ rules:
 - id: baz
   match:
     http:
-      routes: 
+      paths: 
         - path: /baz
   execute:
     - authenticator: test
@@ -512,7 +512,7 @@ rules:
 - id: foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo
   execute:
     - authenticator: test
@@ -527,7 +527,7 @@ rules:
 - id: foz
   match:
     http:
-      routes:
+      paths:
         - path: /foz
   execute:
     - authenticator: test
@@ -606,7 +606,7 @@ rules:
 - id: bar
   match:
     http:
-      routes:
+      paths:
         - path: /bar
   execute:
     - authenticator: test
@@ -657,7 +657,7 @@ rules:
 - id: bar
   match:
     http:
-      routes:
+      paths:
         - path: /bar
   execute:
     - authenticator: test
@@ -706,7 +706,7 @@ rules:
 - id: foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo
   execute:
     - authenticator: test
@@ -748,7 +748,7 @@ rules:
 - id: bar
   match:
     http:
-      routes:
+      paths:
         - path: /bar
   execute:
     - authenticator: test
@@ -763,7 +763,7 @@ rules:
 - id: baz
   match:
     http:
-      routes:
+      paths:
         - path: /baz
   execute:
     - authenticator: test
@@ -810,7 +810,7 @@ rules:
 - id: bar
   match:
     http:
-      routes:
+      paths:
         - path: /bar
   execute:
     - authenticator: test

--- a/internal/rules/provider/httpendpoint/ruleset_endpoint_test.go
+++ b/internal/rules/provider/httpendpoint/ruleset_endpoint_test.go
@@ -184,7 +184,7 @@ rules:
     http:
       paths:
         - path: /foo/:bar
-          path_params:
+          captures:
             - name: bar
               type: glob
               value: "*baz"
@@ -205,10 +205,10 @@ rules:
 				assert.Equal(t, "foo", ruleSet.Rules[0].ID)
 				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Paths, 1)
 				assert.Equal(t, "/foo/:bar", ruleSet.Rules[0].Matcher.HTTP.Paths[0].Path)
-				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams, 1)
-				assert.Equal(t, "bar", ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams[0].Name)
-				assert.Equal(t, "glob", ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams[0].Type)
-				assert.Equal(t, "*baz", ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams[0].Value)
+				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Paths[0].Captures, 1)
+				assert.Equal(t, "bar", ruleSet.Rules[0].Matcher.HTTP.Paths[0].Captures[0].Name)
+				assert.Equal(t, "glob", ruleSet.Rules[0].Matcher.HTTP.Paths[0].Captures[0].Type)
+				assert.Equal(t, "*baz", ruleSet.Rules[0].Matcher.HTTP.Paths[0].Captures[0].Value)
 				assert.Equal(t, []string{"GET"}, ruleSet.Rules[0].Matcher.HTTP.Methods)
 				assert.NotEmpty(t, ruleSet.Hash)
 			},
@@ -269,7 +269,7 @@ rules:
         "match": {
           "http": {
             "paths": [
-              { "path": "/foo/bar/:baz", "path_params": [{ "name": "baz", "type":"glob", "value":"{*.ico,*.js}" }] }
+              { "path": "/foo/bar/:baz", "captures": [{ "name": "baz", "type":"glob", "value":"{*.ico,*.js}" }] }
             ],
             "methods": [ "GET" ],
             "hosts": [ "moobar.local:9090" ]

--- a/internal/rules/provider/httpendpoint/ruleset_endpoint_test.go
+++ b/internal/rules/provider/httpendpoint/ruleset_endpoint_test.go
@@ -132,8 +132,9 @@ name: test
 rules:
 - id: bar
   match:
-    routes: 
-      - path: /bar
+    http:
+      routes: 
+        - path: /bar
 `))
 				require.NoError(t, err)
 			},
@@ -180,13 +181,14 @@ name: test
 rules:
 - id: foo
   match:
-    routes:
-      - path: /foo/:bar
-        path_params:
-          - name: bar
-            type: glob
-            value: "*baz"
-    methods: [ GET ]
+    http:
+      routes:
+        - path: /foo/:bar
+          path_params:
+            - name: bar
+              type: glob
+              value: "*baz"
+      methods: [ GET ]
   execute:
    - authenticator: test
 `))
@@ -201,13 +203,13 @@ rules:
 				assert.Equal(t, "1", ruleSet.Version)
 				assert.Len(t, ruleSet.Rules, 1)
 				assert.Equal(t, "foo", ruleSet.Rules[0].ID)
-				require.Len(t, ruleSet.Rules[0].Matcher.Routes, 1)
-				assert.Equal(t, "/foo/:bar", ruleSet.Rules[0].Matcher.Routes[0].Path)
-				require.Len(t, ruleSet.Rules[0].Matcher.Routes[0].PathParams, 1)
-				assert.Equal(t, "bar", ruleSet.Rules[0].Matcher.Routes[0].PathParams[0].Name)
-				assert.Equal(t, "glob", ruleSet.Rules[0].Matcher.Routes[0].PathParams[0].Type)
-				assert.Equal(t, "*baz", ruleSet.Rules[0].Matcher.Routes[0].PathParams[0].Value)
-				assert.Equal(t, []string{"GET"}, ruleSet.Rules[0].Matcher.Methods)
+				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Routes, 1)
+				assert.Equal(t, "/foo/:bar", ruleSet.Rules[0].Matcher.HTTP.Routes[0].Path)
+				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams, 1)
+				assert.Equal(t, "bar", ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams[0].Name)
+				assert.Equal(t, "glob", ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams[0].Type)
+				assert.Equal(t, "*baz", ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams[0].Value)
+				assert.Equal(t, []string{"GET"}, ruleSet.Rules[0].Matcher.HTTP.Methods)
 				assert.NotEmpty(t, ruleSet.Hash)
 			},
 		},
@@ -221,15 +223,17 @@ rules:
 				t.Helper()
 
 				w.Header().Set("Content-Type", "application/json")
-				_, err := w.Write([]byte(`{ 
+				_, err := w.Write([]byte(`{
 	"version": "1",
 	"name": "test",
 	"rules": [
-		{ 
+		{
           "id": "foo",
-          "match": { 
-            "routes": [{"path": "/foo"}],
-            "methods" : ["GET"]
+          "match": {
+            "http": {
+              "routes": [{"path": "/foo"}],
+              "methods" : ["GET"]
+            }
           },
           "execute": [{ "authenticator": "test"}] }
 	]
@@ -256,19 +260,21 @@ rules:
 				t.Helper()
 
 				w.Header().Set("Content-Type", "application/json")
-				_, err := w.Write([]byte(`{ 
+				_, err := w.Write([]byte(`{
 	"version": "1",
 	"name": "test",
 	"rules": [
-      { 
+      {
 	    "id": "foo",
         "match": {
-          "routes": [
-            { "path": "/foo/bar/:baz", "path_params": [{ "name": "baz", "type":"glob", "value":"{*.ico,*.js}" }] }
-          ],
-          "methods": [ "GET" ],
-          "hosts": [ "moobar.local:9090" ],
-	    },
+          "http": {
+            "routes": [
+              { "path": "/foo/bar/:baz", "path_params": [{ "name": "baz", "type":"glob", "value":"{*.ico,*.js}" }] }
+            ],
+            "methods": [ "GET" ],
+            "hosts": [ "moobar.local:9090" ]
+          }
+        },
         "execute": [{ "authenticator": "test"}]
 	  }
 	]

--- a/internal/rules/provider/httpendpoint/ruleset_endpoint_test.go
+++ b/internal/rules/provider/httpendpoint/ruleset_endpoint_test.go
@@ -133,7 +133,7 @@ rules:
 - id: bar
   match:
     http:
-      routes: 
+      paths: 
         - path: /bar
 `))
 				require.NoError(t, err)
@@ -182,7 +182,7 @@ rules:
 - id: foo
   match:
     http:
-      routes:
+      paths:
         - path: /foo/:bar
           path_params:
             - name: bar
@@ -203,12 +203,12 @@ rules:
 				assert.Equal(t, "1", ruleSet.Version)
 				assert.Len(t, ruleSet.Rules, 1)
 				assert.Equal(t, "foo", ruleSet.Rules[0].ID)
-				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Routes, 1)
-				assert.Equal(t, "/foo/:bar", ruleSet.Rules[0].Matcher.HTTP.Routes[0].Path)
-				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams, 1)
-				assert.Equal(t, "bar", ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams[0].Name)
-				assert.Equal(t, "glob", ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams[0].Type)
-				assert.Equal(t, "*baz", ruleSet.Rules[0].Matcher.HTTP.Routes[0].PathParams[0].Value)
+				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Paths, 1)
+				assert.Equal(t, "/foo/:bar", ruleSet.Rules[0].Matcher.HTTP.Paths[0].Path)
+				require.Len(t, ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams, 1)
+				assert.Equal(t, "bar", ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams[0].Name)
+				assert.Equal(t, "glob", ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams[0].Type)
+				assert.Equal(t, "*baz", ruleSet.Rules[0].Matcher.HTTP.Paths[0].PathParams[0].Value)
 				assert.Equal(t, []string{"GET"}, ruleSet.Rules[0].Matcher.HTTP.Methods)
 				assert.NotEmpty(t, ruleSet.Hash)
 			},
@@ -231,7 +231,7 @@ rules:
           "id": "foo",
           "match": {
             "http": {
-              "routes": [{"path": "/foo"}],
+              "paths": [{"path": "/foo"}],
               "methods" : ["GET"]
             }
           },
@@ -268,7 +268,7 @@ rules:
 	    "id": "foo",
         "match": {
           "http": {
-            "routes": [
+            "paths": [
               { "path": "/foo/bar/:baz", "path_params": [{ "name": "baz", "type":"glob", "value":"{*.ico,*.js}" }] }
             ],
             "methods": [ "GET" ],

--- a/internal/rules/provider/kubernetes/api/v1beta1/client_test.go
+++ b/internal/rules/provider/kubernetes/api/v1beta1/client_test.go
@@ -56,18 +56,20 @@ const response = `{
             ],
             "id": "test:rule",
             "match": {
-              "routes": [
-                {
-                  "path": "/foobar/*foo",
-                  "path_params": [{ "name": "foo", "type": "glob", "value": "foos*" }]
-                },
-                {
-                  "path": "/foobar/baz"
-                }
-              ],
-              "scheme": "http",
-              "hosts": [ "127.0.0.1" ],
-              "methods": ["GET", "POST"]
+              "http": {
+                "routes": [
+                  {
+                    "path": "/foobar/*foo",
+                    "path_params": [{ "name": "foo", "type": "glob", "value": "foos*" }]
+                  },
+                  {
+                    "path": "/foobar/baz"
+                  }
+                ],
+                "scheme": "http",
+                "hosts": [ "127.0.0.1" ],
+                "methods": ["GET", "POST"]
+              }
             },
             "forward_to": {
               "host": "foo.bar",
@@ -145,17 +147,17 @@ func verifyRuleSetList(t *testing.T, rls *RuleSetList) {
 
 	rule := ruleSet.Spec.Rules[0]
 	assert.Equal(t, "test:rule", rule.ID)
-	assert.Len(t, rule.Matcher.Routes, 2)
-	assert.Equal(t, "/foobar/*foo", rule.Matcher.Routes[0].Path)
-	assert.Len(t, rule.Matcher.Routes[0].PathParams, 1)
-	assert.Equal(t, "foo", rule.Matcher.Routes[0].PathParams[0].Name)
-	assert.Equal(t, "glob", rule.Matcher.Routes[0].PathParams[0].Type)
-	assert.Equal(t, "foos*", rule.Matcher.Routes[0].PathParams[0].Value)
-	assert.Equal(t, "/foobar/baz", rule.Matcher.Routes[1].Path)
-	assert.Equal(t, "http", rule.Matcher.Scheme)
-	assert.Len(t, rule.Matcher.Hosts, 1)
-	assert.Equal(t, "127.0.0.1", rule.Matcher.Hosts[0])
-	assert.ElementsMatch(t, rule.Matcher.Methods, []string{"GET", "POST"})
+	assert.Len(t, rule.Matcher.HTTP.Routes, 2)
+	assert.Equal(t, "/foobar/*foo", rule.Matcher.HTTP.Routes[0].Path)
+	assert.Len(t, rule.Matcher.HTTP.Routes[0].PathParams, 1)
+	assert.Equal(t, "foo", rule.Matcher.HTTP.Routes[0].PathParams[0].Name)
+	assert.Equal(t, "glob", rule.Matcher.HTTP.Routes[0].PathParams[0].Type)
+	assert.Equal(t, "foos*", rule.Matcher.HTTP.Routes[0].PathParams[0].Value)
+	assert.Equal(t, "/foobar/baz", rule.Matcher.HTTP.Routes[1].Path)
+	assert.Equal(t, "http", rule.Matcher.HTTP.Scheme)
+	assert.Len(t, rule.Matcher.HTTP.Hosts, 1)
+	assert.Equal(t, "127.0.0.1", rule.Matcher.HTTP.Hosts[0])
+	assert.ElementsMatch(t, rule.Matcher.HTTP.Methods, []string{"GET", "POST"})
 	assert.Empty(t, rule.ErrorHandler)
 	assert.Equal(t, "https://foo.bar/baz/bar?foo=bar", rule.Backend.CreateURL(&url.URL{
 		Scheme:   "http",

--- a/internal/rules/provider/kubernetes/api/v1beta1/client_test.go
+++ b/internal/rules/provider/kubernetes/api/v1beta1/client_test.go
@@ -60,7 +60,7 @@ const response = `{
                 "paths": [
                   {
                     "path": "/foobar/*foo",
-                    "path_params": [{ "name": "foo", "type": "glob", "value": "foos*" }]
+                    "captures": [{ "name": "foo", "type": "glob", "value": "foos*" }]
                   },
                   {
                     "path": "/foobar/baz"
@@ -149,10 +149,10 @@ func verifyRuleSetList(t *testing.T, rls *RuleSetList) {
 	assert.Equal(t, "test:rule", rule.ID)
 	assert.Len(t, rule.Matcher.HTTP.Paths, 2)
 	assert.Equal(t, "/foobar/*foo", rule.Matcher.HTTP.Paths[0].Path)
-	assert.Len(t, rule.Matcher.HTTP.Paths[0].PathParams, 1)
-	assert.Equal(t, "foo", rule.Matcher.HTTP.Paths[0].PathParams[0].Name)
-	assert.Equal(t, "glob", rule.Matcher.HTTP.Paths[0].PathParams[0].Type)
-	assert.Equal(t, "foos*", rule.Matcher.HTTP.Paths[0].PathParams[0].Value)
+	assert.Len(t, rule.Matcher.HTTP.Paths[0].Captures, 1)
+	assert.Equal(t, "foo", rule.Matcher.HTTP.Paths[0].Captures[0].Name)
+	assert.Equal(t, "glob", rule.Matcher.HTTP.Paths[0].Captures[0].Type)
+	assert.Equal(t, "foos*", rule.Matcher.HTTP.Paths[0].Captures[0].Value)
 	assert.Equal(t, "/foobar/baz", rule.Matcher.HTTP.Paths[1].Path)
 	assert.Equal(t, "http", rule.Matcher.HTTP.Scheme)
 	assert.Len(t, rule.Matcher.HTTP.Hosts, 1)

--- a/internal/rules/provider/kubernetes/api/v1beta1/client_test.go
+++ b/internal/rules/provider/kubernetes/api/v1beta1/client_test.go
@@ -57,7 +57,7 @@ const response = `{
             "id": "test:rule",
             "match": {
               "http": {
-                "routes": [
+                "paths": [
                   {
                     "path": "/foobar/*foo",
                     "path_params": [{ "name": "foo", "type": "glob", "value": "foos*" }]
@@ -147,13 +147,13 @@ func verifyRuleSetList(t *testing.T, rls *RuleSetList) {
 
 	rule := ruleSet.Spec.Rules[0]
 	assert.Equal(t, "test:rule", rule.ID)
-	assert.Len(t, rule.Matcher.HTTP.Routes, 2)
-	assert.Equal(t, "/foobar/*foo", rule.Matcher.HTTP.Routes[0].Path)
-	assert.Len(t, rule.Matcher.HTTP.Routes[0].PathParams, 1)
-	assert.Equal(t, "foo", rule.Matcher.HTTP.Routes[0].PathParams[0].Name)
-	assert.Equal(t, "glob", rule.Matcher.HTTP.Routes[0].PathParams[0].Type)
-	assert.Equal(t, "foos*", rule.Matcher.HTTP.Routes[0].PathParams[0].Value)
-	assert.Equal(t, "/foobar/baz", rule.Matcher.HTTP.Routes[1].Path)
+	assert.Len(t, rule.Matcher.HTTP.Paths, 2)
+	assert.Equal(t, "/foobar/*foo", rule.Matcher.HTTP.Paths[0].Path)
+	assert.Len(t, rule.Matcher.HTTP.Paths[0].PathParams, 1)
+	assert.Equal(t, "foo", rule.Matcher.HTTP.Paths[0].PathParams[0].Name)
+	assert.Equal(t, "glob", rule.Matcher.HTTP.Paths[0].PathParams[0].Type)
+	assert.Equal(t, "foos*", rule.Matcher.HTTP.Paths[0].PathParams[0].Value)
+	assert.Equal(t, "/foobar/baz", rule.Matcher.HTTP.Paths[1].Path)
 	assert.Equal(t, "http", rule.Matcher.HTTP.Scheme)
 	assert.Len(t, rule.Matcher.HTTP.Hosts, 1)
 	assert.Equal(t, "127.0.0.1", rule.Matcher.HTTP.Hosts[0])

--- a/internal/rules/provider/kubernetes/provider_test.go
+++ b/internal/rules/provider/kubernetes/provider_test.go
@@ -236,7 +236,7 @@ func (h *RuleSetResourceHandler) writeListResponse(t *testing.T, w http.Response
 					ID: "test",
 					Matcher: cfgv1beta1.Matcher{
 						HTTP: &cfgv1beta1.HTTPMatcher{
-							Routes:  []cfgv1beta1.Route{{Path: "/"}},
+							Paths:   []cfgv1beta1.Path{{Path: "/"}},
 							Scheme:  "http",
 							Methods: []string{http.MethodGet},
 							Hosts:   []string{"foo.bar"},
@@ -406,8 +406,8 @@ func TestProviderLifecycle(t *testing.T) {
 				assert.Equal(t, "http", rule.Matcher.HTTP.Scheme)
 				assert.Len(t, rule.Matcher.HTTP.Hosts, 1)
 				assert.Equal(t, "foo.bar", rule.Matcher.HTTP.Hosts[0])
-				assert.Len(t, rule.Matcher.HTTP.Routes, 1)
-				assert.Equal(t, "/", rule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, rule.Matcher.HTTP.Paths, 1)
+				assert.Equal(t, "/", rule.Matcher.HTTP.Paths[0].Path)
 				assert.Len(t, rule.Matcher.HTTP.Methods, 1)
 				assert.Contains(t, rule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "baz", rule.Backend.Host)
@@ -576,8 +576,8 @@ func TestProviderLifecycle(t *testing.T) {
 				assert.Equal(t, "http", createdRule.Matcher.HTTP.Scheme)
 				assert.Len(t, createdRule.Matcher.HTTP.Hosts, 1)
 				assert.Equal(t, "foo.bar", createdRule.Matcher.HTTP.Hosts[0])
-				assert.Len(t, createdRule.Matcher.HTTP.Routes, 1)
-				assert.Equal(t, "/", createdRule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, createdRule.Matcher.HTTP.Paths, 1)
+				assert.Equal(t, "/", createdRule.Matcher.HTTP.Paths[0].Path)
 				assert.Len(t, createdRule.Matcher.HTTP.Methods, 1)
 				assert.Contains(t, createdRule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "baz", createdRule.Backend.Host)
@@ -652,8 +652,8 @@ func TestProviderLifecycle(t *testing.T) {
 				assert.Equal(t, "http", createdRule.Matcher.HTTP.Scheme)
 				assert.Len(t, createdRule.Matcher.HTTP.Hosts, 1)
 				assert.Equal(t, "foo.bar", createdRule.Matcher.HTTP.Hosts[0])
-				assert.Len(t, createdRule.Matcher.HTTP.Routes, 1)
-				assert.Equal(t, "/", createdRule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, createdRule.Matcher.HTTP.Paths, 1)
+				assert.Equal(t, "/", createdRule.Matcher.HTTP.Paths[0].Path)
 				assert.Len(t, createdRule.Matcher.HTTP.Methods, 1)
 				assert.Contains(t, createdRule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "baz", createdRule.Backend.Host)
@@ -725,8 +725,8 @@ func TestProviderLifecycle(t *testing.T) {
 				assert.Equal(t, "http", createdRule.Matcher.HTTP.Scheme)
 				assert.Len(t, createdRule.Matcher.HTTP.Hosts, 1)
 				assert.Equal(t, "foo.bar", createdRule.Matcher.HTTP.Hosts[0])
-				assert.Len(t, createdRule.Matcher.HTTP.Routes, 1)
-				assert.Equal(t, "/", createdRule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, createdRule.Matcher.HTTP.Paths, 1)
+				assert.Equal(t, "/", createdRule.Matcher.HTTP.Paths[0].Path)
 				assert.Len(t, createdRule.Matcher.HTTP.Methods, 1)
 				assert.Contains(t, createdRule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "baz", createdRule.Backend.Host)
@@ -810,7 +810,7 @@ func TestProviderLifecycle(t *testing.T) {
 								ID: "test",
 								Matcher: cfgv1beta1.Matcher{
 									HTTP: &cfgv1beta1.HTTPMatcher{
-										Routes:  []cfgv1beta1.Route{{Path: "/"}},
+										Paths:   []cfgv1beta1.Path{{Path: "/"}},
 										Scheme:  "http",
 										Methods: []string{http.MethodGet},
 										Hosts:   []string{"foo.bar"},
@@ -877,8 +877,8 @@ func TestProviderLifecycle(t *testing.T) {
 				assert.Equal(t, "http", createdRule.Matcher.HTTP.Scheme)
 				assert.Len(t, createdRule.Matcher.HTTP.Hosts, 1)
 				assert.Equal(t, "foo.bar", createdRule.Matcher.HTTP.Hosts[0])
-				assert.Len(t, createdRule.Matcher.HTTP.Routes, 1)
-				assert.Equal(t, "/", createdRule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, createdRule.Matcher.HTTP.Paths, 1)
+				assert.Equal(t, "/", createdRule.Matcher.HTTP.Paths[0].Path)
 				assert.Len(t, createdRule.Matcher.HTTP.Methods, 1)
 				assert.Contains(t, createdRule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "baz", createdRule.Backend.Host)
@@ -908,8 +908,8 @@ func TestProviderLifecycle(t *testing.T) {
 				assert.Equal(t, "http", createdRule.Matcher.HTTP.Scheme)
 				assert.Len(t, createdRule.Matcher.HTTP.Hosts, 1)
 				assert.Equal(t, "foo.bar", createdRule.Matcher.HTTP.Hosts[0])
-				assert.Len(t, createdRule.Matcher.HTTP.Routes, 1)
-				assert.Equal(t, "/", createdRule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, createdRule.Matcher.HTTP.Paths, 1)
+				assert.Equal(t, "/", createdRule.Matcher.HTTP.Paths[0].Path)
 				assert.Len(t, createdRule.Matcher.HTTP.Methods, 1)
 				assert.Contains(t, createdRule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "bar", updatedRule.Backend.Host)
@@ -991,8 +991,8 @@ func TestProviderLifecycle(t *testing.T) {
 				assert.Equal(t, "http", createdRule.Matcher.HTTP.Scheme)
 				assert.Len(t, createdRule.Matcher.HTTP.Hosts, 1)
 				assert.Equal(t, "foo.bar", createdRule.Matcher.HTTP.Hosts[0])
-				assert.Len(t, createdRule.Matcher.HTTP.Routes, 1)
-				assert.Equal(t, "/", createdRule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, createdRule.Matcher.HTTP.Paths, 1)
+				assert.Equal(t, "/", createdRule.Matcher.HTTP.Paths[0].Path)
 				assert.Len(t, createdRule.Matcher.HTTP.Methods, 1)
 				assert.Contains(t, createdRule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "baz", createdRule.Backend.Host)
@@ -1022,8 +1022,8 @@ func TestProviderLifecycle(t *testing.T) {
 				assert.Equal(t, "http", createdRule.Matcher.HTTP.Scheme)
 				assert.Len(t, createdRule.Matcher.HTTP.Hosts, 1)
 				assert.Equal(t, "foo.bar", createdRule.Matcher.HTTP.Hosts[0])
-				assert.Len(t, createdRule.Matcher.HTTP.Routes, 1)
-				assert.Equal(t, "/", createdRule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, createdRule.Matcher.HTTP.Paths, 1)
+				assert.Equal(t, "/", createdRule.Matcher.HTTP.Paths[0].Path)
 				assert.Len(t, createdRule.Matcher.HTTP.Methods, 1)
 				assert.Contains(t, createdRule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "baz", deleteRule.Backend.Host)
@@ -1068,7 +1068,7 @@ func TestProviderLifecycle(t *testing.T) {
 								ID: "test",
 								Matcher: cfgv1beta1.Matcher{
 									HTTP: &cfgv1beta1.HTTPMatcher{
-										Routes:  []cfgv1beta1.Route{{Path: "/"}},
+										Paths:   []cfgv1beta1.Path{{Path: "/"}},
 										Scheme:  "http",
 										Methods: []string{http.MethodGet},
 										Hosts:   []string{"foo.bar"},

--- a/internal/rules/provider/kubernetes/provider_test.go
+++ b/internal/rules/provider/kubernetes/provider_test.go
@@ -235,10 +235,12 @@ func (h *RuleSetResourceHandler) writeListResponse(t *testing.T, w http.Response
 				{
 					ID: "test",
 					Matcher: cfgv1beta1.Matcher{
-						Routes:  []cfgv1beta1.Route{{Path: "/"}},
-						Scheme:  "http",
-						Methods: []string{http.MethodGet},
-						Hosts:   []string{"foo.bar"},
+						HTTP: &cfgv1beta1.HTTPMatcher{
+							Routes:  []cfgv1beta1.Route{{Path: "/"}},
+							Scheme:  "http",
+							Methods: []string{http.MethodGet},
+							Hosts:   []string{"foo.bar"},
+						},
 					},
 					Backend: &cfgv1beta1.Backend{
 						Host: "baz",
@@ -401,13 +403,13 @@ func TestProviderLifecycle(t *testing.T) {
 
 				rule := ruleSet.Rules[0]
 				assert.Equal(t, "test", rule.ID)
-				assert.Equal(t, "http", rule.Matcher.Scheme)
-				assert.Len(t, rule.Matcher.Hosts, 1)
-				assert.Equal(t, "foo.bar", rule.Matcher.Hosts[0])
-				assert.Len(t, rule.Matcher.Routes, 1)
-				assert.Equal(t, "/", rule.Matcher.Routes[0].Path)
-				assert.Len(t, rule.Matcher.Methods, 1)
-				assert.Contains(t, rule.Matcher.Methods, http.MethodGet)
+				assert.Equal(t, "http", rule.Matcher.HTTP.Scheme)
+				assert.Len(t, rule.Matcher.HTTP.Hosts, 1)
+				assert.Equal(t, "foo.bar", rule.Matcher.HTTP.Hosts[0])
+				assert.Len(t, rule.Matcher.HTTP.Routes, 1)
+				assert.Equal(t, "/", rule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, rule.Matcher.HTTP.Methods, 1)
+				assert.Contains(t, rule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "baz", rule.Backend.Host)
 				assert.Empty(t, rule.ErrorHandler)
 				assert.Len(t, rule.Execute, 2)
@@ -571,13 +573,13 @@ func TestProviderLifecycle(t *testing.T) {
 
 				createdRule := ruleSet.Rules[0]
 				assert.Equal(t, "test", createdRule.ID)
-				assert.Equal(t, "http", createdRule.Matcher.Scheme)
-				assert.Len(t, createdRule.Matcher.Hosts, 1)
-				assert.Equal(t, "foo.bar", createdRule.Matcher.Hosts[0])
-				assert.Len(t, createdRule.Matcher.Routes, 1)
-				assert.Equal(t, "/", createdRule.Matcher.Routes[0].Path)
-				assert.Len(t, createdRule.Matcher.Methods, 1)
-				assert.Contains(t, createdRule.Matcher.Methods, http.MethodGet)
+				assert.Equal(t, "http", createdRule.Matcher.HTTP.Scheme)
+				assert.Len(t, createdRule.Matcher.HTTP.Hosts, 1)
+				assert.Equal(t, "foo.bar", createdRule.Matcher.HTTP.Hosts[0])
+				assert.Len(t, createdRule.Matcher.HTTP.Routes, 1)
+				assert.Equal(t, "/", createdRule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, createdRule.Matcher.HTTP.Methods, 1)
+				assert.Contains(t, createdRule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "baz", createdRule.Backend.Host)
 				assert.Empty(t, createdRule.ErrorHandler)
 				assert.Len(t, createdRule.Execute, 2)
@@ -647,13 +649,13 @@ func TestProviderLifecycle(t *testing.T) {
 
 				createdRule := ruleSet.Rules[0]
 				assert.Equal(t, "test", createdRule.ID)
-				assert.Equal(t, "http", createdRule.Matcher.Scheme)
-				assert.Len(t, createdRule.Matcher.Hosts, 1)
-				assert.Equal(t, "foo.bar", createdRule.Matcher.Hosts[0])
-				assert.Len(t, createdRule.Matcher.Routes, 1)
-				assert.Equal(t, "/", createdRule.Matcher.Routes[0].Path)
-				assert.Len(t, createdRule.Matcher.Methods, 1)
-				assert.Contains(t, createdRule.Matcher.Methods, http.MethodGet)
+				assert.Equal(t, "http", createdRule.Matcher.HTTP.Scheme)
+				assert.Len(t, createdRule.Matcher.HTTP.Hosts, 1)
+				assert.Equal(t, "foo.bar", createdRule.Matcher.HTTP.Hosts[0])
+				assert.Len(t, createdRule.Matcher.HTTP.Routes, 1)
+				assert.Equal(t, "/", createdRule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, createdRule.Matcher.HTTP.Methods, 1)
+				assert.Contains(t, createdRule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "baz", createdRule.Backend.Host)
 				assert.Empty(t, createdRule.ErrorHandler)
 				assert.Len(t, createdRule.Execute, 2)
@@ -720,13 +722,13 @@ func TestProviderLifecycle(t *testing.T) {
 
 				createdRule := ruleSet.Rules[0]
 				assert.Equal(t, "test", createdRule.ID)
-				assert.Equal(t, "http", createdRule.Matcher.Scheme)
-				assert.Len(t, createdRule.Matcher.Hosts, 1)
-				assert.Equal(t, "foo.bar", createdRule.Matcher.Hosts[0])
-				assert.Len(t, createdRule.Matcher.Routes, 1)
-				assert.Equal(t, "/", createdRule.Matcher.Routes[0].Path)
-				assert.Len(t, createdRule.Matcher.Methods, 1)
-				assert.Contains(t, createdRule.Matcher.Methods, http.MethodGet)
+				assert.Equal(t, "http", createdRule.Matcher.HTTP.Scheme)
+				assert.Len(t, createdRule.Matcher.HTTP.Hosts, 1)
+				assert.Equal(t, "foo.bar", createdRule.Matcher.HTTP.Hosts[0])
+				assert.Len(t, createdRule.Matcher.HTTP.Routes, 1)
+				assert.Equal(t, "/", createdRule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, createdRule.Matcher.HTTP.Methods, 1)
+				assert.Contains(t, createdRule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "baz", createdRule.Backend.Host)
 				assert.Empty(t, createdRule.ErrorHandler)
 				assert.Len(t, createdRule.Execute, 2)
@@ -807,10 +809,12 @@ func TestProviderLifecycle(t *testing.T) {
 							{
 								ID: "test",
 								Matcher: cfgv1beta1.Matcher{
-									Routes:  []cfgv1beta1.Route{{Path: "/"}},
-									Scheme:  "http",
-									Methods: []string{http.MethodGet},
-									Hosts:   []string{"foo.bar"},
+									HTTP: &cfgv1beta1.HTTPMatcher{
+										Routes:  []cfgv1beta1.Route{{Path: "/"}},
+										Scheme:  "http",
+										Methods: []string{http.MethodGet},
+										Hosts:   []string{"foo.bar"},
+									},
 								},
 								Backend: &cfgv1beta1.Backend{
 									Host: "bar",
@@ -870,13 +874,13 @@ func TestProviderLifecycle(t *testing.T) {
 
 				createdRule := ruleSet.Rules[0]
 				assert.Equal(t, "test", createdRule.ID)
-				assert.Equal(t, "http", createdRule.Matcher.Scheme)
-				assert.Len(t, createdRule.Matcher.Hosts, 1)
-				assert.Equal(t, "foo.bar", createdRule.Matcher.Hosts[0])
-				assert.Len(t, createdRule.Matcher.Routes, 1)
-				assert.Equal(t, "/", createdRule.Matcher.Routes[0].Path)
-				assert.Len(t, createdRule.Matcher.Methods, 1)
-				assert.Contains(t, createdRule.Matcher.Methods, http.MethodGet)
+				assert.Equal(t, "http", createdRule.Matcher.HTTP.Scheme)
+				assert.Len(t, createdRule.Matcher.HTTP.Hosts, 1)
+				assert.Equal(t, "foo.bar", createdRule.Matcher.HTTP.Hosts[0])
+				assert.Len(t, createdRule.Matcher.HTTP.Routes, 1)
+				assert.Equal(t, "/", createdRule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, createdRule.Matcher.HTTP.Methods, 1)
+				assert.Contains(t, createdRule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "baz", createdRule.Backend.Host)
 				assert.Empty(t, createdRule.ErrorHandler)
 				assert.Len(t, createdRule.Execute, 2)
@@ -901,13 +905,13 @@ func TestProviderLifecycle(t *testing.T) {
 
 				updatedRule := ruleSet.Rules[0]
 				assert.Equal(t, "test", updatedRule.ID)
-				assert.Equal(t, "http", createdRule.Matcher.Scheme)
-				assert.Len(t, createdRule.Matcher.Hosts, 1)
-				assert.Equal(t, "foo.bar", createdRule.Matcher.Hosts[0])
-				assert.Len(t, createdRule.Matcher.Routes, 1)
-				assert.Equal(t, "/", createdRule.Matcher.Routes[0].Path)
-				assert.Len(t, createdRule.Matcher.Methods, 1)
-				assert.Contains(t, createdRule.Matcher.Methods, http.MethodGet)
+				assert.Equal(t, "http", createdRule.Matcher.HTTP.Scheme)
+				assert.Len(t, createdRule.Matcher.HTTP.Hosts, 1)
+				assert.Equal(t, "foo.bar", createdRule.Matcher.HTTP.Hosts[0])
+				assert.Len(t, createdRule.Matcher.HTTP.Routes, 1)
+				assert.Equal(t, "/", createdRule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, createdRule.Matcher.HTTP.Methods, 1)
+				assert.Contains(t, createdRule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "bar", updatedRule.Backend.Host)
 				assert.Empty(t, updatedRule.ErrorHandler)
 				assert.Len(t, updatedRule.Execute, 2)
@@ -984,13 +988,13 @@ func TestProviderLifecycle(t *testing.T) {
 
 				createdRule := ruleSet.Rules[0]
 				assert.Equal(t, "test", createdRule.ID)
-				assert.Equal(t, "http", createdRule.Matcher.Scheme)
-				assert.Len(t, createdRule.Matcher.Hosts, 1)
-				assert.Equal(t, "foo.bar", createdRule.Matcher.Hosts[0])
-				assert.Len(t, createdRule.Matcher.Routes, 1)
-				assert.Equal(t, "/", createdRule.Matcher.Routes[0].Path)
-				assert.Len(t, createdRule.Matcher.Methods, 1)
-				assert.Contains(t, createdRule.Matcher.Methods, http.MethodGet)
+				assert.Equal(t, "http", createdRule.Matcher.HTTP.Scheme)
+				assert.Len(t, createdRule.Matcher.HTTP.Hosts, 1)
+				assert.Equal(t, "foo.bar", createdRule.Matcher.HTTP.Hosts[0])
+				assert.Len(t, createdRule.Matcher.HTTP.Routes, 1)
+				assert.Equal(t, "/", createdRule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, createdRule.Matcher.HTTP.Methods, 1)
+				assert.Contains(t, createdRule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "baz", createdRule.Backend.Host)
 				assert.Empty(t, createdRule.ErrorHandler)
 				assert.Len(t, createdRule.Execute, 2)
@@ -1015,13 +1019,13 @@ func TestProviderLifecycle(t *testing.T) {
 
 				deleteRule := ruleSet.Rules[0]
 				assert.Equal(t, "test", deleteRule.ID)
-				assert.Equal(t, "http", createdRule.Matcher.Scheme)
-				assert.Len(t, createdRule.Matcher.Hosts, 1)
-				assert.Equal(t, "foo.bar", createdRule.Matcher.Hosts[0])
-				assert.Len(t, createdRule.Matcher.Routes, 1)
-				assert.Equal(t, "/", createdRule.Matcher.Routes[0].Path)
-				assert.Len(t, createdRule.Matcher.Methods, 1)
-				assert.Contains(t, createdRule.Matcher.Methods, http.MethodGet)
+				assert.Equal(t, "http", createdRule.Matcher.HTTP.Scheme)
+				assert.Len(t, createdRule.Matcher.HTTP.Hosts, 1)
+				assert.Equal(t, "foo.bar", createdRule.Matcher.HTTP.Hosts[0])
+				assert.Len(t, createdRule.Matcher.HTTP.Routes, 1)
+				assert.Equal(t, "/", createdRule.Matcher.HTTP.Routes[0].Path)
+				assert.Len(t, createdRule.Matcher.HTTP.Methods, 1)
+				assert.Contains(t, createdRule.Matcher.HTTP.Methods, http.MethodGet)
 				assert.Equal(t, "baz", deleteRule.Backend.Host)
 				assert.Empty(t, deleteRule.ErrorHandler)
 				assert.Len(t, deleteRule.Execute, 2)
@@ -1063,10 +1067,12 @@ func TestProviderLifecycle(t *testing.T) {
 							{
 								ID: "test",
 								Matcher: cfgv1beta1.Matcher{
-									Routes:  []cfgv1beta1.Route{{Path: "/"}},
-									Scheme:  "http",
-									Methods: []string{http.MethodGet},
-									Hosts:   []string{"foo.bar"},
+									HTTP: &cfgv1beta1.HTTPMatcher{
+										Routes:  []cfgv1beta1.Route{{Path: "/"}},
+										Scheme:  "http",
+										Methods: []string{http.MethodGet},
+										Hosts:   []string{"foo.bar"},
+									},
 								},
 								Backend: &cfgv1beta1.Backend{
 									Host: "bar",

--- a/internal/rules/provider/kubernetes/webhooks/conversion/ruleset_converter.go
+++ b/internal/rules/provider/kubernetes/webhooks/conversion/ruleset_converter.go
@@ -29,8 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/dadrus/heimdall/internal/config"
+	"github.com/dadrus/heimdall/internal/encoding"
 	"github.com/dadrus/heimdall/internal/rules/converter"
 	"github.com/dadrus/heimdall/internal/rules/provider/kubernetes/api/v1beta1"
+	"github.com/dadrus/heimdall/internal/validation"
 )
 
 type rulesetConverter struct{}
@@ -136,6 +139,16 @@ func (rc *rulesetConverter) Handle(ctx context.Context, req *request) *response 
 func (rc *rulesetConverter) convertSpec(
 	rs map[string]any, fromVersion, toVersion schema.GroupVersion,
 ) (map[string]any, error) {
+	es := config.EnforcementSettings{}
+
+	validator, err := validation.NewValidator(
+		validation.WithTagValidator(es),
+		validation.WithErrorTranslator(es),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	// since conversion is delegated to a converter, which expects
 	// the ruleset in a format used for not kubernetes based providers
 	// there is a need to tune some fields, like adding the version, and
@@ -148,7 +161,7 @@ func (rc *rulesetConverter) convertSpec(
 	}
 
 	result, err := converter.
-		New(strings.TrimPrefix(toVersion.Version, "v")).
+		New(strings.TrimPrefix(toVersion.Version, "v"), encoding.ValidatorFunc(validator.ValidateStruct)).
 		Convert(data, "application/json")
 	if err != nil {
 		return nil, err

--- a/internal/rules/provider/kubernetes/webhooks/conversion/ruleset_converter_test.go
+++ b/internal/rules/provider/kubernetes/webhooks/conversion/ruleset_converter_test.go
@@ -315,8 +315,8 @@ func TestRulSetConverterHandle(t *testing.T) {
 								HTTP: &cfgv1beta1.HTTPMatcher{
 									Paths: []cfgv1beta1.Path{
 										{
-											Path:       "/pub/*baz",
-											PathParams: []cfgv1beta1.ParameterMatcher{{Name: "baz", Value: "*foo*", Type: "glob"}},
+											Path:     "/pub/*baz",
+											Captures: []cfgv1beta1.CaptureMatcher{{Name: "baz", Value: "*foo*", Type: "glob"}},
 										},
 									},
 									Scheme:  "https",
@@ -354,7 +354,7 @@ func TestRulSetConverterHandle(t *testing.T) {
             "paths": [
               {
                 "path": "/pub/*baz",
-                "path_params": [
+                "captures": [
                   { "name": "baz", "value": "*foo*", "type": "glob" }
                 ]
               }

--- a/internal/rules/provider/kubernetes/webhooks/conversion/ruleset_converter_test.go
+++ b/internal/rules/provider/kubernetes/webhooks/conversion/ruleset_converter_test.go
@@ -312,15 +312,17 @@ func TestRulSetConverterHandle(t *testing.T) {
 							ID:                     "public-access",
 							EncodedSlashesHandling: cfgv1beta1.EncodedSlashesOn,
 							Matcher: cfgv1beta1.Matcher{
-								Routes: []cfgv1beta1.Route{
-									{
-										Path:       "/pub/*baz",
-										PathParams: []cfgv1beta1.ParameterMatcher{{Name: "baz", Value: "*foo*", Type: "glob"}},
+								HTTP: &cfgv1beta1.HTTPMatcher{
+									Routes: []cfgv1beta1.Route{
+										{
+											Path:       "/pub/*baz",
+											PathParams: []cfgv1beta1.ParameterMatcher{{Name: "baz", Value: "*foo*", Type: "glob"}},
+										},
 									},
+									Scheme:  "https",
+									Methods: []string{"GET", "POST"},
+									Hosts:   []string{"foo.bar", "*.foo"},
 								},
-								Scheme:  "https",
-								Methods: []string{"GET", "POST"},
-								Hosts:   []string{"foo.bar", "*.foo"},
 							},
 							Backend: &cfgv1beta1.Backend{
 								Host: "foo-app.local:8080",
@@ -348,17 +350,19 @@ func TestRulSetConverterHandle(t *testing.T) {
         "id": "public-access",
         "allow_encoded_slashes": "on",
         "match": {
-          "routes": [
-            { 
-              "path": "/pub/*baz",
-              "path_params": [
-                { "name": "baz", "value": "*foo*", "type": "glob" }
-              ]
-            }
-          ],
-          "methods": ["GET", "POST"],
-          "hosts": [ "foo.bar", "*.foo" ],
-          "scheme": "https"
+          "http": {
+            "routes": [
+              {
+                "path": "/pub/*baz",
+                "path_params": [
+                  { "name": "baz", "value": "*foo*", "type": "glob" }
+                ]
+              }
+            ],
+            "methods": ["GET", "POST"],
+            "hosts": [ "foo.bar", "*.foo" ],
+            "scheme": "https"
+          }
         },
         "forward_to": {
           "host": "foo-app.local:8080"

--- a/internal/rules/provider/kubernetes/webhooks/conversion/ruleset_converter_test.go
+++ b/internal/rules/provider/kubernetes/webhooks/conversion/ruleset_converter_test.go
@@ -313,7 +313,7 @@ func TestRulSetConverterHandle(t *testing.T) {
 							EncodedSlashesHandling: cfgv1beta1.EncodedSlashesOn,
 							Matcher: cfgv1beta1.Matcher{
 								HTTP: &cfgv1beta1.HTTPMatcher{
-									Routes: []cfgv1beta1.Route{
+									Paths: []cfgv1beta1.Path{
 										{
 											Path:       "/pub/*baz",
 											PathParams: []cfgv1beta1.ParameterMatcher{{Name: "baz", Value: "*foo*", Type: "glob"}},
@@ -351,7 +351,7 @@ func TestRulSetConverterHandle(t *testing.T) {
         "allow_encoded_slashes": "on",
         "match": {
           "http": {
-            "routes": [
+            "paths": [
               {
                 "path": "/pub/*baz",
                 "path_params": [

--- a/internal/rules/route_matcher.go
+++ b/internal/rules/route_matcher.go
@@ -155,7 +155,7 @@ func createMethodMatcher(methods []string) (methodMatcher, error) {
 }
 
 func createPathParamsMatcher(
-	params []v1beta1.ParameterMatcher,
+	params []v1beta1.CaptureMatcher,
 	esh v1beta1.EncodedSlashesHandling,
 ) (RouteMatcher, error) {
 	matchers := make(andMatcher, len(params))

--- a/internal/rules/route_matcher_test.go
+++ b/internal/rules/route_matcher_test.go
@@ -87,7 +87,7 @@ func TestCreatePathParamsMatcher(t *testing.T) {
 	t.Parallel()
 
 	for uc, tc := range map[string]struct {
-		conf   []v1beta1.ParameterMatcher
+		conf   []v1beta1.CaptureMatcher
 		assert func(t *testing.T, matcher RouteMatcher, err error)
 	}{
 		"empty configuration": {
@@ -100,7 +100,7 @@ func TestCreatePathParamsMatcher(t *testing.T) {
 			},
 		},
 		"valid glob expression": {
-			conf: []v1beta1.ParameterMatcher{{Name: "foo", Value: "/**", Type: "glob"}},
+			conf: []v1beta1.CaptureMatcher{{Name: "foo", Value: "/**", Type: "glob"}},
 			assert: func(t *testing.T, matcher RouteMatcher, err error) {
 				t.Helper()
 
@@ -114,7 +114,7 @@ func TestCreatePathParamsMatcher(t *testing.T) {
 			},
 		},
 		"invalid glob expression": {
-			conf: []v1beta1.ParameterMatcher{{Name: "foo", Value: "!*][)(*", Type: "glob"}},
+			conf: []v1beta1.CaptureMatcher{{Name: "foo", Value: "!*][)(*", Type: "glob"}},
 			assert: func(t *testing.T, _ RouteMatcher, err error) {
 				t.Helper()
 
@@ -124,7 +124,7 @@ func TestCreatePathParamsMatcher(t *testing.T) {
 			},
 		},
 		"valid regex expression": {
-			conf: []v1beta1.ParameterMatcher{{Name: "foo", Value: ".*", Type: "regex"}},
+			conf: []v1beta1.CaptureMatcher{{Name: "foo", Value: ".*", Type: "regex"}},
 			assert: func(t *testing.T, matcher RouteMatcher, err error) {
 				t.Helper()
 
@@ -138,7 +138,7 @@ func TestCreatePathParamsMatcher(t *testing.T) {
 			},
 		},
 		"invalid regex expression": {
-			conf: []v1beta1.ParameterMatcher{{Name: "foo", Value: "?>?<*??", Type: "regex"}},
+			conf: []v1beta1.CaptureMatcher{{Name: "foo", Value: "?>?<*??", Type: "regex"}},
 			assert: func(t *testing.T, _ RouteMatcher, err error) {
 				t.Helper()
 
@@ -148,7 +148,7 @@ func TestCreatePathParamsMatcher(t *testing.T) {
 			},
 		},
 		"exact expression": {
-			conf: []v1beta1.ParameterMatcher{{Name: "foo", Value: "?>?<*??", Type: "exact"}},
+			conf: []v1beta1.CaptureMatcher{{Name: "foo", Value: "?>?<*??", Type: "exact"}},
 			assert: func(t *testing.T, matcher RouteMatcher, err error) {
 				t.Helper()
 
@@ -162,7 +162,7 @@ func TestCreatePathParamsMatcher(t *testing.T) {
 			},
 		},
 		"unsupported type": {
-			conf: []v1beta1.ParameterMatcher{{Name: "foo", Value: "foo", Type: "bar"}},
+			conf: []v1beta1.CaptureMatcher{{Name: "foo", Value: "foo", Type: "bar"}},
 			assert: func(t *testing.T, _ RouteMatcher, err error) {
 				t.Helper()
 
@@ -238,7 +238,7 @@ func TestPathParamsMatcherMatches(t *testing.T) {
 	t.Parallel()
 
 	for uc, tc := range map[string]struct {
-		conf          []v1beta1.ParameterMatcher
+		conf          []v1beta1.CaptureMatcher
 		slashHandling v1beta1.EncodedSlashesHandling
 		toMatch       string
 		keys          []string
@@ -246,14 +246,14 @@ func TestPathParamsMatcherMatches(t *testing.T) {
 		matches       bool
 	}{
 		"parameter not present in keys": {
-			conf: []v1beta1.ParameterMatcher{
+			conf: []v1beta1.CaptureMatcher{
 				{Name: "foo", Type: "exact", Value: "bar"},
 			},
 			keys:   []string{"bar"},
 			values: []string{"baz"},
 		},
 		"encoded slashes are not allowed": {
-			conf: []v1beta1.ParameterMatcher{
+			conf: []v1beta1.CaptureMatcher{
 				{Name: "foo", Type: "exact", Value: "bar%2Fbaz"},
 			},
 			slashHandling: v1beta1.EncodedSlashesOff,
@@ -262,7 +262,7 @@ func TestPathParamsMatcherMatches(t *testing.T) {
 			toMatch:       "http://example.com/bar%2Fbaz",
 		},
 		"lowercase encoded slashes are not allowed": {
-			conf: []v1beta1.ParameterMatcher{
+			conf: []v1beta1.CaptureMatcher{
 				{Name: "foo", Type: "exact", Value: "bar%2fbaz"},
 			},
 			slashHandling: v1beta1.EncodedSlashesOff,
@@ -271,7 +271,7 @@ func TestPathParamsMatcherMatches(t *testing.T) {
 			toMatch:       "http://example.com/bar%2fbaz",
 		},
 		"matches with path having allowed but not decoded encoded slashes": {
-			conf: []v1beta1.ParameterMatcher{
+			conf: []v1beta1.CaptureMatcher{
 				{Name: "foo", Type: "exact", Value: "bar%2Fbaz[id]"},
 			},
 			slashHandling: v1beta1.EncodedSlashesOnNoDecode,
@@ -281,7 +281,7 @@ func TestPathParamsMatcherMatches(t *testing.T) {
 			matches:       true,
 		},
 		"matches with path having allowed but not decoded lowercase encoded slashes": {
-			conf: []v1beta1.ParameterMatcher{
+			conf: []v1beta1.CaptureMatcher{
 				{Name: "foo", Type: "exact", Value: "bar%2fbaz[id]"},
 			},
 			slashHandling: v1beta1.EncodedSlashesOnNoDecode,
@@ -291,7 +291,7 @@ func TestPathParamsMatcherMatches(t *testing.T) {
 			matches:       true,
 		},
 		"matches with path having allowed decoded slashes": {
-			conf: []v1beta1.ParameterMatcher{
+			conf: []v1beta1.CaptureMatcher{
 				{Name: "foo", Type: "exact", Value: "bar/baz[id]"},
 			},
 			slashHandling: v1beta1.EncodedSlashesOn,
@@ -301,7 +301,7 @@ func TestPathParamsMatcherMatches(t *testing.T) {
 			matches:       true,
 		},
 		"matches with path having allowed decoded lowercase encoded slashes": {
-			conf: []v1beta1.ParameterMatcher{
+			conf: []v1beta1.CaptureMatcher{
 				{Name: "foo", Type: "exact", Value: "bar/baz[id]"},
 			},
 			slashHandling: v1beta1.EncodedSlashesOn,
@@ -311,7 +311,7 @@ func TestPathParamsMatcherMatches(t *testing.T) {
 			matches:       true,
 		},
 		"does not match the request path if appropriate matcher is not defined as first element": {
-			conf: []v1beta1.ParameterMatcher{
+			conf: []v1beta1.CaptureMatcher{
 				{Name: "foo", Type: "exact", Value: "bar/foo"},
 				{Name: "foo", Type: "exact", Value: "bar/bar"},
 			},
@@ -322,7 +322,7 @@ func TestPathParamsMatcherMatches(t *testing.T) {
 			matches:       false,
 		},
 		"doesn't match": {
-			conf: []v1beta1.ParameterMatcher{
+			conf: []v1beta1.CaptureMatcher{
 				{Name: "foo", Type: "exact", Value: "bar"},
 			},
 			slashHandling: v1beta1.EncodedSlashesOn,

--- a/internal/rules/rule_factory_impl.go
+++ b/internal/rules/rule_factory_impl.go
@@ -186,7 +186,7 @@ func (f *ruleFactory) addRoutes(
 		hosts = []string{"*"}
 	}
 
-	for _, rc := range http.Routes {
+	for _, rc := range http.Paths {
 		ppm, err := createPathParamsMatcher(rc.PathParams, slashesHandling)
 		if err != nil {
 			return errorchain.NewWithMessagef(

--- a/internal/rules/rule_factory_impl.go
+++ b/internal/rules/rule_factory_impl.go
@@ -172,19 +172,21 @@ func (f *ruleFactory) addRoutes(
 	matcher v1beta1.Matcher,
 	slashesHandling v1beta1.EncodedSlashesHandling,
 ) error {
-	mm, err := createMethodMatcher(matcher.Methods)
+	http := matcher.HTTP
+
+	mm, err := createMethodMatcher(http.Methods)
 	if err != nil {
 		return err
 	}
 
-	sm := schemeMatcher(matcher.Scheme)
+	sm := schemeMatcher(http.Scheme)
 
-	hosts := matcher.Hosts
+	hosts := http.Hosts
 	if len(hosts) == 0 {
 		hosts = []string{"*"}
 	}
 
-	for _, rc := range matcher.Routes {
+	for _, rc := range http.Routes {
 		ppm, err := createPathParamsMatcher(rc.PathParams, slashesHandling)
 		if err != nil {
 			return errorchain.NewWithMessagef(

--- a/internal/rules/rule_factory_impl.go
+++ b/internal/rules/rule_factory_impl.go
@@ -187,7 +187,7 @@ func (f *ruleFactory) addRoutes(
 	}
 
 	for _, rc := range http.Paths {
-		ppm, err := createPathParamsMatcher(rc.PathParams, slashesHandling)
+		ppm, err := createPathParamsMatcher(rc.Captures, slashesHandling)
 		if err != nil {
 			return errorchain.NewWithMessagef(
 				pipeline.ErrConfiguration,

--- a/internal/rules/rule_factory_impl_test.go
+++ b/internal/rules/rule_factory_impl_test.go
@@ -696,7 +696,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 			opMode: config.ProxyMode,
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 			},
 			assert: func(t *testing.T, err error, _ *ruleImpl) {
 				t.Helper()
@@ -710,7 +710,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 			config: v1beta1.Rule{
 				ID: "foobar",
 				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{
-					Routes:  []v1beta1.Route{{Path: "/foo/bar"}},
+					Paths:   []v1beta1.Path{{Path: "/foo/bar"}},
 					Methods: []string{""},
 				}},
 				Execute: []v1beta1.Step{
@@ -749,7 +749,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 			config: v1beta1.Rule{
 				ID: "foobar",
 				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{
-					Routes: []v1beta1.Route{
+					Paths: []v1beta1.Path{
 						{
 							Path:       "/foo/:bar",
 							PathParams: []v1beta1.ParameterMatcher{{Name: "bar", Type: "foo", Value: "baz"}},
@@ -791,7 +791,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"error while creating the execute pipeline": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{{AuthenticatorRef: "foo"}},
 			},
 			configureMocks: func(t *testing.T, repo *mocks1.RepositoryMock, resolver *secretsmocks.ResolverMock) {
@@ -814,7 +814,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"error while creating on_error pipeline": {
 			config: v1beta1.Rule{
 				ID:           "foobar",
-				Matcher:      v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher:      v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				ErrorHandler: []v1beta1.Step{{ErrorHandlerRef: "foo", ID: "bar"}},
 			},
 			configureMocks: func(t *testing.T, repo *mocks1.RepositoryMock, resolver *secretsmocks.ResolverMock) {
@@ -837,7 +837,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"without default rule and without any execute configuration": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 			},
 			assert: func(t *testing.T, err error, _ *ruleImpl) {
 				t.Helper()
@@ -850,7 +850,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"without default rule and with malformed execute configuration": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: ""},
 				},
@@ -866,7 +866,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"without default rule and with malformed on_error configuration": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 				},
@@ -897,7 +897,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"without default rule and minimum required configuration in decision mode": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 				},
@@ -947,8 +947,8 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 			config: v1beta1.Rule{
 				ID: "foobar",
 				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{
-					Routes: []v1beta1.Route{{Path: "/foo/bar"}},
-					Hosts:  []string{"FoO.ExAmPlE.cOm", "*.ExAmPlE.cOm"},
+					Paths: []v1beta1.Path{{Path: "/foo/bar"}},
+					Hosts: []string{"FoO.ExAmPlE.cOm", "*.ExAmPlE.cOm"},
 				}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
@@ -989,7 +989,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 			config: v1beta1.Rule{
 				ID:      "foobar",
 				Backend: &v1beta1.Backend{Host: "foo.bar"},
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{{AuthenticatorRef: "foo"}},
 			},
 			configureMocks: func(t *testing.T, repo *mocks1.RepositoryMock, resolver *secretsmocks.ResolverMock) {
@@ -1037,7 +1037,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"with default rule and regular rule with id and a single route only": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 			},
 			defaultRule: &ruleImpl{
 				p: rulePipelineImpl{
@@ -1087,7 +1087,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 			config: v1beta1.Rule{
 				ID: "foobar",
 				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{
-					Routes: []v1beta1.Route{
+					Paths: []v1beta1.Path{
 						{
 							Path:       "/foo/:resource",
 							PathParams: []v1beta1.ParameterMatcher{{Name: "resource", Type: "regex", Value: "(bar|baz)"}},
@@ -1201,7 +1201,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 			config: v1beta1.Rule{
 				ID: "foobar",
 				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{
-					Routes: []v1beta1.Route{
+					Paths: []v1beta1.Path{
 						{
 							Path:       "/foo/:resource",
 							PathParams: []v1beta1.ParameterMatcher{{Name: "resource", Type: "regex", Value: "(bar|baz)"}},
@@ -1329,7 +1329,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"malformed conditional configuration in the execute pipeline": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 					{FinalizerRef: "bar", Condition: new("")},
@@ -1366,7 +1366,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"duplicate step ids in the execute pipeline": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo", ID: "1"},
 					{FinalizerRef: "bar", ID: "1"},
@@ -1403,7 +1403,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"conditional execution of some mechanisms in the execute pipeline": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 					{AuthorizerRef: "bar", Condition: new("false")},
@@ -1493,7 +1493,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"conditional execution of error handler": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 					{AuthorizerRef: "bar"},
@@ -1581,7 +1581,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"duplicate ids in the error pipeline": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 				},
@@ -1628,7 +1628,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"error while getting the referenced mechanism": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 				},
@@ -1649,7 +1649,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"fallback of authenticators for the default principal": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 					{AuthenticatorRef: "bar"},
@@ -1698,7 +1698,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"single authenticator for the default principal and fallback authenticators for custom named principal": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 					{AuthenticatorRef: "bar", Principal: new("custom")},
@@ -1769,7 +1769,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"no authenticator for the default principal configured": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "bar", Principal: new("a")},
 					{AuthenticatorRef: "baz", Principal: new("b")},
@@ -1823,7 +1823,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 			tracer: trace2.NewTracerProvider().Tracer("test"),
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Paths: []v1beta1.Path{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 				},

--- a/internal/rules/rule_factory_impl_test.go
+++ b/internal/rules/rule_factory_impl_test.go
@@ -696,7 +696,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 			opMode: config.ProxyMode,
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 			},
 			assert: func(t *testing.T, err error, _ *ruleImpl) {
 				t.Helper()
@@ -709,10 +709,10 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"error while creating method matcher": {
 			config: v1beta1.Rule{
 				ID: "foobar",
-				Matcher: v1beta1.Matcher{
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{
 					Routes:  []v1beta1.Route{{Path: "/foo/bar"}},
 					Methods: []string{""},
-				},
+				}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 				},
@@ -748,14 +748,14 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"error while creating route path params matcher": {
 			config: v1beta1.Rule{
 				ID: "foobar",
-				Matcher: v1beta1.Matcher{
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{
 					Routes: []v1beta1.Route{
 						{
 							Path:       "/foo/:bar",
 							PathParams: []v1beta1.ParameterMatcher{{Name: "bar", Type: "foo", Value: "baz"}},
 						},
 					},
-				},
+				}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo", ID: "1"},
 				},
@@ -791,7 +791,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"error while creating the execute pipeline": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{{AuthenticatorRef: "foo"}},
 			},
 			configureMocks: func(t *testing.T, repo *mocks1.RepositoryMock, resolver *secretsmocks.ResolverMock) {
@@ -814,7 +814,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"error while creating on_error pipeline": {
 			config: v1beta1.Rule{
 				ID:           "foobar",
-				Matcher:      v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher:      v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				ErrorHandler: []v1beta1.Step{{ErrorHandlerRef: "foo", ID: "bar"}},
 			},
 			configureMocks: func(t *testing.T, repo *mocks1.RepositoryMock, resolver *secretsmocks.ResolverMock) {
@@ -837,7 +837,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"without default rule and without any execute configuration": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 			},
 			assert: func(t *testing.T, err error, _ *ruleImpl) {
 				t.Helper()
@@ -850,7 +850,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"without default rule and with malformed execute configuration": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: ""},
 				},
@@ -866,7 +866,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"without default rule and with malformed on_error configuration": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 				},
@@ -897,7 +897,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"without default rule and minimum required configuration in decision mode": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 				},
@@ -946,10 +946,10 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"normalizes trie host matchers to lowercase": {
 			config: v1beta1.Rule{
 				ID: "foobar",
-				Matcher: v1beta1.Matcher{
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{
 					Routes: []v1beta1.Route{{Path: "/foo/bar"}},
 					Hosts:  []string{"FoO.ExAmPlE.cOm", "*.ExAmPlE.cOm"},
-				},
+				}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 				},
@@ -989,7 +989,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 			config: v1beta1.Rule{
 				ID:      "foobar",
 				Backend: &v1beta1.Backend{Host: "foo.bar"},
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{{AuthenticatorRef: "foo"}},
 			},
 			configureMocks: func(t *testing.T, repo *mocks1.RepositoryMock, resolver *secretsmocks.ResolverMock) {
@@ -1037,7 +1037,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"with default rule and regular rule with id and a single route only": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 			},
 			defaultRule: &ruleImpl{
 				p: rulePipelineImpl{
@@ -1086,7 +1086,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"with default rule and with all attributes defined by the regular rule itself in decision mode": {
 			config: v1beta1.Rule{
 				ID: "foobar",
-				Matcher: v1beta1.Matcher{
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{
 					Routes: []v1beta1.Route{
 						{
 							Path:       "/foo/:resource",
@@ -1100,7 +1100,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 					Scheme:  "https",
 					Methods: []string{"BAR", "BAZ"},
 					Hosts:   []string{"*.example.com"},
-				},
+				}},
 				EncodedSlashesHandling: v1beta1.EncodedSlashesOnNoDecode,
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo", ID: "1"},
@@ -1200,7 +1200,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 			opMode: config.ProxyMode,
 			config: v1beta1.Rule{
 				ID: "foobar",
-				Matcher: v1beta1.Matcher{
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{
 					Routes: []v1beta1.Route{
 						{
 							Path:       "/foo/:resource",
@@ -1214,7 +1214,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 					Scheme:  "https",
 					Methods: []string{"BAR", "BAZ"},
 					Hosts:   []string{"*.example.com"},
-				},
+				}},
 				EncodedSlashesHandling: v1beta1.EncodedSlashesOn,
 				Backend: &v1beta1.Backend{
 					Host: "bar.foo",
@@ -1329,7 +1329,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"malformed conditional configuration in the execute pipeline": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 					{FinalizerRef: "bar", Condition: new("")},
@@ -1366,7 +1366,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"duplicate step ids in the execute pipeline": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo", ID: "1"},
 					{FinalizerRef: "bar", ID: "1"},
@@ -1403,7 +1403,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"conditional execution of some mechanisms in the execute pipeline": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 					{AuthorizerRef: "bar", Condition: new("false")},
@@ -1493,7 +1493,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"conditional execution of error handler": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 					{AuthorizerRef: "bar"},
@@ -1581,7 +1581,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"duplicate ids in the error pipeline": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 				},
@@ -1628,7 +1628,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"error while getting the referenced mechanism": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 				},
@@ -1649,7 +1649,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"fallback of authenticators for the default principal": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 					{AuthenticatorRef: "bar"},
@@ -1698,7 +1698,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"single authenticator for the default principal and fallback authenticators for custom named principal": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 					{AuthenticatorRef: "bar", Principal: new("custom")},
@@ -1769,7 +1769,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 		"no authenticator for the default principal configured": {
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "bar", Principal: new("a")},
 					{AuthenticatorRef: "baz", Principal: new("b")},
@@ -1823,7 +1823,7 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 			tracer: trace2.NewTracerProvider().Tracer("test"),
 			config: v1beta1.Rule{
 				ID:      "foobar",
-				Matcher: v1beta1.Matcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}},
+				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{Routes: []v1beta1.Route{{Path: "/foo/bar"}}}},
 				Execute: []v1beta1.Step{
 					{AuthenticatorRef: "foo"},
 				},

--- a/internal/rules/rule_factory_impl_test.go
+++ b/internal/rules/rule_factory_impl_test.go
@@ -751,8 +751,8 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{
 					Paths: []v1beta1.Path{
 						{
-							Path:       "/foo/:bar",
-							PathParams: []v1beta1.ParameterMatcher{{Name: "bar", Type: "foo", Value: "baz"}},
+							Path:     "/foo/:bar",
+							Captures: []v1beta1.CaptureMatcher{{Name: "bar", Type: "foo", Value: "baz"}},
 						},
 					},
 				}},
@@ -1089,12 +1089,12 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{
 					Paths: []v1beta1.Path{
 						{
-							Path:       "/foo/:resource",
-							PathParams: []v1beta1.ParameterMatcher{{Name: "resource", Type: "regex", Value: "(bar|baz)"}},
+							Path:     "/foo/:resource",
+							Captures: []v1beta1.CaptureMatcher{{Name: "resource", Type: "regex", Value: "(bar|baz)"}},
 						},
 						{
-							Path:       "/bar/:resource",
-							PathParams: []v1beta1.ParameterMatcher{{Name: "resource", Type: "glob", Value: "{a,b}"}},
+							Path:     "/bar/:resource",
+							Captures: []v1beta1.CaptureMatcher{{Name: "resource", Type: "glob", Value: "{a,b}"}},
 						},
 					},
 					Scheme:  "https",
@@ -1203,12 +1203,12 @@ func TestRuleFactoryCreateRule(t *testing.T) {
 				Matcher: v1beta1.Matcher{HTTP: &v1beta1.HTTPMatcher{
 					Paths: []v1beta1.Path{
 						{
-							Path:       "/foo/:resource",
-							PathParams: []v1beta1.ParameterMatcher{{Name: "resource", Type: "regex", Value: "(bar|baz)"}},
+							Path:     "/foo/:resource",
+							Captures: []v1beta1.CaptureMatcher{{Name: "resource", Type: "regex", Value: "(bar|baz)"}},
 						},
 						{
-							Path:       "/bar/:resource",
-							PathParams: []v1beta1.ParameterMatcher{{Name: "resource", Type: "glob", Value: "{a,b}"}},
+							Path:     "/bar/:resource",
+							Captures: []v1beta1.CaptureMatcher{{Name: "resource", Type: "glob", Value: "{a,b}"}},
 						},
 					},
 					Scheme:  "https",


### PR DESCRIPTION
## Related issue(s)

relates to #2756

## Checklist

- [x] I agree to follow this project's Code of Conduct.
- [x] I have read, and I am following this repository's Contributing Guidelines.
- [x] I have read the Security Policy.
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

This PR prepares the rule matching model for protocol-specific matching criteria, required for #2756.

It introduces an `http` property below `match` and moves the existing matching criteria into it, so `match` becomes the protocol-independent entry point for future protocol-specific matchers. As part of this, `routes` is renamed to `paths`, and the nested `path_params` to `captures`. Matching behavior itself is unchanged.

Before (`1alpha4`):

```yaml
match:
  routes:
    - path: /foo/:bar/**
      path_params:
        - name: bar
          type: glob
          value: "*baz"
  # further matching criteria
```

After (`1beta1`):

```yaml
match:
  http:  # new definition for http matching criteria
    paths: # was routes before
      - path: /foo/:bar/**
        captures: # was path_params before
          - name: bar
            type: glob
            value: "*baz"
    # further matching criteria (unchanged)
```

Existing `1alpha4` RuleSets are converted automatically via the `heimdall convert ruleset` command or the CRD conversion webhook. However, RuleSets using the deprecated `glob` or `regex` host matcher types must be adjusted before conversion, as their semantics cannot be represented reliably by the simplified `1beta1` host syntax.