### PR TITLE
fix: Removed implicit request body token extraction from JWT and OAuth2 authenticators

### DIFF
--- a/docs/content/docs/mechanisms/authenticators.adoc
+++ b/docs/content/docs/mechanisms/authenticators.adoc
@@ -244,7 +244,7 @@ config:
 
 == OAuth2 Introspection
 
-This authenticator handles requests that have Bearer token in the HTTP Authorization header (`Authorization: Bearer <token>`), in the `access_token` query parameter or the `access_token` body parameter (latter, if the body is of `application/x-www-form-urlencoded` MIME type). It then uses https://datatracker.ietf.org/doc/html/rfc7662[OAuth 2.0 Token Introspection] endpoint to check if the token is valid. The validation includes at least the verification of the status and the time validity. That is if the token is still active and whether it has been issued in an acceptable time frame. Latter can be adjusted by specifying a leeway. All other validation options can and should be configured.
+This authenticator handles requests that have Bearer token in the HTTP Authorization header (`Authorization: Bearer <token>`) or in the `access_token` query parameter. It then uses https://datatracker.ietf.org/doc/html/rfc7662[OAuth 2.0 Token Introspection] endpoint to check if the token is valid. The validation includes at least the verification of the status and the time validity. That is if the token is still active and whether it has been issued in an acceptable time frame. Latter can be adjusted by specifying a leeway. All other validation options can and should be configured.
 
 To enable the usage of this authenticator, you have to set the `type` property to `oauth2_introspection`.
 
@@ -288,7 +288,7 @@ Controls whether HTTP caching according to https://www.rfc-editor.org/rfc/rfc723
 
 * *`token_source`*: _link:{{< relref "/docs/configuration/types.adoc#_authentication_data_source" >}}[Authentication Data Source]_ (optional, not overridable)
 +
-Where to get the access token from. Defaults to retrieve it from the `Authorization` header, the `access_token` query parameter or the `access_token` body parameter (latter, if the body is of `application/x-www-form-urlencoded` MIME type).
+Where to get the access token from. Defaults to retrieve it from the `Authorization` header, or the `access_token` query parameter.
 
 * *`assertions`*: _link:{{< relref "/docs/configuration/types.adoc#_assertions" >}}[Assertions]_ (optional, overridable)
 +
@@ -390,7 +390,7 @@ Controls whether HTTP caching according to https://www.rfc-editor.org/rfc/rfc723
 
 * *`jwt_source`*: _link:{{< relref "/docs/configuration/types.adoc#_authentication_data_source" >}}[Authentication Data Source]_ (optional, not overridable)
 +
-Where to get the access token from. Defaults to retrieve it from the `Authorization` header, the `access_token` query parameter or the `access_token` body parameter (latter, if the body is of `application/x-www-form-urlencoded` MIME type).
+Where to get the access token from. Defaults to retrieve it from the `Authorization` header or the `access_token` query parameter.
 
 * *`assertions`*: _link:{{< relref "/docs/configuration/types.adoc#_assertions" >}}[Assertions]_ (dependant, overridable)
 +

--- a/docs/content/docs/mechanisms/authenticators.adoc
+++ b/docs/content/docs/mechanisms/authenticators.adoc
@@ -243,8 +243,7 @@ config:
 ====
 
 == OAuth2 Introspection
-
-This authenticator handles requests that have Bearer token in the HTTP Authorization header (`Authorization: Bearer <token>`) or in the `access_token` query parameter. It then uses https://datatracker.ietf.org/doc/html/rfc7662[OAuth 2.0 Token Introspection] endpoint to check if the token is valid. The validation includes at least the verification of the status and the time validity. That is if the token is still active and whether it has been issued in an acceptable time frame. Latter can be adjusted by specifying a leeway. All other validation options can and should be configured.
+This authenticator handles requests that have an access token in the HTTP Authorization header (`Authorization: Bearer <token>`), a query parameter or, if explicitly configured, a body parameter. It then uses https://datatracker.ietf.org/doc/html/rfc7662[OAuth 2.0 Token Introspection] endpoint to check if the token is valid. The validation includes at least the verification of the status and the time validity. That is if the token is still active and whether it has been issued in an acceptable time frame. Latter can be adjusted by specifying a leeway. All other validation options can and should be configured.
 
 To enable the usage of this authenticator, you have to set the `type` property to `oauth2_introspection`.
 
@@ -288,7 +287,7 @@ Controls whether HTTP caching according to https://www.rfc-editor.org/rfc/rfc723
 
 * *`token_source`*: _link:{{< relref "/docs/configuration/types.adoc#_authentication_data_source" >}}[Authentication Data Source]_ (optional, not overridable)
 +
-Where to get the access token from. Defaults to retrieve it from the `Authorization` header, or the `access_token` query parameter.
+Where to get the access token from. Defaults to retrieve it from the `Authorization` header or the `access_token` query parameter.
 
 * *`assertions`*: _link:{{< relref "/docs/configuration/types.adoc#_assertions" >}}[Assertions]_ (optional, overridable)
 +
