### PR TITLE
fix: Corrected client IP extraction for Envoy gRPC ext_authz

### DIFF
--- a/internal/handler/envoyextauth/grpcv3/request_context.go
+++ b/internal/handler/envoyextauth/grpcv3/request_context.go
@@ -28,7 +28,7 @@ import (
 	"github.com/rs/zerolog"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/contenttype"
@@ -96,12 +96,6 @@ func newRequestContext() *RequestContext {
 }
 
 func (r *RequestContext) Init(ctx context.Context, req *envoy_auth.CheckRequest) {
-	clientIPs := r.hmdlReq.ClientIPAddresses
-
-	if rmd, ok := metadata.FromIncomingContext(ctx); ok {
-		clientIPs = requestClientIPs(clientIPs, rmd)
-	}
-
 	httpReq := req.GetAttributes().GetRequest().GetHttp()
 
 	parsed, err := url.ParseRequestURI(httpReq.GetPath())
@@ -123,17 +117,33 @@ func (r *RequestContext) Init(ctx context.Context, req *envoy_auth.CheckRequest)
 		Path:     parsed.Path,
 		RawQuery: parsed.RawQuery,
 	}
+
 	r.reqHeaders["Host"] = r.hmdlReq.URL.Host
-	r.hmdlReq.ClientIPAddresses = clientIPs
+	r.hmdlReq.ClientIPAddresses = requestClientIPs(
+		ctx,
+		r.hmdlReq.ClientIPAddresses,
+		r.reqHeaders,
+	)
 }
 
