### PR TITLE
fix: Rule-level cache TTL overrides respected by cached mechanisms

### DIFF
--- a/internal/rules/mechanisms/authenticators/generic_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/generic_authenticator.go
@@ -18,6 +18,7 @@ package authenticators
 
 import (
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"io"
@@ -396,6 +397,10 @@ func (a *genericAuthenticator) calculateCacheKey(reference string) string {
 	digest := sha256.New()
 	digest.Write(a.e.Hash())
 	digest.Write(stringx.ToBytes(reference))
+
+	var ttl [8]byte
+	binary.BigEndian.PutUint64(ttl[:], uint64(a.ttl)) //nolint:gosec
+	digest.Write(ttl[:])
 
 	var result [sha256.Size]byte
 

--- a/internal/rules/mechanisms/authenticators/generic_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/generic_authenticator_test.go
@@ -1465,3 +1465,29 @@ func TestGenericAuthenticatorReadResponse(t *testing.T) {
 		})
 	}
 }
+
+func TestGenericAuthenticatorCalculateCacheKey(t *testing.T) {
+	t.Parallel()
+
+	// GIVEN
+	ep := endpoint.Endpoint{
+		URL: "https://example.com/identity",
+	}
+
+	a1 := &genericAuthenticator{
+		e:   ep,
+		ttl: 5 * time.Second,
+	}
+
+	a2 := &genericAuthenticator{
+		e:   ep,
+		ttl: 15 * time.Second,
+	}
+
+	// WHEN
+	key1 := a1.calculateCacheKey("authentication-data")
+	key2 := a2.calculateCacheKey("authentication-data")
+
+	// THEN
+	assert.NotEqual(t, key1, key2)
+}

--- a/internal/rules/mechanisms/authenticators/jwt_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/x509"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"net/http"
@@ -631,6 +632,16 @@ func (a *jwtAuthenticator) calculateCacheKey(ep *endpoint.Endpoint, renderedURL,
 	digest.Write(ep.Hash())
 	digest.Write(stringx.ToBytes(renderedURL))
 	digest.Write(stringx.ToBytes(reference))
+
+	if a.ttl == nil {
+		digest.Write([]byte{0})
+	} else {
+		digest.Write([]byte{1})
+
+		var ttl [8]byte
+		binary.BigEndian.PutUint64(ttl[:], uint64(*a.ttl)) //nolint:gosec
+		digest.Write(ttl[:])
+	}
 
 	var result [sha256.Size]byte
 

--- a/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
@@ -2703,3 +2703,20 @@ func TestJwtAuthenticatorIsInsecure(t *testing.T) {
 	// WHEN & THEN
 	require.False(t, auth.IsInsecure())
 }
+
+func TestJwtAuthenticatorCalculateCacheKeyWithDefaultAndExplicitTTL(t *testing.T) {
+	t.Parallel()
+
+	// GIVEN
+	ep := &endpoint.Endpoint{URL: "https://example.com/.well-known/jwks.json"}
+
+	withDefaultTTL := &jwtAuthenticator{}
+	withExplicitTTL := &jwtAuthenticator{ttl: new(5 * time.Second)}
+
+	// WHEN
+	key1 := withDefaultTTL.calculateCacheKey(ep, ep.URL, "kid")
+	key2 := withExplicitTTL.calculateCacheKey(ep, ep.URL, "kid")
+
+	// THEN
+	assert.NotEqual(t, key1, key2)
+}

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"io"
@@ -505,11 +506,24 @@ func (a *oauth2IntrospectionAuthenticator) getCacheTTL(introspectResp *oauth2.In
 	}
 }
 
