### PR TITLE
fix: Enforced trusted proxies for Envoy gRPC ext_authz

### DIFF
--- a/internal/handler/envoyextauth/grpcv3/service.go
+++ b/internal/handler/envoyextauth/grpcv3/service.go
@@ -33,6 +33,7 @@ import (
 	"github.com/dadrus/heimdall/internal/handler/middleware/grpc/errorhandler"
 	loggermiddleware "github.com/dadrus/heimdall/internal/handler/middleware/grpc/logger"
 	"github.com/dadrus/heimdall/internal/handler/middleware/grpc/otelmetrics"
+	"github.com/dadrus/heimdall/internal/handler/middleware/grpc/trustedproxy"
 	"github.com/dadrus/heimdall/internal/rules/rule"
 )
 
@@ -63,6 +64,7 @@ func newService(
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.ChainUnaryInterceptor(
 			recovery.UnaryServerInterceptor(recoveryHandler),
+			trustedproxy.New(logger, cfg.TrustedProxies...),
 			metrics.UnaryServerInterceptor(),
 			errorhandler.New(
 				errorhandler.WithVerboseErrors(cfg.Respond.Verbose),

--- a/internal/handler/middleware/grpc/trustedproxy/interceptor.go
+++ b/internal/handler/middleware/grpc/trustedproxy/interceptor.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package trustedproxy
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+
+	"github.com/dadrus/heimdall/internal/handler/middleware/trustedproxy"
+)
+
+func New(logger zerolog.Logger, proxies ...string) grpc.UnaryServerInterceptor {
+	matcher := trustedproxy.NewMatcher(logger, proxies...)
+
+	return func(
+		ctx context.Context,
+		req any,
+		_ *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (any, error) {
+		if !matcher.Contains(peerIP(ctx)) {
+			ctx = sanitizeMetadata(ctx)
+			sanitizeRequest(req)
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+func peerIP(ctx context.Context) net.IP {
+	peerInfo, ok := peer.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+
+	if addr, ok := peerInfo.Addr.(*net.TCPAddr); ok {
+		return addr.IP
+	}
+
+	host, _, err := net.SplitHostPort(peerInfo.Addr.String())
+	if err != nil {
+		return net.ParseIP(peerInfo.Addr.String())
+	}
+
+	return net.ParseIP(host)
+}
+
+func sanitizeMetadata(ctx context.Context) context.Context {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return ctx
+	}
+
+	trustedproxy.RemoveForwardingHeaders(md.Delete)
+
+	return metadata.NewIncomingContext(ctx, md)
+}
+
+func sanitizeRequest(req any) {
+	checkReq, ok := req.(*envoy_auth.CheckRequest)
+	if !ok {
+		return
+	}
+
+	headers := checkReq.
+		GetAttributes().
+		GetRequest().
+		GetHttp().
+		GetHeaders()
+
+	trustedproxy.RemoveForwardingHeaders(func(name string) {
+		delete(headers, strings.ToLower(name))
+	})
+}

--- a/internal/handler/middleware/grpc/trustedproxy/interceptor.go
+++ b/internal/handler/middleware/grpc/trustedproxy/interceptor.go
@@ -90,6 +90,10 @@ func sanitizeRequest(req any) {
 		GetHeaders()
 
 	trustedproxy.RemoveForwardingHeaders(func(name string) {
-		delete(headers, strings.ToLower(name))
+		for key := range headers {
+			if strings.EqualFold(key, name) {
+				delete(headers, key)
+			}
+		}
 	})
 }

--- a/internal/handler/middleware/grpc/trustedproxy/interceptor_test.go
+++ b/internal/handler/middleware/grpc/trustedproxy/interceptor_test.go
@@ -163,14 +163,9 @@ func TestInterceptorExecution(t *testing.T) {
 				require.Empty(t, receivedMD.Get("Forwarded"))
 				require.Equal(t, []string{"foo"}, receivedMD.Get("X-Foo-Bar"))
 
-				require.Empty(t, receivedHeaders["x-forwarded-proto"])
-				require.Empty(t, receivedHeaders["x-forwarded-host"])
-				require.Empty(t, receivedHeaders["x-forwarded-path"])
-				require.Empty(t, receivedHeaders["x-forwarded-uri"])
-				require.Empty(t, receivedHeaders["x-forwarded-for"])
-				require.Empty(t, receivedHeaders["x-forwarded-method"])
-				require.Empty(t, receivedHeaders["forwarded"])
-				require.Equal(t, "foo", receivedHeaders["x-foo-bar"])
+				require.Equal(t, map[string]string{
+					"x-foo-bar": "foo",
+				}, receivedHeaders)
 			} else {
 				require.Equal(t, sendMD.Get("X-Forwarded-Proto"), receivedMD.Get("X-Forwarded-Proto"))
 				require.Equal(t, sendMD.Get("X-Forwarded-Host"), receivedMD.Get("X-Forwarded-Host"))
@@ -181,20 +176,15 @@ func TestInterceptorExecution(t *testing.T) {
 				require.Equal(t, sendMD.Get("Forwarded"), receivedMD.Get("Forwarded"))
 				require.Equal(t, sendMD.Get("X-Foo-Bar"), receivedMD.Get("X-Foo-Bar"))
 
-				require.Equal(t, sendHeaders["x-forwarded-proto"], receivedHeaders["x-forwarded-proto"])
-				require.Equal(t, sendHeaders["x-forwarded-host"], receivedHeaders["x-forwarded-host"])
-				require.Equal(t, sendHeaders["x-forwarded-path"], receivedHeaders["x-forwarded-path"])
-				require.Equal(t, sendHeaders["x-forwarded-uri"], receivedHeaders["x-forwarded-uri"])
-				require.Equal(t, sendHeaders["x-forwarded-for"], receivedHeaders["x-forwarded-for"])
-				require.Equal(t, sendHeaders["x-forwarded-method"], receivedHeaders["x-forwarded-method"])
-				require.Equal(t, sendHeaders["forwarded"], receivedHeaders["forwarded"])
-				require.Equal(t, sendHeaders["x-foo-bar"], receivedHeaders["x-foo-bar"])
+				require.Equal(t, sendHeaders, receivedHeaders)
 			}
 
 			logs := tb.CollectedLog()
-			if len(logs) != 0 {
-				require.NotEmpty(t, tc.warningLog, "logs contain warnings, but no warnings are expected")
+
+			if len(tc.warningLog) != 0 {
 				assert.Contains(t, logs, tc.warningLog)
+			} else {
+				require.Empty(t, logs)
 			}
 		})
 	}

--- a/internal/handler/middleware/grpc/trustedproxy/interceptor_test.go
+++ b/internal/handler/middleware/grpc/trustedproxy/interceptor_test.go
@@ -172,96 +172,28 @@ func TestInterceptorExecution(t *testing.T) {
 				require.Empty(t, receivedHeaders["forwarded"])
 				require.Equal(t, "foo", receivedHeaders["x-foo-bar"])
 			} else {
-				require.Equal(
-					t,
-					sendMD.Get("X-Forwarded-Proto"),
-					receivedMD.Get("X-Forwarded-Proto"),
-				)
-				require.Equal(
-					t,
-					sendMD.Get("X-Forwarded-Host"),
-					receivedMD.Get("X-Forwarded-Host"),
-				)
-				require.Equal(
-					t,
-					sendMD.Get("X-Forwarded-Path"),
-					receivedMD.Get("X-Forwarded-Path"),
-				)
-				require.Equal(
-					t,
-					sendMD.Get("X-Forwarded-Uri"),
-					receivedMD.Get("X-Forwarded-Uri"),
-				)
-				require.Equal(
-					t,
-					sendMD.Get("X-Forwarded-For"),
-					receivedMD.Get("X-Forwarded-For"),
-				)
-				require.Equal(
-					t,
-					sendMD.Get("X-Forwarded-Method"),
-					receivedMD.Get("X-Forwarded-Method"),
-				)
-				require.Equal(
-					t,
-					sendMD.Get("Forwarded"),
-					receivedMD.Get("Forwarded"),
-				)
-				require.Equal(
-					t,
-					sendMD.Get("X-Foo-Bar"),
-					receivedMD.Get("X-Foo-Bar"),
-				)
+				require.Equal(t, sendMD.Get("X-Forwarded-Proto"), receivedMD.Get("X-Forwarded-Proto"))
+				require.Equal(t, sendMD.Get("X-Forwarded-Host"), receivedMD.Get("X-Forwarded-Host"))
+				require.Equal(t, sendMD.Get("X-Forwarded-Path"), receivedMD.Get("X-Forwarded-Path"))
+				require.Equal(t, sendMD.Get("X-Forwarded-Uri"), receivedMD.Get("X-Forwarded-Uri"))
+				require.Equal(t, sendMD.Get("X-Forwarded-For"), receivedMD.Get("X-Forwarded-For"))
+				require.Equal(t, sendMD.Get("X-Forwarded-Method"), receivedMD.Get("X-Forwarded-Method"))
+				require.Equal(t, sendMD.Get("Forwarded"), receivedMD.Get("Forwarded"))
+				require.Equal(t, sendMD.Get("X-Foo-Bar"), receivedMD.Get("X-Foo-Bar"))
 
-				require.Equal(
-					t,
-					sendHeaders["x-forwarded-proto"],
-					receivedHeaders["x-forwarded-proto"],
-				)
-				require.Equal(
-					t,
-					sendHeaders["x-forwarded-host"],
-					receivedHeaders["x-forwarded-host"],
-				)
-				require.Equal(
-					t,
-					sendHeaders["x-forwarded-path"],
-					receivedHeaders["x-forwarded-path"],
-				)
-				require.Equal(
-					t,
-					sendHeaders["x-forwarded-uri"],
-					receivedHeaders["x-forwarded-uri"],
-				)
-				require.Equal(
-					t,
-					sendHeaders["x-forwarded-for"],
-					receivedHeaders["x-forwarded-for"],
-				)
-				require.Equal(
-					t,
-					sendHeaders["x-forwarded-method"],
-					receivedHeaders["x-forwarded-method"],
-				)
-				require.Equal(
-					t,
-					sendHeaders["forwarded"],
-					receivedHeaders["forwarded"],
-				)
-				require.Equal(
-					t,
-					sendHeaders["x-foo-bar"],
-					receivedHeaders["x-foo-bar"],
-				)
+				require.Equal(t, sendHeaders["x-forwarded-proto"], receivedHeaders["x-forwarded-proto"])
+				require.Equal(t, sendHeaders["x-forwarded-host"], receivedHeaders["x-forwarded-host"])
+				require.Equal(t, sendHeaders["x-forwarded-path"], receivedHeaders["x-forwarded-path"])
+				require.Equal(t, sendHeaders["x-forwarded-uri"], receivedHeaders["x-forwarded-uri"])
+				require.Equal(t, sendHeaders["x-forwarded-for"], receivedHeaders["x-forwarded-for"])
+				require.Equal(t, sendHeaders["x-forwarded-method"], receivedHeaders["x-forwarded-method"])
+				require.Equal(t, sendHeaders["forwarded"], receivedHeaders["forwarded"])
+				require.Equal(t, sendHeaders["x-foo-bar"], receivedHeaders["x-foo-bar"])
 			}
 
 			logs := tb.CollectedLog()
 			if len(logs) != 0 {
-				require.NotEmpty(
-					t,
-					tc.warningLog,
-					"logs contain warnings, but no warnings are expected",
-				)
+				require.NotEmpty(t, tc.warningLog, "logs contain warnings, but no warnings are expected")
 				assert.Contains(t, logs, tc.warningLog)
 			}
 		})

--- a/internal/handler/middleware/grpc/trustedproxy/interceptor_test.go
+++ b/internal/handler/middleware/grpc/trustedproxy/interceptor_test.go
@@ -1,0 +1,269 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package trustedproxy
+
+import (
+	"context"
+	"maps"
+	"net"
+	"testing"
+
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+
+	"github.com/dadrus/heimdall/internal/x/testsupport"
+)
+
+func TestInterceptorExecution(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		ips        []string
+		shouldDrop bool
+		warningLog string
+	}{
+		"bad IP range": {
+			ips:        []string{"/128"},
+			shouldDrop: true,
+			warningLog: "could not be parsed",
+		},
+		"single IP trusted": {
+			ips:        []string{"127.0.0.1"},
+			shouldDrop: false,
+		},
+		"trusted IP range": {
+			ips:        []string{"127.0.0.0/24"},
+			shouldDrop: false,
+		},
+		"source in IP range but not trusted IPv4": {
+			ips:        []string{"172.0.0.0/0"},
+			shouldDrop: false,
+			warningLog: "trusted proxies contains insecure",
+		},
+		"source not in IPv6 range and is not trusted 1": {
+			ips:        []string{"::/0"},
+			shouldDrop: true,
+			warningLog: "trusted proxies contains insecure",
+		},
+		"source not in IPv6 range and is not trusted 2": {
+			ips:        []string{"3209:7473:73ed:a31c:0a08:f214:2434:d5ce/0"},
+			shouldDrop: true,
+			warningLog: "trusted proxies contains insecure",
+		},
+		"source not in IPv4 range": {
+			ips:        []string{"172.0.0.0/24"},
+			shouldDrop: true,
+		},
+		"empty list": {
+			ips:        []string{},
+			shouldDrop: true,
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			// GIVEN
+			sendMD := metadata.Pairs(
+				"x-forwarded-proto", "https",
+				"x-forwarded-host", "foobar.com",
+				"x-forwarded-path", "/test",
+				"x-forwarded-uri", "/test?foo=bar",
+				"x-forwarded-for", "172.17.1.2",
+				"x-forwarded-method", "GET",
+				"forwarded", "for=172.17.1.2;proto=https",
+				"x-foo-bar", "foo",
+			)
+			sendHeaders := map[string]string{
+				"x-forwarded-proto":  "https",
+				"x-forwarded-host":   "foobar.com",
+				"x-forwarded-path":   "/test",
+				"x-forwarded-uri":    "/test?foo=bar",
+				"x-forwarded-for":    "172.17.1.2",
+				"x-forwarded-method": "GET",
+				"forwarded":          "for=172.17.1.2;proto=https",
+				"x-foo-bar":          "foo",
+			}
+
+			var (
+				receivedMD      metadata.MD
+				receivedHeaders map[string]string
+			)
+
+			tb := &testsupport.TestingLog{TB: t}
+			logger := zerolog.New(zerolog.TestWriter{T: tb})
+
+			ctx := metadata.NewIncomingContext(t.Context(), sendMD)
+			ctx = peer.NewContext(ctx, &peer.Peer{
+				Addr: &net.TCPAddr{
+					IP:   net.ParseIP("127.0.0.1"),
+					Port: 12345,
+				},
+			})
+
+			req := &envoy_auth.CheckRequest{
+				Attributes: &envoy_auth.AttributeContext{
+					Request: &envoy_auth.AttributeContext_Request{
+						Http: &envoy_auth.AttributeContext_HttpRequest{
+							Headers: sendHeaders,
+						},
+					},
+				},
+			}
+
+			interceptor := New(logger, tc.ips...)
+
+			// WHEN
+			_, err := interceptor(
+				ctx,
+				req,
+				&grpc.UnaryServerInfo{},
+				func(ctx context.Context, req any) (any, error) {
+					receivedMD, _ = metadata.FromIncomingContext(ctx)
+
+					checkReq := req.(*envoy_auth.CheckRequest)
+					receivedHeaders = maps.Clone(
+						checkReq.
+							GetAttributes().
+							GetRequest().
+							GetHttp().
+							GetHeaders(),
+					)
+
+					return &envoy_auth.CheckResponse{}, nil
+				},
+			)
+
+			// THEN
+			require.NoError(t, err)
+
+			if tc.shouldDrop {
+				require.Empty(t, receivedMD.Get("X-Forwarded-Proto"))
+				require.Empty(t, receivedMD.Get("X-Forwarded-Host"))
+				require.Empty(t, receivedMD.Get("X-Forwarded-Path"))
+				require.Empty(t, receivedMD.Get("X-Forwarded-Uri"))
+				require.Empty(t, receivedMD.Get("X-Forwarded-For"))
+				require.Empty(t, receivedMD.Get("X-Forwarded-Method"))
+				require.Empty(t, receivedMD.Get("Forwarded"))
+				require.Equal(t, []string{"foo"}, receivedMD.Get("X-Foo-Bar"))
+
+				require.Empty(t, receivedHeaders["x-forwarded-proto"])
+				require.Empty(t, receivedHeaders["x-forwarded-host"])
+				require.Empty(t, receivedHeaders["x-forwarded-path"])
+				require.Empty(t, receivedHeaders["x-forwarded-uri"])
+				require.Empty(t, receivedHeaders["x-forwarded-for"])
+				require.Empty(t, receivedHeaders["x-forwarded-method"])
+				require.Empty(t, receivedHeaders["forwarded"])
+				require.Equal(t, "foo", receivedHeaders["x-foo-bar"])
+			} else {
+				require.Equal(
+					t,
+					sendMD.Get("X-Forwarded-Proto"),
+					receivedMD.Get("X-Forwarded-Proto"),
+				)
+				require.Equal(
+					t,
+					sendMD.Get("X-Forwarded-Host"),
+					receivedMD.Get("X-Forwarded-Host"),
+				)
+				require.Equal(
+					t,
+					sendMD.Get("X-Forwarded-Path"),
+					receivedMD.Get("X-Forwarded-Path"),
+				)
+				require.Equal(
+					t,
+					sendMD.Get("X-Forwarded-Uri"),
+					receivedMD.Get("X-Forwarded-Uri"),
+				)
+				require.Equal(
+					t,
+					sendMD.Get("X-Forwarded-For"),
+					receivedMD.Get("X-Forwarded-For"),
+				)
+				require.Equal(
+					t,
+					sendMD.Get("X-Forwarded-Method"),
+					receivedMD.Get("X-Forwarded-Method"),
+				)
+				require.Equal(
+					t,
+					sendMD.Get("Forwarded"),
+					receivedMD.Get("Forwarded"),
+				)
+				require.Equal(
+					t,
+					sendMD.Get("X-Foo-Bar"),
+					receivedMD.Get("X-Foo-Bar"),
+				)
+
+				require.Equal(
+					t,
+					sendHeaders["x-forwarded-proto"],
+					receivedHeaders["x-forwarded-proto"],
+				)
+				require.Equal(
+					t,
+					sendHeaders["x-forwarded-host"],
+					receivedHeaders["x-forwarded-host"],
+				)
+				require.Equal(
+					t,
+					sendHeaders["x-forwarded-path"],
+					receivedHeaders["x-forwarded-path"],
+				)
+				require.Equal(
+					t,
+					sendHeaders["x-forwarded-uri"],
+					receivedHeaders["x-forwarded-uri"],
+				)
+				require.Equal(
+					t,
+					sendHeaders["x-forwarded-for"],
+					receivedHeaders["x-forwarded-for"],
+				)
+				require.Equal(
+					t,
+					sendHeaders["x-forwarded-method"],
+					receivedHeaders["x-forwarded-method"],
+				)
+				require.Equal(
+					t,
+					sendHeaders["forwarded"],
+					receivedHeaders["forwarded"],
+				)
+				require.Equal(
+					t,
+					sendHeaders["x-foo-bar"],
+					receivedHeaders["x-foo-bar"],
+				)
+			}
+
+			logs := tb.CollectedLog()
+			if len(logs) != 0 {
+				require.NotEmpty(
+					t,
+					tc.warningLog,
+					"logs contain warnings, but no warnings are expected",
+				)
+				assert.Contains(t, logs, tc.warningLog)
+			}
+		})
+	}
+}