-func requestClientIPs(ips []string, md metadata.MD) []string {
-	// this header is used by envoyproxy to forward the ip addresses of the hops
-	if res, _ := httpx.IPsFromXForwardedFor(ips, md.Get("x-forwarded-for")); len(res) != 0 {
-		return res
+func requestClientIPs(ctx context.Context, ips []string, headers map[string]string) []string {
+	res, _ := httpx.IPsFromForwarded(ips, []string{headers["Forwarded"]})
+	if len(res) == 0 {
+		res, _ = httpx.IPsFromXForwardedFor(ips, []string{headers["X-Forwarded-For"]})
 	}
 
-	return ips
+	if len(res) == 0 {
+		res = ips
+	}
+
+	if peerInfo, ok := peer.FromContext(ctx); ok && peerInfo.Addr != nil {
+		peerIP := httpx.IPFromHostPort(peerInfo.Addr.String())
+		if len(peerIP) != 0 {
+			res = append(res, peerIP)
+		}
+	}
+
+	return res
 }
 
 func (r *RequestContext) Reset() {

--- a/internal/handler/envoyextauth/grpcv3/request_context_test.go
+++ b/internal/handler/envoyextauth/grpcv3/request_context_test.go
@@ -49,9 +49,10 @@ func TestNewRequestContext(t *testing.T) {
 		Body:     "content=heimdall",
 		RawBody:  []byte("content=heimdall"),
 		Headers: map[string]string{
-			"x-foo-bar":    "barfoo",
-			"cookie":       "bar=foo;foo=baz",
-			"content-type": "application/x-www-form-urlencoded",
+			"x-foo-bar":       "barfoo",
+			"cookie":          "bar=foo;foo=baz",
+			"content-type":    "application/x-www-form-urlencoded",
+			"x-forwarded-for": "127.0.0.1",
 		},
 	}
 	checkReq := &envoy_auth.CheckRequest{
@@ -61,17 +62,20 @@ func TestNewRequestContext(t *testing.T) {
 			},
 		},
 	}
+
 	md := metadata.New(nil)
-	md.Set("x-forwarded-for", "127.0.0.1", "192.168.1.1")
+	md.Set("x-forwarded-for", "203.0.113.1")
+
+	grpcCtx := metadata.NewIncomingContext(t.Context(), md)
+	grpcCtx = peer.NewContext(grpcCtx, &peer.Peer{
+		Addr: &net.TCPAddr{
+			IP:   net.ParseIP("192.168.1.1"),
+			Port: 12345,
+		},
+	})
 
 	cf := newContextFactory()
-	ctx := cf.Create(
-		metadata.NewIncomingContext(
-			t.Context(),
-			md,
-		),
-		checkReq,
-	)
+	ctx := cf.Create(grpcCtx, checkReq)
 
 	defer cf.Destroy(ctx)
 
@@ -84,82 +88,15 @@ func TestNewRequestContext(t *testing.T) {
 	require.Equal(t, "bar=moo#foobar", ctx.Request().URL.RawQuery)
 	require.Equal(t, "moo#foobar", ctx.Request().URL.URL.Query().Get("bar"))
 	require.Equal(t, map[string]any{"content": []string{"heimdall"}}, ctx.Request().Body())
-	require.Len(t, ctx.Request().Headers(), 4)
+	require.Len(t, ctx.Request().Headers(), 5)
 	require.Equal(t, "foo.bar:8080", ctx.Request().Header("Host"))
 	require.Equal(t, "barfoo", ctx.Request().Header("X-Foo-Bar"))
+	require.Equal(t, "127.0.0.1", ctx.Request().Header("X-Forwarded-For"))
 	require.Equal(t, "foo", ctx.Request().Cookie("bar"))
 	require.Equal(t, "baz", ctx.Request().Cookie("foo"))
 	require.Empty(t, ctx.Request().Cookie("baz"))
 	require.NotNil(t, ctx.Context())
 	assert.Equal(t, []string{"127.0.0.1", "192.168.1.1"}, ctx.Request().ClientIPAddresses)
-}
-
-func TestNewRequestContextXForwardedForCSV(t *testing.T) {
-	t.Parallel()
-
-	// GIVEN
-	checkReq := &envoy_auth.CheckRequest{
-		Attributes: &envoy_auth.AttributeContext{
-			Request: &envoy_auth.AttributeContext_Request{
-				Http: &envoy_auth.AttributeContext_HttpRequest{
-					Method:  http.MethodGet,
-					Scheme:  "https",
-					Host:    "foo.bar",
-					Path:    "/",
-					Headers: map[string]string{},
-				},
-			},
-		},
-	}
-	md := metadata.New(nil)
-	md.Set("x-forwarded-for", "127.0.0.1, 192.168.1.1")
-
-	cf := newContextFactory()
-	ctx := cf.Create(
-		metadata.NewIncomingContext(
-			t.Context(),
-			md,
-		),
-		checkReq,
-	)
-	defer cf.Destroy(ctx)
-
-	// THEN
-	assert.Equal(t, []string{"127.0.0.1", "192.168.1.1"}, ctx.Request().ClientIPAddresses)
-}
-
-func TestNewRequestContextXForwardedForMixedValues(t *testing.T) {
-	t.Parallel()
-
-	// GIVEN
-	checkReq := &envoy_auth.CheckRequest{
-		Attributes: &envoy_auth.AttributeContext{
-			Request: &envoy_auth.AttributeContext_Request{
-				Http: &envoy_auth.AttributeContext_HttpRequest{
-					Method:  http.MethodGet,
-					Scheme:  "https",
-					Host:    "foo.bar",
-					Path:    "/",
-					Headers: map[string]string{},
-				},
-			},
-		},
-	}
-	md := metadata.New(nil)
-	md.Set("x-forwarded-for", "127.0.0.1", "192.168.1.1, 10.0.0.2", "   ")
-
-	cf := newContextFactory()
-	ctx := cf.Create(
-		metadata.NewIncomingContext(
-			t.Context(),
-			md,
-		),
-		checkReq,
-	)
-	defer cf.Destroy(ctx)
-
-	// THEN
-	assert.Equal(t, []string{"127.0.0.1", "192.168.1.1", "10.0.0.2"}, ctx.Request().ClientIPAddresses)
 }
 
 func TestRequestContextURL(t *testing.T) {
@@ -292,6 +229,7 @@ func TestRequestContextFinalize(t *testing.T) {
 				header := findHeader(okResponse.GetHeaders(), "X-For-Upstream-1")
 				require.NotNil(t, header)
 				assert.Equal(t, "some-value-1,some-value-3", header.GetValue())
+
 				header = findHeader(okResponse.GetHeaders(), "X-For-Upstream-2")
 				require.NotNil(t, header)
 				assert.Equal(t, "some-value-2", header.GetValue())
@@ -343,6 +281,7 @@ func TestRequestContextFinalize(t *testing.T) {
 
 				require.Len(t, okResponse.GetHeaders(), 1)
 				assert.Equal(t, "Cookie", okResponse.GetHeaders()[0].GetHeader().GetKey())
+
 				values := strings.Split(okResponse.GetHeaders()[0].GetHeader().GetValue(), ";")
 				assert.Len(t, values, 2)
 				assert.Contains(t, okResponse.GetHeaders()[0].GetHeader().GetValue(), "some-cookie=value-1")
@@ -368,9 +307,11 @@ func TestRequestContextFinalize(t *testing.T) {
 				require.NotNil(t, okResponse)
 
 				require.Len(t, okResponse.GetHeaders(), 2)
+
 				header := findHeader(okResponse.GetHeaders(), "X-For-Upstream")
 				require.NotNil(t, header)
 				assert.Equal(t, "some-value", header.GetValue())
+
 				header = findHeader(okResponse.GetHeaders(), "Cookie")
 				require.NotNil(t, header)
 				assert.Equal(t, "some-cookie=value-1", header.GetValue())
@@ -569,6 +510,8 @@ func TestRequestContextRequestURLCaptures(t *testing.T) {
 
 	// WHEN
 	captures := ctx.Request().URL.Captures
+
+	// THEN
 	require.Len(t, captures, 1)
 	assert.Equal(t, "b", captures["a"])
 }
@@ -586,19 +529,25 @@ func TestRequestContextReset(t *testing.T) {
 					Path:    "/test",
 					Query:   "bar=moo",
 					RawBody: []byte(`{ "content": "heimdall" }`),
-					Headers: map[string]string{"content-type": "application/json"},
+					Headers: map[string]string{
+						"content-type":    "application/json",
+						"x-forwarded-for": "127.0.0.1",
+					},
 				},
 			},
 		},
 	}
 
-	md := metadata.MD{
-		"x-forwarded-for": []string{"127.0.0.1"},
-	}
+	grpcCtx := peer.NewContext(context.TODO(), &peer.Peer{
+		Addr: &net.TCPAddr{
+			IP:   net.ParseIP("192.168.1.1"),
+			Port: 12345,
+		},
+	})
 
 	// GIVEN
 	ctx := newRequestContext()
-	ctx.Init(metadata.NewIncomingContext(context.TODO(), md), checkReq)
+	ctx.Init(grpcCtx, checkReq)
 	ctx.Request().URL.Captures = map[string]string{"b": "a"}
 	ctx.SetPipelineError(errors.New("test error"))
 	_ = ctx.Body()
@@ -607,6 +556,12 @@ func TestRequestContextReset(t *testing.T) {
 	ctx.AddCookieForUpstream("foo", "bar")
 	ctx.AddHeaderForUpstream("bar", "foo")
 	_ = ctx.Headers()
+
+	require.Equal(
+		t,
+		[]string{"127.0.0.1", "192.168.1.1"},
+		ctx.Request().ClientIPAddresses,
+	)
 
 	// WHEN
 	ctx.Reset()
@@ -688,6 +643,7 @@ func TestRequestContextHeader(t *testing.T) {
 					},
 				},
 			)
+
 			defer cf.Destroy(ctx)
 
 			assert.Equal(t, tc.expected, ctx.Request().Header(tc.name))
@@ -736,6 +692,17 @@ func TestRequestClientIPs(t *testing.T) {
 			expected: []string{
 				"127.0.0.3",
 				"192.168.12.127",
+				"192.0.2.1",
+			},
+		},
+		"X-Forwarded-For contains multiple and empty values": {
+			headers: map[string]string{
+				"X-Forwarded-For": "127.0.0.1, 192.168.1.1, 10.0.0.2,   ",
+			},
+			expected: []string{
+				"127.0.0.1",
+				"192.168.1.1",
+				"10.0.0.2",
 				"192.0.2.1",
 			},
 		},

--- a/internal/handler/envoyextauth/grpcv3/request_context_test.go
+++ b/internal/handler/envoyextauth/grpcv3/request_context_test.go
@@ -19,6 +19,7 @@ package grpcv3
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"strings"
 	"testing"
@@ -29,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 
 	"github.com/dadrus/heimdall/internal/heimdall"
 )
@@ -689,6 +691,77 @@ func TestRequestContextHeader(t *testing.T) {
 			defer cf.Destroy(ctx)
 
 			assert.Equal(t, tc.expected, ctx.Request().Header(tc.name))
+		})
+	}
+}
+
+func TestRequestClientIPs(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		headers  map[string]string
+		expected []string
+	}{
+		"neither Forwarded, nor X-Forwarded-For headers are present": {
+			headers: map[string]string{},
+			expected: []string{
+				"192.0.2.1",
+			},
+		},
+		"only Forwarded header is present": {
+			headers: map[string]string{
+				"Forwarded": "proto=http;for=127.0.0.1, proto=https;for=192.168.12.125",
+			},
+			expected: []string{
+				"127.0.0.1",
+				"192.168.12.125",
+				"192.0.2.1",
+			},
+		},
+		"only X-Forwarded-For header is present": {
+			headers: map[string]string{
+				"X-Forwarded-For": "127.0.0.1, 192.168.12.125",
+			},
+			expected: []string{
+				"127.0.0.1",
+				"192.168.12.125",
+				"192.0.2.1",
+			},
+		},
+		"Forwarded and X-Forwarded-For headers are present": {
+			headers: map[string]string{
+				"X-Forwarded-For": "127.0.0.2, 192.168.12.126",
+				"Forwarded":       "proto=http;for=127.0.0.3, proto=http;for=192.168.12.127",
+			},
+			expected: []string{
+				"127.0.0.3",
+				"192.168.12.127",
+				"192.0.2.1",
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			// GIVEN
+			md := metadata.New(nil)
+			md.Set("x-forwarded-for", "203.0.113.1")
+
+			ctx := metadata.NewIncomingContext(t.Context(), md)
+			ctx = peer.NewContext(ctx, &peer.Peer{
+				Addr: &net.TCPAddr{
+					IP:   net.ParseIP("192.0.2.1"),
+					Port: 12345,
+				},
+			})
+
+			// WHEN
+			ips := requestClientIPs(
+				ctx,
+				make([]string, 0, 10),
+				tc.headers,
+			)
+
+			// THEN
+			assert.Equal(t, tc.expected, ips)
 		})
 	}
 }

