### PR TITLE
fix: Apply remote authorizer expressions to cached responses

### DIFF
--- a/internal/rules/mechanisms/authorizers/remote_authorizer.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer.go
@@ -163,6 +163,7 @@ func newRemoteAuthorizer(app app.Context, name string, rawConfig map[string]any)
 	}, nil
 }
 
+//nolint:cyclop
 func (a *remoteAuthorizer) Execute(ctx heimdall.RequestContext, sub *subject.Subject) error {
 	logger := zerolog.Ctx(ctx.Context())
 	logger.Debug().
@@ -176,6 +177,7 @@ func (a *remoteAuthorizer) Execute(ctx heimdall.RequestContext, sub *subject.Sub
 	var (
 		cacheKey string
 		authInfo *authorizationInformation
+		fetched  bool
 	)
 
 	vals, payload, err := a.renderTemplates(ctx, sub)
@@ -185,6 +187,7 @@ func (a *remoteAuthorizer) Execute(ctx heimdall.RequestContext, sub *subject.Sub
 
 	if a.ttl > 0 {
 		cacheKey = a.calculateCacheKey(sub, vals, payload)
+
 		if entry, err := cch.Get(ctx.Context(), cacheKey); err == nil {
 			var ai authorizationInformation
 
@@ -197,17 +200,23 @@ func (a *remoteAuthorizer) Execute(ctx heimdall.RequestContext, sub *subject.Sub
 	}
 
 	if authInfo == nil {
-		authInfo, err = a.doAuthorize(ctx, sub, vals, payload)
+		authInfo, err = a.fetchAuthorizationInformation(ctx, sub, vals, payload)
 		if err != nil {
 			return err
 		}
 
-		if a.ttl > 0 && len(cacheKey) != 0 {
-			data, _ := json.Marshal(authInfo)
+		fetched = true
+	}
 
-			if err = cch.Set(ctx.Context(), cacheKey, data, a.ttl); err != nil {
-				logger.Warn().Err(err).Msg("Failed to cache authorization information")
-			}
+	if err = a.verify(ctx, authInfo.Payload); err != nil {
+		return err
+	}
+
+	if fetched && a.ttl > 0 && len(cacheKey) != 0 {
+		data, _ := json.Marshal(authInfo)
+
+		if err = cch.Set(ctx.Context(), cacheKey, data, a.ttl); err != nil {
+			logger.Warn().Err(err).Msg("Failed to cache authorization information")
 		}
 	}
 
@@ -278,7 +287,7 @@ func (a *remoteAuthorizer) ID() string { return a.id }
 
 func (a *remoteAuthorizer) ContinueOnError() bool { return false }
 
-func (a *remoteAuthorizer) doAuthorize(
+func (a *remoteAuthorizer) fetchAuthorizationInformation(
 	ctx heimdall.RequestContext,
 	sub *subject.Subject,
 	values map[string]string,
@@ -330,11 +339,6 @@ func (a *remoteAuthorizer) doAuthorize(
 
 	data, err := a.readResponse(ctx, resp)
 	if err != nil && !errors.Is(err, errNoContent) {
-		return nil, err
-	}
-
-	err = a.verify(ctx, data)
-	if err != nil {
 		return nil, err
 	}
 

--- a/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
@@ -1276,6 +1276,75 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 				assert.Equal(t, "authorizer", identifier.ID())
 			},
 		},
+		"failed with positive cache hit due to authorization expression": {
+			authorizer: &remoteAuthorizer{
+				id: "authz",
+				e: endpoint.Endpoint{
+					URL: srv.URL,
+				},
+				expressions: func() []*cellib.CompiledExpression {
+					exp, err := cellib.CompileExpression(
+						env,
+						"Payload.role == 'admin'",
+						"admin role required",
+					)
+					require.NoError(t, err)
+
+					return []*cellib.CompiledExpression{exp}
+				}(),
+				ttl: 20 * time.Second,
+			},
+			subject: &subject.Subject{
+				ID:         "my-id",
+				Attributes: map[string]any{},
+			},
+			configureContext: func(t *testing.T, ctx *heimdallmocks.RequestContextMock) {
+				t.Helper()
+
+				ctx.EXPECT().Request().Return(nil)
+			},
+			configureCache: func(
+				t *testing.T,
+				cch *mocks.CacheMock,
+				auth *remoteAuthorizer,
+				sub *subject.Subject,
+			) {
+				t.Helper()
+
+				rawInfo, err := json.Marshal(authorizationInformation{
+					Payload: map[string]any{
+						"role": "user",
+					},
+				})
+				require.NoError(t, err)
+
+				cacheKey := auth.calculateCacheKey(sub, nil, "")
+
+				cch.EXPECT().Get(mock.Anything, cacheKey).Return(rawInfo, nil)
+			},
+			assert: func(
+				t *testing.T,
+				err error,
+				_ *subject.Subject,
+				outputs map[string]any,
+				results heimdall.Results,
+			) {
+				t.Helper()
+
+				assert.False(t, authorizationEndpointCalled)
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, heimdall.ErrAuthorization)
+				require.ErrorContains(t, err, "admin role required")
+
+				var identifier interface{ ID() string }
+				require.ErrorAs(t, err, &identifier)
+				assert.Equal(t, "authz", identifier.ID())
+
+				assert.NotContains(t, outputs, "authz")
+				assert.NotContains(t, results, "authz")
+			},
+		},
 	} {
 		t.Run(uc, func(t *testing.T) {
 			// GIVEN


### PR DESCRIPTION
## Related issue(s)

closes #3450 

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

This PR fixes the referenced issue.
