### PR TITLE
fix: Data race in CEL `networks()` resolved

### DIFF
--- a/internal/rules/mechanisms/cellib/networks.go
+++ b/internal/rules/mechanisms/cellib/networks.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,6 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-
 package cellib
 
 import (
@@ -21,6 +20,8 @@ import (
 	"net"
 	"reflect"
 	"slices"
+	"sync"
+	"sync/atomic"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/operators"
@@ -47,18 +48,17 @@ func newIPNetworks(cidrs []string) (IPNetworks, error) {
 		}
 	}
 
-	return IPNetworks{Ranger: ranger, cidrs: cidrs}, nil
+	return IPNetworks{ranger: ranger}, nil
 }
 
 type IPNetworks struct {
-	cidranger.Ranger
-
-	cidrs []string
+	ranger cidranger.Ranger
 }
 
 func (n IPNetworks) ConvertToNative(typeDesc reflect.Type) (any, error) {
-	if reflect.TypeOf(n.Ranger).AssignableTo(typeDesc) {
-		return n.Ranger, nil
+	rangerType := reflect.TypeOf(n.ranger)
+	if rangerType != nil && rangerType.AssignableTo(typeDesc) {
+		return n.ranger, nil
 	}
 
 	if reflect.TypeOf(n).AssignableTo(typeDesc) {
@@ -80,14 +80,14 @@ func (n IPNetworks) ConvertToType(typeVal ref.Type) ref.Val {
 }
 
 func (n IPNetworks) Equal(other ref.Val) ref.Val {
-	otherDur, ok := other.(IPNetworks)
+	otherNetworks, ok := other.(IPNetworks)
 
-	return types.Bool(ok && n.Ranger == otherDur.Ranger)
+	return types.Bool(ok && n.ranger == otherNetworks.ranger)
 }
 
 func (n IPNetworks) Type() ref.Type { return ipNetworksType }
 
-func (n IPNetworks) Value() any { return n.Ranger }
+func (n IPNetworks) Value() any { return n.ranger }
 
 func (n IPNetworks) Contains(value ref.Val) ref.Val {
 	if singleIP, ok := value.Value().(string); ok {
@@ -107,7 +107,7 @@ func (n IPNetworks) Contains(value ref.Val) ref.Val {
 }
 
 func (n IPNetworks) containsIP(ip string) bool {
-	res, _ := n.Ranger.Contains(net.ParseIP(ip))
+	res, _ := n.ranger.Contains(net.ParseIP(ip))
 
 	return res
 }
@@ -115,6 +115,114 @@ func (n IPNetworks) containsIP(ip string) bool {
 func (n IPNetworks) containsAll(ips []string) bool {
 	for _, ip := range ips {
 		if !n.containsIP(ip) {
+			return false
+		}
+	}
+
+	return true
+}
+
+type networkCache struct {
+	mu       sync.Mutex
+	snapshot atomic.Pointer[networkCacheSnapshot]
+}
+
+type networkCacheSnapshot struct {
+	entries []networkCacheEntry
+}
+
+type networkCacheEntry struct {
+	cidrs    []string
+	networks IPNetworks
+}
+
+func (c *networkCache) getOrCreate(cidrs []string) (IPNetworks, error) {
+	if networks, found := c.get(cidrs); found {
+		return networks, nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Another evaluation might have populated the cache while waiting for the lock.
+	if networks, found := c.get(cidrs); found {
+		return networks, nil
+	}
+
+	// Cache entries are immutable once published and therefore must own their CIDR slice.
+	cidrs = slices.Clone(cidrs)
+
+	networks, err := newIPNetworks(cidrs)
+	if err != nil {
+		return IPNetworks{}, err
+	}
+
+	current := c.snapshot.Load()
+	var entries []networkCacheEntry
+	if current != nil {
+		entries = current.entries
+	}
+
+	next := make([]networkCacheEntry, len(entries)+1)
+	copy(next, entries)
+	next[len(entries)] = networkCacheEntry{
+		cidrs:    cidrs,
+		networks: networks,
+	}
+
+	c.snapshot.Store(&networkCacheSnapshot{entries: next})
+
+	return networks, nil
+}
+
+func (c *networkCache) get(cidrs []string) (IPNetworks, bool) {
+	snapshot := c.snapshot.Load()
+	if snapshot == nil {
+		return IPNetworks{}, false
+	}
+
+	for _, entry := range snapshot.entries {
+		if sameCIDRs(entry.cidrs, cidrs) {
+			return entry.networks, true
+		}
+	}
+
+	return IPNetworks{}, false
+}
+
+// sameCIDRs compares two CIDR lists as multisets. This preserves the previous
+// cache semantics, where CIDRs were sorted before comparison, without sorting
+// or allocating on the cache-hit path.
+func sameCIDRs(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+
+	if slices.Equal(left, right) {
+		return true
+	}
+
+	for idx, cidr := range left {
+		if slices.Contains(left[:idx], cidr) {
+			continue
+		}
+
+		leftCount := 0
+		rightCount := 0
+
+		for _, candidate := range left {
+			if candidate == cidr {
+				leftCount++
+			}
+		}
+
+		for _, candidate := range right {
+			if candidate == cidr {
+				rightCount++
+			}
+		}
+
+		if leftCount != rightCount {
 			return false
 		}
 	}
@@ -137,7 +245,7 @@ func (networksLib) ProgramOptions() []cel.ProgramOption {
 }
 
 func (networksLib) CompileOptions() []cel.EnvOption {
-	var networkInstances []IPNetworks
+	cache := networkCache{}
 
 	return []cel.EnvOption{
 		// IPNetworks specific functions
@@ -147,18 +255,10 @@ func (networksLib) CompileOptions() []cel.EnvOption {
 				cel.UnaryBinding(func(netVal ref.Val) ref.Val {
 					addresses := []string{netVal.Value().(string)} // nolint: forcetypeassert
 
-					for _, net := range networkInstances {
-						if slices.Equal(net.cidrs, addresses) {
-							return net
-						}
-					}
-
-					networks, err := newIPNetworks(addresses)
+					networks, err := cache.getOrCreate(addresses)
 					if err != nil {
 						return types.WrapErr(err)
 					}
-
-					networkInstances = append(networkInstances, networks)
 
 					return networks
 				}),
@@ -171,21 +271,10 @@ func (networksLib) CompileOptions() []cel.EnvOption {
 						return types.WrapErr(err)
 					}
 
-					addresses := cidrs.([]string) // nolint: forcetypeassert
-					slices.Sort(addresses)
-
-					for _, net := range networkInstances {
-						if slices.Equal(net.cidrs, addresses) {
-							return net
-						}
-					}
-
-					networks, err := newIPNetworks(addresses)
+					networks, err := cache.getOrCreate(cidrs.([]string)) // nolint: forcetypeassert
 					if err != nil {
 						return types.WrapErr(err)
 					}
-
-					networkInstances = append(networkInstances, networks)
 
 					return networks
 				}),

--- a/internal/rules/mechanisms/cellib/networks_test.go
+++ b/internal/rules/mechanisms/cellib/networks_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,10 +13,11 @@
 // limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-
 package cellib
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/google/cel-go/cel"
@@ -56,6 +57,264 @@ func TestNetworks(t *testing.T) {
 			out, _, err := prg.Eval(map[string]any{})
 			require.NoError(t, err)
 			require.Equal(t, true, out.Value()) //nolint:testifylint
+		})
+	}
+}
+
+func TestNetworksConcurrentEvaluation(t *testing.T) {
+	env, err := cel.NewEnv(Library())
+	require.NoError(t, err)
+
+	expr, err := CompileExpression(env, `"10.1.2.3" in networks("10.0.0.0/8")`, "denied")
+	require.NoError(t, err)
+
+	const (
+		goroutines  = 32
+		evaluations = 200
+	)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, goroutines)
+
+	for range goroutines {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			<-start
+
+			for range evaluations {
+				if err := expr.Eval(map[string]any{}); err != nil {
+					errs <- err
+
+					return
+				}
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+func TestNetworksConcurrentEvaluationWithDynamicCIDRs(t *testing.T) {
+	env, err := cel.NewEnv(
+		Library(),
+		cel.Variable("cidrs", cel.ListType(cel.StringType)),
+	)
+	require.NoError(t, err)
+
+	expr, err := CompileExpression(env, `"10.1.2.3" in networks(cidrs)`, "denied")
+	require.NoError(t, err)
+
+	const (
+		goroutines  = 32
+		evaluations = 200
+	)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, goroutines)
+
+	for idx := range goroutines {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			dynamicCIDR := fmt.Sprintf("192.168.%d.0/24", idx)
+			cidrs := []string{dynamicCIDR, "10.0.0.0/8"}
+			activation := map[string]any{"cidrs": cidrs}
+
+			<-start
+
+			for range evaluations {
+				if err := expr.Eval(activation); err != nil {
+					errs <- err
+
+					return
+				}
+			}
+
+			if cidrs[0] != dynamicCIDR || cidrs[1] != "10.0.0.0/8" {
+				errs <- fmt.Errorf("networks modified input CIDRs: %v", cidrs)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+func TestNetworkCacheConcurrentReuse(t *testing.T) {
+	t.Parallel()
+
+	var cache networkCache
+
+	const goroutines = 32
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make(chan IPNetworks, goroutines)
+	errs := make(chan error, goroutines)
+
+	for range goroutines {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			<-start
+
+			networks, err := cache.getOrCreate([]string{"10.0.0.0/8"})
+			if err != nil {
+				errs <- err
+
+				return
+			}
+
+			results <- networks
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	var ranger any
+
+	for networks := range results {
+		if ranger == nil {
+			ranger = networks.ranger
+
+			continue
+		}
+
+		require.Same(t, ranger, networks.ranger)
+	}
+
+	snapshot := cache.snapshot.Load()
+	require.NotNil(t, snapshot)
+	require.Len(t, snapshot.entries, 1)
+	require.Equal(t, []string{"10.0.0.0/8"}, snapshot.entries[0].cidrs)
+	require.Same(t, ranger, snapshot.entries[0].networks.ranger)
+}
+
+func TestNetworkCacheOwnsCIDRs(t *testing.T) {
+	t.Parallel()
+
+	var cache networkCache
+	cidrs := []string{"192.168.0.0/16", "10.0.0.0/8"}
+	original := []string{"192.168.0.0/16", "10.0.0.0/8"}
+
+	networks, err := cache.getOrCreate(cidrs)
+	require.NoError(t, err)
+	require.Equal(t, original, cidrs)
+
+	cidrs[0] = "172.16.0.0/12"
+
+	cached, found := cache.get(original)
+	require.True(t, found)
+	require.Same(t, networks.ranger, cached.ranger)
+
+	_, found = cache.get(cidrs)
+	require.False(t, found)
+
+	snapshot := cache.snapshot.Load()
+	require.NotNil(t, snapshot)
+	require.Len(t, snapshot.entries, 1)
+	require.Equal(t, original, snapshot.entries[0].cidrs)
+}
+
+func TestNetworkCacheReusesCIDRsRegardlessOfOrder(t *testing.T) {
+	t.Parallel()
+
+	var cache networkCache
+
+	first, err := cache.getOrCreate([]string{
+		"192.168.0.0/16",
+		"10.0.0.0/8",
+	})
+	require.NoError(t, err)
+
+	second, err := cache.getOrCreate([]string{
+		"10.0.0.0/8",
+		"192.168.0.0/16",
+	})
+	require.NoError(t, err)
+
+	require.Same(t, first.ranger, second.ranger)
+
+	snapshot := cache.snapshot.Load()
+	require.NotNil(t, snapshot)
+	require.Len(t, snapshot.entries, 1)
+}
+
+func TestSameCIDRs(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		left     []string
+		right    []string
+		expected bool
+	}{
+		"same order": {
+			left:     []string{"10.0.0.0/8", "192.168.0.0/16"},
+			right:    []string{"10.0.0.0/8", "192.168.0.0/16"},
+			expected: true,
+		},
+		"different order": {
+			left:     []string{"10.0.0.0/8", "192.168.0.0/16"},
+			right:    []string{"192.168.0.0/16", "10.0.0.0/8"},
+			expected: true,
+		},
+		"same duplicates": {
+			left:     []string{"10.0.0.0/8", "10.0.0.0/8", "192.168.0.0/16"},
+			right:    []string{"192.168.0.0/16", "10.0.0.0/8", "10.0.0.0/8"},
+			expected: true,
+		},
+		"different duplicates": {
+			left:     []string{"10.0.0.0/8", "10.0.0.0/8", "192.168.0.0/16"},
+			right:    []string{"10.0.0.0/8", "192.168.0.0/16", "192.168.0.0/16"},
+			expected: false,
+		},
+		"different values": {
+			left:     []string{"10.0.0.0/8", "192.168.0.0/16"},
+			right:    []string{"10.0.0.0/8", "172.16.0.0/12"},
+			expected: false,
+		},
+		"different lengths": {
+			left:     []string{"10.0.0.0/8"},
+			right:    []string{"10.0.0.0/8", "192.168.0.0/16"},
+			expected: false,
+		},
+		"empty": {
+			left:     nil,
+			right:    []string{},
+			expected: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.expected, sameCIDRs(tc.left, tc.right))
 		})
 	}
 }


### PR DESCRIPTION
## Related issue(s)

closes #3431

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

This PR fixes the issue referenced above by replacing the unsynchronized `networks()` cache with an immutable snapshot-based cache. Cache reads remain lock-free, while synchronization is limited to cache misses and population, preserving reuse of the corresponding instances on the request hot path.