@@ -346,7 +345,7 @@ If the `iss` claim of the issued JWT is set to `\https://my-auth-server.com/real
 
 == JWT
 
-As the link:{{< relref "#_oauth2_introspection">}}[OAuth2 Introspection] authenticator, this authenticator handles requests that have a Bearer token in the `Authorization` header, in a different header, a query parameter or a body parameter as well. Unlike the OAuth2 Introspection authenticator it expects the token to be a JSON Web Token (JWT) and verifies it according https://www.rfc-editor.org/rfc/rfc7519#section-7.2[RFC 7519, Section 7.2]. It does however not support encrypted payloads and nested JWTs. In addition to this, validation includes the verification of the time validity. Latter can be adjusted by specifying a leeway. All other validation options can and should be configured.
+As the link:{{< relref "#_oauth2_introspection">}}[OAuth2 Introspection] authenticator, this authenticator handles requests that have a Bearer token in the `Authorization` header, in a different header, a query parameter or, if explicitly configured, a body parameter. Unlike the OAuth2 Introspection authenticator it expects the token to be a JSON Web Token (JWT) and verifies it according https://www.rfc-editor.org/rfc/rfc7519#section-7.2[RFC 7519, Section 7.2]. It does however not support encrypted payloads and nested JWTs. In addition to this, validation includes the verification of the time validity. Latter can be adjusted by specifying a leeway. All other validation options can and should be configured.
 
 To enable the usage of this authenticator, you have to set the `type` property to `jwt`.
 

--- a/internal/rules/mechanisms/authenticators/jwt_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator.go
@@ -157,7 +157,6 @@ func newJwtAuthenticator(
 			return extractors.CompositeExtractStrategy{
 				extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"},
 				extractors.QueryParameterExtractStrategy{Name: "access_token"},
-				extractors.BodyParameterExtractStrategy{Name: "access_token"},
 			}
 		},
 		func() extractors.CompositeExtractStrategy { return conf.AuthDataSource },

--- a/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
@@ -178,10 +178,9 @@ assertions:
 
 				// token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
-				assert.Len(t, auth.ads, 3)
+				assert.Len(t, auth.ads, 2)
 				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"})
 				assert.Contains(t, auth.ads, extractors.QueryParameterExtractStrategy{Name: "access_token"})
-				assert.Contains(t, auth.ads, extractors.BodyParameterExtractStrategy{Name: "access_token"})
 
 				// assertions settings
 				require.NoError(t, auth.a.ScopesMatcher.Match([]string{}))
@@ -241,10 +240,9 @@ cache_ttl: 5s`),
 
 				// token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
-				assert.Len(t, auth.ads, 3)
+				assert.Len(t, auth.ads, 2)
 				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"})
 				assert.Contains(t, auth.ads, extractors.QueryParameterExtractStrategy{Name: "access_token"})
-				assert.Contains(t, auth.ads, extractors.BodyParameterExtractStrategy{Name: "access_token"})
 
 				// assertions settings
 				require.NoError(t, auth.a.ScopesMatcher.Match([]string{}))
@@ -419,10 +417,9 @@ cache_ttl: 5s`),
 
 				// token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
-				assert.Len(t, auth.ads, 3)
+				assert.Len(t, auth.ads, 2)
 				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"})
 				assert.Contains(t, auth.ads, extractors.QueryParameterExtractStrategy{Name: "access_token"})
-				assert.Contains(t, auth.ads, extractors.BodyParameterExtractStrategy{Name: "access_token"})
 
 				// assertions settings
 				require.NoError(t, auth.a.ScopesMatcher.Match([]string{}))
@@ -505,10 +502,9 @@ cache_ttl: 5s`),
 
 				// token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
-				assert.Len(t, auth.ads, 3)
+				assert.Len(t, auth.ads, 2)
 				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"})
 				assert.Contains(t, auth.ads, extractors.QueryParameterExtractStrategy{Name: "access_token"})
-				assert.Contains(t, auth.ads, extractors.BodyParameterExtractStrategy{Name: "access_token"})
 
 				// assertions settings
 				require.NoError(t, auth.a.ScopesMatcher.Match([]string{}))

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
@@ -138,7 +138,6 @@ func newOAuth2IntrospectionAuthenticator(
 			return extractors.CompositeExtractStrategy{
 				extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"},
 				extractors.QueryParameterExtractStrategy{Name: "access_token"},
-				extractors.BodyParameterExtractStrategy{Name: "access_token"},
 			}
 		},
 		func() extractors.CompositeExtractStrategy { return conf.AuthDataSource },

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
@@ -143,10 +143,9 @@ introspection_endpoint:
 
 				// assert token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
-				assert.Len(t, auth.ads, 3)
+				assert.Len(t, auth.ads, 2)
 				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"})
 				assert.Contains(t, auth.ads, extractors.QueryParameterExtractStrategy{Name: "access_token"})
-				assert.Contains(t, auth.ads, extractors.BodyParameterExtractStrategy{Name: "access_token"})
 
 				// assert subject factory
 				assert.NotNil(t, auth.sf)
@@ -290,10 +289,9 @@ metadata_endpoint:
 
 				// assert token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
-				assert.Len(t, auth.ads, 3)
+				assert.Len(t, auth.ads, 2)
 				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"})
 				assert.Contains(t, auth.ads, extractors.QueryParameterExtractStrategy{Name: "access_token"})
-				assert.Contains(t, auth.ads, extractors.BodyParameterExtractStrategy{Name: "access_token"})
 
 				// assert subject factory
 				assert.NotNil(t, auth.sf)
@@ -367,10 +365,9 @@ metadata_endpoint:
 
 				// assert token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
-				assert.Len(t, auth.ads, 3)
+				assert.Len(t, auth.ads, 2)
 				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"})
 				assert.Contains(t, auth.ads, extractors.QueryParameterExtractStrategy{Name: "access_token"})
-				assert.Contains(t, auth.ads, extractors.BodyParameterExtractStrategy{Name: "access_token"})
 
 				// assert subject factory
 				assert.NotNil(t, auth.sf)


### PR DESCRIPTION
## Related issue(s)

closes #3424

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

This PR removes request body token extraction from the default token sources of the `jwt` and `oauth2_introspection` authenticators. Tokens can still be read from the request body when explicitly configured to do so.

**Note:** This may be a breaking change for setups relying on clients sending the token in the request body without explicitly configuring the respective authenticator to read it from there.