--- a/internal/handler/middleware/grpc/logger/interceptor.go
+++ b/internal/handler/middleware/grpc/logger/interceptor.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -39,6 +40,7 @@ type ServerInterceptor interface {
 
 func New(logger zerolog.Logger, opts ...Option) ServerInterceptor {
 	conf := config{accessLogEnabled: true}
+
 	for _, opt := range opts {
 		opt(&conf)
 	}
@@ -69,13 +71,29 @@ func (li *logInterceptor) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 		peerAddr := peerFromCtx(ctx)
 		ctx = accesscontext.New(ctx)
 
-		logEvt := logCommonData(li.accessLogger.Info(), start, peerAddr, info.FullMethod, traceCtx, requestMD)
+		logEvt := logCommonData(
+			li.accessLogger.Info(),
+			start,
+			peerAddr,
+			info.FullMethod,
+			traceCtx,
+			req,
+			requestMD,
+		)
 		logEvt.Msg("TX started")
 
 		resp, err := handler(withTraceData(li.logger.With(), &traceCtx).Logger().WithContext(ctx), req)
 		grpcStatus, _ := status.FromError(err)
 
-		logEvt = logCommonData(li.accessLogger.Info(), start, peerAddr, info.FullMethod, traceCtx, requestMD)
+		logEvt = logCommonData(
+			li.accessLogger.Info(),
+			start,
+			peerAddr,
+			info.FullMethod,
+			traceCtx,
+			req,
+			requestMD,
+		)
 		logEvt = logAccessStatus(ctx, logEvt, err).
 			Uint32("_grpc_status_code", uint32(grpcStatus.Code())).
 			Int64("_tx_duration_ms", time.Since(start).Milliseconds())
@@ -86,9 +104,7 @@ func (li *logInterceptor) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 }
 
 func (li *logInterceptor) StreamServerInterceptor() grpc.StreamServerInterceptor {
-	return func(
-		srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler,
-	) error {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		ctx := stream.Context()
 		traceCtx := tracecontext.Extract(ctx)
 
@@ -101,13 +117,29 @@ func (li *logInterceptor) StreamServerInterceptor() grpc.StreamServerInterceptor
 		peerAddr := peerFromCtx(ctx)
 		ctx = accesscontext.New(ctx)
 
-		logEvt := logCommonData(li.accessLogger.Info(), start, peerAddr, info.FullMethod, traceCtx, requestMD)
+		logEvt := logCommonData(
+			li.accessLogger.Info(),
+			start,
+			peerAddr,
+			info.FullMethod,
+			traceCtx,
+			nil,
+			requestMD,
+		)
 		logEvt.Msg("TX started")
 
 		err := handler(srv, stream)
 		grpcStatus, _ := status.FromError(err)
 
-		logEvt = logCommonData(li.accessLogger.Info(), start, peerAddr, info.FullMethod, traceCtx, requestMD)
+		logEvt = logCommonData(
+			li.accessLogger.Info(),
+			start,
+			peerAddr,
+			info.FullMethod,
+			traceCtx,
+			nil,
+			requestMD,
+		)
 		logEvt = logAccessStatus(ctx, logEvt, err).
 			Uint32("_grpc_status_code", uint32(grpcStatus.Code())).
 			Int64("_tx_duration_ms", time.Since(start).Milliseconds())
@@ -137,13 +169,29 @@ func logCommonData(
 	peerAddr string,
 	fullMethod string,
 	traceCtx tracecontext.TraceContext,
+	req any,
 	requestMD metadata.MD,
 ) *zerolog.Event {
 	logEvt.
 		Int64("_tx_start", start.Unix()).
 		Str("_client_ip", peerAddr).
 		Str("_grpc_method", fullMethod)
+
 	logEvt = logTraceData(&traceCtx, logEvt)
+
+	if checkReq, ok := req.(*envoy_auth.CheckRequest); ok {
+		headers := checkReq.
+			GetAttributes().
+			GetRequest().
+			GetHttp().
+			GetHeaders()
+
+		logEvt = logHeader(logEvt, headers, "x-forwarded-for", "_x_forwarded_for")
+		logEvt = logHeader(logEvt, headers, "forwarded", "_forwarded")
+
+		return logEvt
+	}
+
 	logEvt = logMetaData(logEvt, requestMD, "x-forwarded-for", "_x_forwarded_for")
 	logEvt = logMetaData(logEvt, requestMD, "forwarded", "_forwarded")
 
@@ -183,6 +231,19 @@ func logTraceData(traceCtx *tracecontext.TraceContext, logEvt *zerolog.Event) *z
 		if len(traceCtx.ParentID) != 0 {
 			logEvt = logEvt.Str("_parent_id", traceCtx.ParentID)
 		}
+	}
+
+	return logEvt
+}
+
+func logHeader(
+	logEvt *zerolog.Event,
+	headers map[string]string,
+	headerName string,
+	logKey string,
+) *zerolog.Event {
+	if value := headers[headerName]; len(value) != 0 {
+		return logEvt.Str(logKey, value)
 	}
 
 	return logEvt

--- a/internal/handler/middleware/grpc/logger/interceptor_test.go
+++ b/internal/handler/middleware/grpc/logger/interceptor_test.go
@@ -54,11 +54,14 @@ func TestLogInterceptorForKnownService(t *testing.T) {
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}))
 
 	parentCtx := trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID: trace.TraceID{1}, SpanID: trace.SpanID{2}, TraceFlags: trace.FlagsSampled,
+		TraceID:    trace.TraceID{1},
+		SpanID:     trace.SpanID{2},
+		TraceFlags: trace.FlagsSampled,
 	})
 
 	for uc, tc := range map[string]struct {
 		outgoingContext func(t *testing.T) context.Context
+		requestHeaders  map[string]string
 		configureMock   func(t *testing.T, m *mocks2.MockHandler)
 		assert          func(t *testing.T, logEvent1, logEvent2, logEvent3 map[string]any)
 	}{
@@ -71,7 +74,8 @@ func TestLogInterceptorForKnownService(t *testing.T) {
 			configureMock: func(t *testing.T, m *mocks2.MockHandler) {
 				t.Helper()
 
-				m.On("Check",
+				m.On(
+					"Check",
 					mock.MatchedBy(
 						func(ctx context.Context) bool {
 							zerolog.Ctx(ctx).Info().Msg("test called")
@@ -82,7 +86,11 @@ func TestLogInterceptorForKnownService(t *testing.T) {
 					),
 					mock.Anything,
 				).Return(
-					&envoy_auth.CheckResponse{Status: &rpc_status.Status{Code: int32(envoy_type.StatusCode_OK)}},
+					&envoy_auth.CheckResponse{
+						Status: &rpc_status.Status{
+							Code: int32(envoy_type.StatusCode_OK),
+						},
+					},
 					nil,
 				)
 			},
@@ -130,20 +138,26 @@ func TestLogInterceptorForKnownService(t *testing.T) {
 				t.Helper()
 
 				md := map[string]string{
-					"x-forwarded-for": "127.0.0.1",
-					"forwarded":       "for=127.0.0.1",
+					"x-forwarded-for": "203.0.113.1",
+					"forwarded":       "for=203.0.113.1",
 				}
 
 				otel.GetTextMapPropagator().Inject(
 					trace.ContextWithRemoteSpanContext(t.Context(), parentCtx),
-					propagation.MapCarrier(md))
+					propagation.MapCarrier(md),
+				)
 
 				return metadata.NewOutgoingContext(t.Context(), metadata.New(md))
+			},
+			requestHeaders: map[string]string{
+				"x-forwarded-for": "127.0.0.1",
+				"forwarded":       "for=127.0.0.1",
 			},
 			configureMock: func(t *testing.T, m *mocks2.MockHandler) {
 				t.Helper()
 
-				m.On("Check",
+				m.On(
+					"Check",
 					mock.MatchedBy(
 						func(ctx context.Context) bool {
 							zerolog.Ctx(ctx).Info().Msg("test called")
@@ -205,7 +219,8 @@ func TestLogInterceptorForKnownService(t *testing.T) {
 			configureMock: func(t *testing.T, m *mocks2.MockHandler) {
 				t.Helper()
 
-				m.On("Check",
+				m.On(
+					"Check",
 					mock.MatchedBy(
 						func(ctx context.Context) bool {
 							zerolog.Ctx(ctx).Info().Msg("test called")
@@ -217,7 +232,11 @@ func TestLogInterceptorForKnownService(t *testing.T) {
 					),
 					mock.Anything,
 				).Return(
-					&envoy_auth.CheckResponse{Status: &rpc_status.Status{Code: int32(envoy_type.StatusCode_Forbidden)}},
+					&envoy_auth.CheckResponse{
+						Status: &rpc_status.Status{
+							Code: int32(envoy_type.StatusCode_Forbidden),
+						},
+					},
 					nil,
 				)
 			},
@@ -273,9 +292,16 @@ func TestLogInterceptorForKnownService(t *testing.T) {
 			tb := &testsupport.TestingLog{TB: t}
 			logger := zerolog.New(zerolog.TestWriter{T: tb})
 			handler := &mocks2.MockHandler{}
-			conn, err := grpc.NewClient("passthrough://bufnet",
-				grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
-				grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+			conn, err := grpc.NewClient(
+				"passthrough://bufnet",
+				grpc.WithContextDialer(
+					func(context.Context, string) (net.Conn, error) {
+						return lis.Dial()
+					},
+				),
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
 			require.NoError(t, err)
 
 			defer conn.Close()
@@ -299,9 +325,10 @@ func TestLogInterceptorForKnownService(t *testing.T) {
 				Attributes: &envoy_auth.AttributeContext{
 					Request: &envoy_auth.AttributeContext_Request{
 						Http: &envoy_auth.AttributeContext_HttpRequest{
-							Body:   "foo",
-							Method: http.MethodPost,
-							Path:   "/foobar",
+							Body:    "foo",
+							Method:  http.MethodPost,
+							Path:    "/foobar",
+							Headers: tc.requestHeaders,
 						},
 					},
 				},
@@ -312,7 +339,6 @@ func TestLogInterceptorForKnownService(t *testing.T) {
 
 			events := strings.Split(tb.CollectedLog(), "}")
 			require.Len(t, events, 4)
-
 			require.NoError(t, json.Unmarshal([]byte(events[0]+"}"), &logLine1))
 			require.NoError(t, json.Unmarshal([]byte(events[1]+"}"), &logLine2))
 			require.NoError(t, json.Unmarshal([]byte(events[2]+"}"), &logLine3))
@@ -332,19 +358,35 @@ func TestLogInterceptorWithAccessLogDisabled(t *testing.T) {
 	logger := zerolog.New(zerolog.TestWriter{T: tb})
 	handler := &mocks2.MockHandler{}
 
-	conn, err := grpc.NewClient("passthrough://bufnet",
-		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
+		grpc.WithContextDialer(
+			func(context.Context, string) (net.Conn, error) {
+				return lis.Dial()
+			},
+		),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
 	require.NoError(t, err)
 
 	defer conn.Close()
 
-	handler.On("Check", mock.MatchedBy(func(ctx context.Context) bool {
-		zerolog.Ctx(ctx).Info().Msg("test called")
+	handler.On(
+		"Check",
+		mock.MatchedBy(
+			func(ctx context.Context) bool {
+				zerolog.Ctx(ctx).Info().Msg("test called")
 
-		return true
-	}), mock.Anything).Return(
-		&envoy_auth.CheckResponse{Status: &rpc_status.Status{Code: int32(envoy_type.StatusCode_OK)}},
+				return true
+			},
+		),
+		mock.Anything,
+	).Return(
+		&envoy_auth.CheckResponse{
+			Status: &rpc_status.Status{
+				Code: int32(envoy_type.StatusCode_OK),
+			},
+		},
 		nil,
 	)
 
@@ -375,13 +417,16 @@ func TestLogInterceptorWithAccessLogDisabled(t *testing.T) {
 
 	// THEN
 	require.NoError(t, err)
+
 	srv.Stop()
 
 	events := strings.Split(strings.TrimRight(tb.CollectedLog(), "\n"), "}")
+
 	// only "test called" log event should be present, no TX started / finished
 	require.Len(t, events, 2)
 
 	var logLine map[string]any
+
 	require.NoError(t, json.Unmarshal([]byte(events[0]+"}"), &logLine))
 
 	assert.Equal(t, "test called", logLine["message"])
@@ -399,17 +444,25 @@ func TestLogInterceptorStreamWithAccessLogDisabled(t *testing.T) {
 	logger := zerolog.New(zerolog.TestWriter{T: tb})
 	handler := &mocks2.MockHandler{}
 
-	conn, err := grpc.NewClient("passthrough://bufnet",
-		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return lis.Dial() }),
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
+		grpc.WithContextDialer(
+			func(context.Context, string) (net.Conn, error) {
+				return lis.Dial()
+			},
+		),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
 	require.NoError(t, err)
 
 	defer conn.Close()
 
 	srv := grpc.NewServer(
-		grpc.UnknownServiceHandler(func(_ interface{}, _ grpc.ServerStream) error {
-			return status.Error(codes.Unknown, "unknown service or method")
-		}),
+		grpc.UnknownServiceHandler(
+			func(_ interface{}, _ grpc.ServerStream) error {
+				return status.Error(codes.Unknown, "unknown service or method")
+			},
+		),
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.ChainStreamInterceptor(New(logger, WithAccessLogEnabled(false)).StreamServerInterceptor()),
 	)
@@ -426,6 +479,7 @@ func TestLogInterceptorStreamWithAccessLogDisabled(t *testing.T) {
 
 	// THEN
 	require.Error(t, err)
+
 	srv.Stop()
 	handler.AssertExpectations(t)
 
@@ -446,20 +500,26 @@ func TestLogInterceptorForUnknownService(t *testing.T) {
 	tb := &testsupport.TestingLog{TB: t}
 	logger := zerolog.New(zerolog.TestWriter{T: tb})
 	handler := &mocks2.MockHandler{}
+
 	bufDialer := func(context.Context, string) (net.Conn, error) {
 		return lis.Dial()
 	}
-	conn, err := grpc.NewClient("passthrough://bufnet",
+
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
 		grpc.WithContextDialer(bufDialer),
-		grpc.WithTransportCredentials(insecure.NewCredentials()))
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
 	require.NoError(t, err)
 
 	defer conn.Close()
 
 	srv := grpc.NewServer(
-		grpc.UnknownServiceHandler(func(_ interface{}, _ grpc.ServerStream) error {
-			return status.Error(codes.Unknown, "unknown service or method")
-		}),
+		grpc.UnknownServiceHandler(
+			func(_ interface{}, _ grpc.ServerStream) error {
+				return status.Error(codes.Unknown, "unknown service or method")
+			},
+		),
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
 		grpc.ChainStreamInterceptor(New(logger).StreamServerInterceptor()),
 	)
@@ -476,6 +536,7 @@ func TestLogInterceptorForUnknownService(t *testing.T) {
 
 	// THEN
 	require.Error(t, err)
+
 	srv.Stop()
 	handler.AssertExpectations(t)
 

--- a/internal/handler/middleware/grpc/trustedproxy/interceptor.go
+++ b/internal/handler/middleware/grpc/trustedproxy/interceptor.go
@@ -19,7 +19,6 @@ package trustedproxy
 import (
 	"context"
 	"net"
-	"strings"
 
 	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	"github.com/rs/zerolog"
@@ -89,11 +88,9 @@ func sanitizeRequest(req any) {
 		GetHttp().
 		GetHeaders()
 
-	trustedproxy.RemoveForwardingHeaders(func(name string) {
-		for key := range headers {
-			if strings.EqualFold(key, name) {
-				delete(headers, key)
-			}
+	for key := range headers {
+		if trustedproxy.IsForwardingHeader(key) {
+			delete(headers, key)
 		}
-	})
+	}
 }

--- a/internal/handler/middleware/trustedproxy/forwarding_headers.go
+++ b/internal/handler/middleware/trustedproxy/forwarding_headers.go
@@ -16,6 +16,8 @@
 
 package trustedproxy
 
+import "strings"
+
 var forwardingHeaders = [...]string{ //nolint:gochecknoglobals
 	"Forwarded",
 	"X-Forwarded-For",
@@ -29,5 +31,26 @@ var forwardingHeaders = [...]string{ //nolint:gochecknoglobals
 func RemoveForwardingHeaders(remove func(string)) {
 	for _, name := range forwardingHeaders {
 		remove(name)
+	}
+}
+
+func IsForwardingHeader(name string) bool {
+	switch {
+	case strings.EqualFold(name, "Forwarded"):
+		return true
+	case strings.EqualFold(name, "X-Forwarded-For"):
+		return true
+	case strings.EqualFold(name, "X-Forwarded-Proto"):
+		return true
+	case strings.EqualFold(name, "X-Forwarded-Host"):
+		return true
+	case strings.EqualFold(name, "X-Forwarded-Uri"):
+		return true
+	case strings.EqualFold(name, "X-Forwarded-Path"):
+		return true
+	case strings.EqualFold(name, "X-Forwarded-Method"):
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/handler/middleware/trustedproxy/forwarding_headers_test.go
+++ b/internal/handler/middleware/trustedproxy/forwarding_headers_test.go
@@ -46,3 +46,75 @@ func TestRemoveForwardingHeaders(t *testing.T) {
 		"X-Foo-Bar": []string{"foo"},
 	}, headers)
 }
+
+func TestIsForwardingHeader(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		name     string
+		expected bool
+	}{
+		"Forwarded": {
+			name:     "Forwarded",
+			expected: true,
+		},
+		"forwarded lowercase": {
+			name:     "forwarded",
+			expected: true,
+		},
+		"Forwarded mixed case": {
+			name:     "FoRwArDeD",
+			expected: true,
+		},
+		"X-Forwarded-For": {
+			name:     "X-Forwarded-For",
+			expected: true,
+		},
+		"X-Forwarded-For uppercase": {
+			name:     "X-FORWARDED-FOR",
+			expected: true,
+		},
+		"X-Forwarded-Proto": {
+			name:     "X-Forwarded-Proto",
+			expected: true,
+		},
+		"X-Forwarded-Host": {
+			name:     "X-Forwarded-Host",
+			expected: true,
+		},
+		"X-Forwarded-Uri": {
+			name:     "X-Forwarded-Uri",
+			expected: true,
+		},
+		"X-Forwarded-Path": {
+			name:     "X-Forwarded-Path",
+			expected: true,
+		},
+		"X-Forwarded-Method lowercase": {
+			name:     "x-forwarded-method",
+			expected: true,
+		},
+		"unrelated header": {
+			name:     "X-Foo-Bar",
+			expected: false,
+		},
+		"similar prefix": {
+			name:     "X-Forwarded-Foo",
+			expected: false,
+		},
+		"empty header": {
+			name:     "",
+			expected: false,
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			t.Parallel()
+
+			// WHEN
+			actual := IsForwardingHeader(tc.name)
+
+			// THEN
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Related issue(s)

closes #3438

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

This PR fixes the referenced issue by deriving client IP addresses from the `Forwarded` and `X-Forwarded-For` headers of the HTTP request contained in Envoy's `CheckRequest` instead of the metadata of the separate gRPC call. The directly connected gRPC peer is appended as the last hop, making the behavior consistent with the regular HTTP integration.

The gRPC access log has been adjusted accordingly to report forwarding information from the actual request being authorized.

