### PR TITLE
fix: Prevented potential crashes under concurrent access during OAuth2 metadata endpoint initialization

### DIFF
--- a/internal/rules/mechanisms/authenticators/jwt_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator.go
@@ -164,7 +164,11 @@ func newJwtAuthenticator(
 	)
 
 	resolver := x.IfThenElseExec(conf.MetadataEndpoint != nil,
-		func() oauth2.ServerMetadataResolver { return conf.MetadataEndpoint },
+		func() oauth2.ServerMetadataResolver {
+			conf.MetadataEndpoint.Init()
+
+			return conf.MetadataEndpoint
+		},
 		func() oauth2.ServerMetadataResolver {
 			ep := conf.JWKSEndpoint
 

--- a/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
@@ -2456,6 +2456,10 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 			ctx := heimdallmocks.NewRequestContextMock(t)
 			ctx.EXPECT().Context().Return(cache.WithContext(t.Context(), cch))
 
+			if metadataEndpoint, ok := tc.authenticator.r.(*oauth2.MetadataEndpoint); ok {
+				metadataEndpoint.Init()
+			}
+
 			configureMocks(t, ctx, cch, ads, tc.authenticator)
 			instructServer(t)
 

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
@@ -145,7 +145,11 @@ func newOAuth2IntrospectionAuthenticator(
 	)
 
 	resolver := x.IfThenElseExec(conf.MetadataEndpoint != nil,
-		func() oauth2.ServerMetadataResolver { return conf.MetadataEndpoint },
+		func() oauth2.ServerMetadataResolver {
+			conf.MetadataEndpoint.Init()
+
+			return conf.MetadataEndpoint
+		},
 		func() oauth2.ServerMetadataResolver {
 			ep := conf.IntrospectionEndpoint
 

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
@@ -1983,6 +1983,10 @@ func TestOauth2IntrospectionAuthenticatorExecute(t *testing.T) {
 			ctx := heimdallmocks.NewRequestContextMock(t)
 			ctx.EXPECT().Context().Return(cache.WithContext(t.Context(), cch))
 
+			if metadataEndpoint, ok := tc.authenticator.r.(*oauth2.MetadataEndpoint); ok {
+				metadataEndpoint.Init()
+			}
+
 			configureMocks(t, ctx, cch, ads, tc.authenticator)
 			instructServer(t)
 

--- a/internal/rules/mechanisms/oauth2/metadata_endpoint.go
+++ b/internal/rules/mechanisms/oauth2/metadata_endpoint.go
@@ -46,8 +46,6 @@ type MetadataEndpoint struct {
 }
 
 func (e *MetadataEndpoint) Get(ctx context.Context, args map[string]any) (ServerMetadata, error) {
-	e.init()
-
 	req, err := e.CreateRequest(ctx, nil, endpoint.RenderFunc(func(value string) (string, error) {
 		tpl, err := template.New(value)
 		if err != nil {
@@ -95,7 +93,7 @@ func (e *MetadataEndpoint) Get(ctx context.Context, args map[string]any) (Server
 	return sm, nil
 }
 
-func (e *MetadataEndpoint) init() {
+func (e *MetadataEndpoint) Init() {
 	if e.Headers == nil {
 		e.Headers = make(map[string]string)
 	}

--- a/internal/rules/mechanisms/oauth2/metadata_endpoint_test.go
+++ b/internal/rules/mechanisms/oauth2/metadata_endpoint_test.go
@@ -411,6 +411,7 @@ func TestMetadataEndpointGet(t *testing.T) {
 					func() map[string]ResolvedEndpointSettings { return tc.resolvedEPSettings },
 				),
 			}
+			ep.Init()
 
 			// WHEN
 			sm, err := ep.Get(t.Context(), tc.args)

--- a/internal/rules/mechanisms/oauth2/metadata_endpoint_test.go
+++ b/internal/rules/mechanisms/oauth2/metadata_endpoint_test.go
@@ -33,6 +33,58 @@ import (
 	"github.com/dadrus/heimdall/internal/x"
 )
 
+func TestMetadataEndpointInit(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		ep       *MetadataEndpoint
+		expected endpoint.Endpoint
+	}{
+		"default settings are applied": {
+			ep: &MetadataEndpoint{},
+			expected: endpoint.Endpoint{
+				Method:  http.MethodGet,
+				Headers: map[string]string{"Accept": "application/json"},
+				HTTPCache: &endpoint.HTTPCache{
+					Enabled:    true,
+					DefaultTTL: 30 * time.Minute,
+				},
+			},
+		},
+		"configured settings are preserved": {
+			ep: &MetadataEndpoint{
+				Endpoint: endpoint.Endpoint{
+					Method:  http.MethodPatch,
+					Headers: map[string]string{"Accept": "application/custom+json"},
+					HTTPCache: &endpoint.HTTPCache{
+						Enabled:    false,
+						DefaultTTL: time.Minute,
+					},
+				},
+			},
+			expected: endpoint.Endpoint{
+				Method:  http.MethodPatch,
+				Headers: map[string]string{"Accept": "application/custom+json"},
+				HTTPCache: &endpoint.HTTPCache{
+					Enabled:    false,
+					DefaultTTL: time.Minute,
+				},
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			// GIVEN
+			ep := tc.ep
+
+			// WHEN
+			ep.Init()
+
+			// THEN
+			assert.Equal(t, tc.expected, ep.Endpoint)
+		})
+	}
+}
+
 func TestMetadataEndpointGet(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Related issue(s)

closes #3415 

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

This PR fixes the referenced bug