--- a/internal/handler/middleware/grpc/trustedproxy/interceptor_test.go
+++ b/internal/handler/middleware/grpc/trustedproxy/interceptor_test.go
@@ -81,23 +81,23 @@ func TestInterceptorExecution(t *testing.T) {
 		t.Run(uc, func(t *testing.T) {
 			// GIVEN
 			sendMD := metadata.Pairs(
-				"x-forwarded-proto", "https",
+				"X-Forwarded-Proto", "https",
 				"x-forwarded-host", "foobar.com",
 				"x-forwarded-path", "/test",
 				"x-forwarded-uri", "/test?foo=bar",
-				"x-forwarded-for", "172.17.1.2",
+				"X-FORWARDED-FOR", "172.17.1.2",
 				"x-forwarded-method", "GET",
-				"forwarded", "for=172.17.1.2;proto=https",
+				"FoRwArDeD", "for=172.17.1.2;proto=https",
 				"x-foo-bar", "foo",
 			)
 			sendHeaders := map[string]string{
 				"x-forwarded-proto":  "https",
-				"x-forwarded-host":   "foobar.com",
+				"X-Forwarded-Host":   "foobar.com",
 				"x-forwarded-path":   "/test",
-				"x-forwarded-uri":    "/test?foo=bar",
+				"X-FORWARDED-URI":    "/test?foo=bar",
 				"x-forwarded-for":    "172.17.1.2",
 				"x-forwarded-method": "GET",
-				"forwarded":          "for=172.17.1.2;proto=https",
+				"FoRwArDeD":          "for=172.17.1.2;proto=https",
 				"x-foo-bar":          "foo",
 			}
 

--- a/internal/handler/middleware/http/trustedproxy/handler.go
+++ b/internal/handler/middleware/http/trustedproxy/handler.go
@@ -19,78 +19,22 @@ package trustedproxy
 import (
 	"net"
 	"net/http"
-	"slices"
-	"strings"
 
 	"github.com/rs/zerolog"
 
-	"github.com/dadrus/heimdall/internal/config"
+	"github.com/dadrus/heimdall/internal/handler/middleware/trustedproxy"
 	"github.com/dadrus/heimdall/internal/x/httpx"
 )
 
-var untrustedHeader = []string{ //nolint:gochecknoglobals
-	"Forwarded",
-	"X-Forwarded-For",
-	"X-Forwarded-Proto",
-	"X-Forwarded-Host",
-	"X-Forwarded-Uri",
-	"X-Forwarded-Path",
-	"X-Forwarded-Method",
-}
-
-type ipHolder interface {
-	Contains(ip net.IP) bool
-}
-
-type simpleIP net.IP
-
-func (s simpleIP) Contains(ip net.IP) bool {
-	return net.IP(s).Equal(ip)
-}
-
-type trustedProxySet []ipHolder
-
-func (tpm trustedProxySet) Contains(ip net.IP) bool {
-	for _, proxy := range tpm {
-		if proxy.Contains(ip) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func New(logger zerolog.Logger, proxies ...string) func(http.Handler) http.Handler {
-	var ipHolders []ipHolder
-
-	for _, ipAddr := range proxies {
-		if !strings.Contains(ipAddr, "/") {
-			ipHolders = append(ipHolders, simpleIP(net.ParseIP(ipAddr)))
-
-			continue
-		}
-
-		_, ipNet, err := net.ParseCIDR(ipAddr)
-		if err != nil {
-			logger.Warn().Err(err).
-				Msgf("Trusted proxies entry %q could not be parsed and will be ignored", ipAddr)
-		} else {
-			ipHolders = append(ipHolders, ipNet)
-
-			if slices.Contains(config.InsecureNetworks, ipNet.String()) {
-				logger.Warn().Msgf("Configured trusted proxies contains insecure networks: %s", ipAddr)
-			}
-		}
-	}
-
-	trustedProxies := trustedProxySet(ipHolders)
+	matcher := trustedproxy.NewMatcher(logger, proxies...)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			if !trustedProxies.Contains(net.ParseIP(httpx.IPFromHostPort(req.RemoteAddr))) {
-				for _, name := range untrustedHeader {
-					req.Header.Del(name)
-				}
+			remoteIP := net.ParseIP(httpx.IPFromHostPort(req.RemoteAddr))
+
+			if !matcher.Contains(remoteIP) {
+				trustedproxy.RemoveForwardingHeaders(req.Header.Del)
 			}
 
 			next.ServeHTTP(rw, req)

--- a/internal/handler/middleware/trustedproxy/forwarding_headers.go
+++ b/internal/handler/middleware/trustedproxy/forwarding_headers.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package trustedproxy
+
+var forwardingHeaders = [...]string{ //nolint:gochecknoglobals
+	"Forwarded",
+	"X-Forwarded-For",
+	"X-Forwarded-Proto",
+	"X-Forwarded-Host",
+	"X-Forwarded-Uri",
+	"X-Forwarded-Path",
+	"X-Forwarded-Method",
+}
+
+func RemoveForwardingHeaders(remove func(string)) {
+	for _, name := range forwardingHeaders {
+		remove(name)
+	}
+}

--- a/internal/handler/middleware/trustedproxy/forwarding_headers_test.go
+++ b/internal/handler/middleware/trustedproxy/forwarding_headers_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package trustedproxy
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveForwardingHeaders(t *testing.T) {
+	t.Parallel()
+
+	// GIVEN
+	headers := http.Header{
+		"Forwarded":          []string{"for=172.17.1.2;proto=https"},
+		"X-Forwarded-For":    []string{"172.17.1.2"},
+		"X-Forwarded-Proto":  []string{"https"},
+		"X-Forwarded-Host":   []string{"foobar.com"},
+		"X-Forwarded-Uri":    []string{"/test?foo=bar"},
+		"X-Forwarded-Path":   []string{"/test"},
+		"X-Forwarded-Method": []string{"GET"},
+		"X-Foo-Bar":          []string{"foo"},
+	}
+
+	// WHEN
+	RemoveForwardingHeaders(headers.Del)
+
+	// THEN
+	require.Equal(t, http.Header{
+		"X-Foo-Bar": []string{"foo"},
+	}, headers)
+}

--- a/internal/handler/middleware/trustedproxy/matcher.go
+++ b/internal/handler/middleware/trustedproxy/matcher.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package trustedproxy
+
+import (
+	"net"
+	"slices"
+	"strings"
+
+	"github.com/rs/zerolog"
+
+	"github.com/dadrus/heimdall/internal/config"
+)
+
+type ipHolder interface {
+	Contains(ip net.IP) bool
+}
+
+type simpleIP net.IP
+
+func (s simpleIP) Contains(ip net.IP) bool {
+	return net.IP(s).Equal(ip)
+}
+
+type Matcher struct {
+	proxies []ipHolder
+}
+
+func NewMatcher(logger zerolog.Logger, proxies ...string) *Matcher {
+	holders := make([]ipHolder, 0, len(proxies))
+
+	for _, ipAddr := range proxies {
+		if !strings.Contains(ipAddr, "/") {
+			holders = append(holders, simpleIP(net.ParseIP(ipAddr)))
+
+			continue
+		}
+
+		_, ipNet, err := net.ParseCIDR(ipAddr)
+		if err != nil {
+			logger.Warn().Err(err).
+				Msgf("Trusted proxies entry %q could not be parsed and will be ignored", ipAddr)
+
+			continue
+		}
+
+		holders = append(holders, ipNet)
+
+		if slices.Contains(config.InsecureNetworks, ipNet.String()) {
+			logger.Warn().
+				Msgf("Configured trusted proxies contains insecure networks: %s", ipAddr)
+		}
+	}
+
+	return &Matcher{proxies: holders}
+}
+
+func (m *Matcher) Contains(ip net.IP) bool {
+	for _, proxy := range m.proxies {
+		if proxy.Contains(ip) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/handler/middleware/trustedproxy/matcher_test.go
+++ b/internal/handler/middleware/trustedproxy/matcher_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package trustedproxy
+
+import (
+	"net"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dadrus/heimdall/internal/x/testsupport"
+)
+
+func TestMatcherContains(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		proxies    []string
+		ip         string
+		expected   bool
+		warningLog string
+	}{
+		"bad IP range": {
+			proxies:    []string{"/128"},
+			ip:         "127.0.0.1",
+			expected:   false,
+			warningLog: "could not be parsed",
+		},
+		"single IP trusted": {
+			proxies:  []string{"127.0.0.1"},
+			ip:       "127.0.0.1",
+			expected: true,
+		},
+		"trusted IP range": {
+			proxies:  []string{"127.0.0.0/24"},
+			ip:       "127.0.0.1",
+			expected: true,
+		},
+		"source in insecure IPv4 range": {
+			proxies:    []string{"172.0.0.0/0"},
+			ip:         "127.0.0.1",
+			expected:   true,
+			warningLog: "trusted proxies contains insecure",
+		},
+		"source not in insecure IPv6 range 1": {
+			proxies:    []string{"::/0"},
+			ip:         "127.0.0.1",
+			expected:   false,
+			warningLog: "trusted proxies contains insecure",
+		},
+		"source not in insecure IPv6 range 2": {
+			proxies:    []string{"3209:7473:73ed:a31c:0a08:f214:2434:d5ce/0"},
+			ip:         "127.0.0.1",
+			expected:   false,
+			warningLog: "trusted proxies contains insecure",
+		},
+		"source not in IPv4 range": {
+			proxies:  []string{"172.0.0.0/24"},
+			ip:       "127.0.0.1",
+			expected: false,
+		},
+		"empty list": {
+			proxies:  []string{},
+			ip:       "127.0.0.1",
+			expected: false,
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			// GIVEN
+			tb := &testsupport.TestingLog{TB: t}
+			logger := zerolog.New(zerolog.TestWriter{T: tb})
+			matcher := NewMatcher(logger, tc.proxies...)
+
+			// WHEN
+			matches := matcher.Contains(net.ParseIP(tc.ip))
+
+			// THEN
+			require.Equal(t, tc.expected, matches)
+
+			logs := tb.CollectedLog()
+			if len(tc.warningLog) != 0 {
+				assert.Contains(t, logs, tc.warningLog)
+			} else {
+				require.Empty(t, logs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Related issue(s)

closes #3436

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

This PR fixes the referenced issue by enforcing `trusted_proxies` for the Envoy gRPC `ext_authz` integration.

Note: This may be a breaking change for existing Envoy gRPC `ext_authz` setups. Operators must configure the Envoy proxy address or network via `serve.trusted_proxies` if forwarding information is expected to be processed by heimdall.