-func (a *oauth2IntrospectionAuthenticator) calculateCacheKey(ep *endpoint.Endpoint, templatedURL, token string) string {
+func (a *oauth2IntrospectionAuthenticator) calculateCacheKey(
+	ep *endpoint.Endpoint,
+	templatedURL, token string,
+) string {
 	digest := sha256.New()
 	digest.Write(ep.Hash())
 	digest.Write(stringx.ToBytes(templatedURL))
 	digest.Write(stringx.ToBytes(token))
+
+	if a.ttl == nil {
+		digest.Write([]byte{0})
+	} else {
+		digest.Write([]byte{1})
+
+		var ttl [8]byte
+		binary.BigEndian.PutUint64(ttl[:], uint64(*a.ttl)) //nolint:gosec
+		digest.Write(ttl[:])
+	}
 
 	var result [sha256.Size]byte
 

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
@@ -2185,3 +2185,22 @@ func TestOauth2IntrospectionAuthenticatorIsInsecure(t *testing.T) {
 	// WHEN & THEN
 	require.False(t, auth.IsInsecure())
 }
+
+func TestOAuth2IntrospectionAuthenticatorCalculateCacheKey(t *testing.T) {
+	t.Parallel()
+
+	// GIVEN
+	ep := &endpoint.Endpoint{
+		URL: "https://example.com/introspect",
+	}
+
+	a1 := &oauth2IntrospectionAuthenticator{ttl: new(5 * time.Second)}
+	a2 := &oauth2IntrospectionAuthenticator{ttl: new(15 * time.Second)}
+
+	// WHEN
+	key1 := a1.calculateCacheKey(ep, ep.URL, "token")
+	key2 := a2.calculateCacheKey(ep, ep.URL, "token")
+
+	// THEN
+	assert.NotEqual(t, key1, key2)
+}

--- a/internal/rules/oauth2/clientcredentials/clientcredentials.go
+++ b/internal/rules/oauth2/clientcredentials/clientcredentials.go
@@ -19,6 +19,7 @@ package clientcredentials
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"io"
 	"net/http"
@@ -128,6 +129,16 @@ func (c *Config) calculateCacheKey() string {
 	digest.Write(stringx.ToBytes(c.ClientSecret))
 	digest.Write(stringx.ToBytes(c.TokenURL))
 	digest.Write(stringx.ToBytes(strings.Join(c.Scopes, "")))
+
+	if c.TTL == nil {
+		digest.Write([]byte{0})
+	} else {
+		digest.Write([]byte{1})
+
+		var ttl [8]byte
+		binary.BigEndian.PutUint64(ttl[:], uint64(*c.TTL)) //nolint:gosec
+		digest.Write(ttl[:])
+	}
 
 	var result [sha256.Size]byte
 

--- a/internal/rules/oauth2/clientcredentials/clientcredentials_test.go
+++ b/internal/rules/oauth2/clientcredentials/clientcredentials_test.go
@@ -611,3 +611,29 @@ func TestClientCredentialsHash(t *testing.T) {
 	assert.NotEmpty(t, hash2)
 	assert.NotEqual(t, hash1, hash2)
 }
+
+func TestClientCredentialsCalculateCacheKey(t *testing.T) {
+	t.Parallel()
+
+	// GIVEN
+	c1 := &Config{
+		TokenURL:     "https://example.com/token",
+		ClientID:     "client",
+		ClientSecret: "secret",
+		TTL:          new(5 * time.Second),
+	}
+
+	c2 := &Config{
+		TokenURL:     "https://example.com/token",
+		ClientID:     "client",
+		ClientSecret: "secret",
+		TTL:          new(15 * time.Second),
+	}
+
+	// WHEN
+	key1 := c1.calculateCacheKey()
+	key2 := c2.calculateCacheKey()
+
+	// THEN
+	assert.NotEqual(t, key1, key2)
+}


### PR DESCRIPTION
## Related issue(s)

closes #3445
closes #3446

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description



This PR fixes the referenced issues by taking the rule-level cache_ttl configuration into account when calculating cache keys of the `oauth2_introspection` and `jwt` authenticators. This ensures that rule-level TTL overrides result in independently expiring cache entries.

While addressing the issues, the same behavior was identified in the `generic` authenticator and the `oauth2_client_credentials` finalizer and has been fixed there as well.

`generic` contextualizers and `remote` authorizers were already taking the effective cache TTL into account and required no changes.

---
BEGIN_COMMIT_OVERRIDE
fix: OAuth2 introspection authenticator respects rule-level cache TTL overrides (#3447)
fix: JWT authenticator respects rule-level cache TTL overrides (#3447)
fix: Generic authenticator respects rule-level cache TTL overrides (#3447)
fix: OAuth2 client credentials finalizer respects rule-level cache TTL overrides (#3447)
END_COMMIT_OVERRIDE