### PR TITLE
fix: Canonicalized request header names in Envoy gRPC ext_authz

### DIFF
--- a/internal/handler/envoyextauth/grpcv3/request_context.go
+++ b/internal/handler/envoyextauth/grpcv3/request_context.go
@@ -163,7 +163,10 @@ func canonicalizeHeaders(headers map[string]string) map[string]string {
 
 func (r *RequestContext) Request() *heimdall.Request { return r.hmdlReq }
 func (r *RequestContext) Headers() map[string]string { return r.reqHeaders }
-func (r *RequestContext) Header(name string) string  { return r.reqHeaders[name] }
+
+func (r *RequestContext) Header(name string) string {
+	return r.reqHeaders[http.CanonicalHeaderKey(name)]
+}
 
 func (r *RequestContext) Cookie(name string) string {
 	values, ok := r.reqHeaders["Cookie"]

--- a/internal/handler/envoyextauth/grpcv3/request_context_test.go
+++ b/internal/handler/envoyextauth/grpcv3/request_context_test.go
@@ -630,3 +630,62 @@ func TestRequestContextReset(t *testing.T) {
 	require.Empty(t, ctx.hmdlReq.ClientIPAddresses)
 	require.Equal(t, 10, cap(ctx.hmdlReq.ClientIPAddresses))
 }
+
+func TestRequestContextHeader(t *testing.T) {
+	t.Parallel()
+
+	cf := newContextFactory()
+
+	for uc, tc := range map[string]struct {
+		name     string
+		expected string
+	}{
+		"canonical header name": {
+			name:     "X-Foo",
+			expected: "bar",
+		},
+		"lowercase header name": {
+			name:     "x-foo",
+			expected: "bar",
+		},
+		"uppercase header name": {
+			name:     "X-FOO",
+			expected: "bar",
+		},
+		"mixed case header name": {
+			name:     "x-FoO",
+			expected: "bar",
+		},
+		"unknown header": {
+			name:     "X-Bar",
+			expected: "",
+		},
+		"lowercase host header": {
+			name:     "host",
+			expected: "foo.bar",
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := cf.Create(
+				t.Context(),
+				&envoy_auth.CheckRequest{
+					Attributes: &envoy_auth.AttributeContext{
+						Request: &envoy_auth.AttributeContext_Request{
+							Http: &envoy_auth.AttributeContext_HttpRequest{
+								Host: "FoO.Bar",
+								Headers: map[string]string{
+									"x-foo": "bar",
+								},
+							},
+						},
+					},
+				},
+			)
+			defer cf.Destroy(ctx)
+
+			assert.Equal(t, tc.expected, ctx.Request().Header(tc.name))
+		})
+	}
+}


### PR DESCRIPTION
## Related issue(s)

closes #3422

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

This PR fixes the referenced issue
