### PR TITLE
fix: Apply OAuth2 introspection assertions to cached responses

### DIFF
--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
@@ -309,6 +309,7 @@ func (a *oauth2IntrospectionAuthenticator) extractTokenClaims(token string) (map
 	return nil, err
 }
 
+//nolint:cyclop
 func (a *oauth2IntrospectionAuthenticator) getSubjectInformation(
 	ctx heimdall.RequestContext,
 	token string,
@@ -316,7 +317,12 @@ func (a *oauth2IntrospectionAuthenticator) getSubjectInformation(
 	cch := cache.Ctx(ctx.Context())
 	logger := zerolog.Ctx(ctx.Context())
 
-	var cacheKey string
+	var (
+		cacheKey       string
+		introspectResp *oauth2.IntrospectionResponse
+		rawResp        []byte
+		fetched        bool
+	)
 
 	claims, err := a.extractTokenClaims(token)
 	if err != nil {
@@ -335,20 +341,30 @@ func (a *oauth2IntrospectionAuthenticator) getSubjectInformation(
 
 	if a.isCacheEnabled() {
 		cacheKey = a.calculateCacheKey(metadata.IntrospectionEndpoint, req.URL.String(), token)
-		if entry, err := cch.Get(ctx.Context(), cacheKey); err == nil {
-			logger.Debug().Msg("Reusing introspection response from cache")
 
-			return entry, nil
+		if entry, err := cch.Get(ctx.Context(), cacheKey); err == nil {
+			var response oauth2.IntrospectionResponse
+
+			if err = json.Unmarshal(entry, &response); err == nil {
+				logger.Debug().Msg("Reusing introspection response from cache")
+
+				introspectResp = &response
+				rawResp = entry
+			}
 		}
 	}
 
-	introspectResp, rawResp, err := a.fetchTokenIntrospectionResponse(
-		ctx,
-		metadata.IntrospectionEndpoint.CreateClient(req.URL.Hostname()),
-		req,
-	)
-	if err != nil {
-		return nil, err
+	if introspectResp == nil {
+		introspectResp, rawResp, err = a.fetchTokenIntrospectionResponse(
+			ctx,
+			metadata.IntrospectionEndpoint.CreateClient(req.URL.Hostname()),
+			req,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		fetched = true
 	}
 
 	// verification of the issuer is optional according to RFC 7662. The below implementation
@@ -366,9 +382,11 @@ func (a *oauth2IntrospectionAuthenticator) getSubjectInformation(
 			CausedBy(err)
 	}
 
-	if cacheTTL := a.getCacheTTL(introspectResp); cacheTTL > 0 {
-		if err = cch.Set(ctx.Context(), cacheKey, rawResp, cacheTTL); err != nil {
-			logger.Warn().Err(err).Msg("Failed to cache introspection response")
+	if fetched {
+		if cacheTTL := a.getCacheTTL(introspectResp); cacheTTL > 0 {
+			if err = cch.Set(ctx.Context(), cacheKey, rawResp, cacheTTL); err != nil {
+				logger.Warn().Err(err).Msg("Failed to cache introspection response")
+			}
 		}
 	}
 

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
@@ -1943,6 +1943,72 @@ func TestOauth2IntrospectionAuthenticatorExecute(t *testing.T) {
 				assert.NotEmpty(t, sub.Attributes["exp"])
 			},
 		},
+		"with default cache, with cache hit and failing scope assertion": {
+			authenticator: &oauth2IntrospectionAuthenticator{
+				id: "auth3",
+				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+					return oauth2.ServerMetadata{
+						IntrospectionEndpoint: &endpoint.Endpoint{
+							URL:    srv.URL,
+							Method: http.MethodPost,
+							Headers: map[string]string{
+								"Content-Type": "application/x-www-form-urlencoded",
+								"Accept":       "application/json",
+							},
+						},
+					}, nil
+				}),
+				a: oauth2.Expectation{
+					TrustedIssuers: []string{"foobar"},
+					ScopesMatcher:  oauth2.ExactScopeStrategyMatcher{"write"},
+				},
+				sf: &SubjectInfo{IDFrom: "sub"},
+			},
+			configureMocks: func(t *testing.T,
+				ctx *heimdallmocks.RequestContextMock,
+				cch *mocks.CacheMock,
+				ads *mocks2.AuthDataExtractStrategyMock,
+				_ *oauth2IntrospectionAuthenticator,
+			) {
+				t.Helper()
+
+				ads.EXPECT().GetAuthData(ctx).Return("test_access_token", nil)
+
+				rawIntrospectResponse, err := json.Marshal(map[string]any{
+					"active":     true,
+					"scope":      "read",
+					"username":   "unknown",
+					"token_type": "Bearer",
+					"aud":        "bar",
+					"sub":        "foo",
+					"iss":        "foobar",
+					"iat":        time.Now().Unix(),
+					"nbf":        time.Now().Unix(),
+					"exp":        time.Now().Unix() + 30,
+				})
+				require.NoError(t, err)
+
+				cch.EXPECT().
+					Get(mock.Anything, mock.Anything).
+					Return(rawIntrospectResponse, nil)
+			},
+			assert: func(t *testing.T, err error, sub *subject.Subject) {
+				t.Helper()
+
+				assert.False(t, introspectionEndpointCalled)
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, heimdall.ErrAuthentication)
+				require.ErrorContains(t, err, "assertion conditions")
+				require.ErrorContains(t, err, "required scope write is missing")
+
+				var identifier HandlerIdentifier
+				require.ErrorAs(t, err, &identifier)
+				assert.Equal(t, "auth3", identifier.ID())
+
+				assert.Nil(t, sub)
+			},
+		},
 	} {
 		t.Run(uc, func(t *testing.T) {
 			// GIVEN


### PR DESCRIPTION
## Related issue(s)

closes #3452 

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

This PR fixes the referenced issue.
