### PR TITLE
fix: Consider forwarded values in generic authenticator cache keys

### DIFF
--- a/internal/rules/mechanisms/authenticators/generic_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/generic_authenticator.go
@@ -401,9 +401,14 @@ func (a *genericAuthenticator) calculateCacheKey(ctx heimdall.RequestContext, re
 	if len(a.fwdHeaders) != 0 || len(a.fwdCookies) != 0 {
 		req := ctx.Request()
 
-		var separator [1]byte
+		var (
+			headerKind = [1]byte{0x01}
+			cookieKind = [1]byte{0x02}
+			separator  = [1]byte{0x00}
+		)
 
 		for _, headerName := range a.fwdHeaders {
+			digest.Write(headerKind[:])
 			digest.Write(stringx.ToBytes(headerName))
 			digest.Write(separator[:])
 			digest.Write(stringx.ToBytes(req.Header(headerName)))
@@ -411,6 +416,7 @@ func (a *genericAuthenticator) calculateCacheKey(ctx heimdall.RequestContext, re
 		}
 
 		for _, cookieName := range a.fwdCookies {
+			digest.Write(cookieKind[:])
 			digest.Write(stringx.ToBytes(cookieName))
 			digest.Write(separator[:])
 			digest.Write(stringx.ToBytes(req.Cookie(cookieName)))

--- a/internal/rules/mechanisms/authenticators/generic_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/generic_authenticator.go
@@ -224,7 +224,7 @@ func (a *genericAuthenticator) getSubjectInformation(ctx heimdall.RequestContext
 	)
 
 	if a.ttl > 0 {
-		cacheKey = a.calculateCacheKey(authData)
+		cacheKey = a.calculateCacheKey(ctx, authData)
 		if entry, err := cch.Get(ctx.Context(), cacheKey); err == nil {
 			logger.Debug().Msg("Reusing subject information from cache")
 
@@ -393,10 +393,30 @@ func (a *genericAuthenticator) getCacheTTL(sessionLifespan *SessionLifespan) tim
 	return a.ttl
 }
 
-func (a *genericAuthenticator) calculateCacheKey(reference string) string {
+func (a *genericAuthenticator) calculateCacheKey(ctx heimdall.RequestContext, reference string) string {
 	digest := sha256.New()
 	digest.Write(a.e.Hash())
 	digest.Write(stringx.ToBytes(reference))
+
+	if len(a.fwdHeaders) != 0 || len(a.fwdCookies) != 0 {
+		req := ctx.Request()
+
+		var separator [1]byte
+
+		for _, headerName := range a.fwdHeaders {
+			digest.Write(stringx.ToBytes(headerName))
+			digest.Write(separator[:])
+			digest.Write(stringx.ToBytes(req.Header(headerName)))
+			digest.Write(separator[:])
+		}
+
+		for _, cookieName := range a.fwdCookies {
+			digest.Write(stringx.ToBytes(cookieName))
+			digest.Write(separator[:])
+			digest.Write(stringx.ToBytes(req.Cookie(cookieName)))
+			digest.Write(separator[:])
+		}
+	}
 
 	var ttl [8]byte
 	binary.BigEndian.PutUint64(ttl[:], uint64(a.ttl)) //nolint:gosec

--- a/internal/rules/mechanisms/authenticators/generic_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/generic_authenticator_test.go
@@ -1567,6 +1567,20 @@ func TestGenericAuthenticatorCalculateCacheKey(t *testing.T) {
 			cookies1: map[string]string{"tenant": "foo"},
 			cookies2: map[string]string{"organization": "foo"},
 		},
+		"different forwarded value type": {
+			authenticator1: &genericAuthenticator{
+				e:          ep,
+				fwdHeaders: []string{"tenant"},
+				ttl:        5 * time.Second,
+			},
+			authenticator2: &genericAuthenticator{
+				e:          ep,
+				fwdCookies: []string{"tenant"},
+				ttl:        5 * time.Second,
+			},
+			headers1: map[string]string{"tenant": "foo"},
+			cookies2: map[string]string{"tenant": "foo"},
+		},
 	} {
 		t.Run(uc, func(t *testing.T) {
 			// GIVEN

--- a/internal/rules/mechanisms/authenticators/generic_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/generic_authenticator_test.go
@@ -1469,25 +1469,165 @@ func TestGenericAuthenticatorReadResponse(t *testing.T) {
 func TestGenericAuthenticatorCalculateCacheKey(t *testing.T) {
 	t.Parallel()
 
-	// GIVEN
 	ep := endpoint.Endpoint{
 		URL: "https://example.com/identity",
 	}
 
-	a1 := &genericAuthenticator{
-		e:   ep,
-		ttl: 5 * time.Second,
+	for uc, tc := range map[string]struct {
+		authenticator1 *genericAuthenticator
+		authenticator2 *genericAuthenticator
+		headers1       map[string]string
+		headers2       map[string]string
+		cookies1       map[string]string
+		cookies2       map[string]string
+		expectEqual    bool
+	}{
+		"same configuration and request": {
+			authenticator1: &genericAuthenticator{
+				e:          ep,
+				fwdHeaders: []string{"X-Tenant-ID"},
+				fwdCookies: []string{"tenant"},
+				ttl:        5 * time.Second,
+			},
+			authenticator2: &genericAuthenticator{
+				e:          ep,
+				fwdHeaders: []string{"X-Tenant-ID"},
+				fwdCookies: []string{"tenant"},
+				ttl:        5 * time.Second,
+			},
+			headers1:    map[string]string{"X-Tenant-ID": "tenant-a"},
+			headers2:    map[string]string{"X-Tenant-ID": "tenant-a"},
+			cookies1:    map[string]string{"tenant": "tenant-a"},
+			cookies2:    map[string]string{"tenant": "tenant-a"},
+			expectEqual: true,
+		},
+		"different cache ttl": {
+			authenticator1: &genericAuthenticator{
+				e:   ep,
+				ttl: 5 * time.Second,
+			},
+			authenticator2: &genericAuthenticator{
+				e:   ep,
+				ttl: 15 * time.Second,
+			},
+		},
+		"different forwarded header value": {
+			authenticator1: &genericAuthenticator{
+				e:          ep,
+				fwdHeaders: []string{"X-Tenant-ID"},
+				ttl:        5 * time.Second,
+			},
+			authenticator2: &genericAuthenticator{
+				e:          ep,
+				fwdHeaders: []string{"X-Tenant-ID"},
+				ttl:        5 * time.Second,
+			},
+			headers1: map[string]string{"X-Tenant-ID": "tenant-a"},
+			headers2: map[string]string{"X-Tenant-ID": "tenant-b"},
+		},
+		"different forwarded header name": {
+			authenticator1: &genericAuthenticator{
+				e:          ep,
+				fwdHeaders: []string{"X-Tenant-ID"},
+				ttl:        5 * time.Second,
+			},
+			authenticator2: &genericAuthenticator{
+				e:          ep,
+				fwdHeaders: []string{"X-Organization-ID"},
+				ttl:        5 * time.Second,
+			},
+			headers1: map[string]string{"X-Tenant-ID": "foo"},
+			headers2: map[string]string{"X-Organization-ID": "foo"},
+		},
+		"different forwarded cookie value": {
+			authenticator1: &genericAuthenticator{
+				e:          ep,
+				fwdCookies: []string{"tenant"},
+				ttl:        5 * time.Second,
+			},
+			authenticator2: &genericAuthenticator{
+				e:          ep,
+				fwdCookies: []string{"tenant"},
+				ttl:        5 * time.Second,
+			},
+			cookies1: map[string]string{"tenant": "tenant-a"},
+			cookies2: map[string]string{"tenant": "tenant-b"},
+		},
+		"different forwarded cookie name": {
+			authenticator1: &genericAuthenticator{
+				e:          ep,
+				fwdCookies: []string{"tenant"},
+				ttl:        5 * time.Second,
+			},
+			authenticator2: &genericAuthenticator{
+				e:          ep,
+				fwdCookies: []string{"organization"},
+				ttl:        5 * time.Second,
+			},
+			cookies1: map[string]string{"tenant": "foo"},
+			cookies2: map[string]string{"organization": "foo"},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			// GIVEN
+			ctx1 := heimdallmocks.NewRequestContextMock(t)
+
+			if len(tc.authenticator1.fwdHeaders) != 0 || len(tc.authenticator1.fwdCookies) != 0 {
+				reqFuns1 := heimdallmocks.NewRequestFunctionsMock(t)
+
+				for _, headerName := range tc.authenticator1.fwdHeaders {
+					reqFuns1.EXPECT().
+						Header(headerName).
+						Return(tc.headers1[headerName])
+				}
+
+				for _, cookieName := range tc.authenticator1.fwdCookies {
+					reqFuns1.EXPECT().
+						Cookie(cookieName).
+						Return(tc.cookies1[cookieName])
+				}
+
+				ctx1.EXPECT().
+					Request().
+					Return(&heimdall.Request{
+						RequestFunctions: reqFuns1,
+					})
+			}
+
+			ctx2 := heimdallmocks.NewRequestContextMock(t)
+
+			if len(tc.authenticator2.fwdHeaders) != 0 || len(tc.authenticator2.fwdCookies) != 0 {
+				reqFuns2 := heimdallmocks.NewRequestFunctionsMock(t)
+
+				for _, headerName := range tc.authenticator2.fwdHeaders {
+					reqFuns2.EXPECT().
+						Header(headerName).
+						Return(tc.headers2[headerName])
+				}
+
+				for _, cookieName := range tc.authenticator2.fwdCookies {
+					reqFuns2.EXPECT().
+						Cookie(cookieName).
+						Return(tc.cookies2[cookieName])
+				}
+
+				ctx2.EXPECT().
+					Request().
+					Return(&heimdall.Request{
+						RequestFunctions: reqFuns2,
+					})
+			}
+
+			// WHEN
+			key1 := tc.authenticator1.calculateCacheKey(ctx1, "authentication-data")
+			key2 := tc.authenticator2.calculateCacheKey(ctx2, "authentication-data")
+
+			// THEN
+			if tc.expectEqual {
+				assert.Equal(t, key1, key2)
+			} else {
+				assert.NotEqual(t, key1, key2)
+			}
+		})
 	}
-
-	a2 := &genericAuthenticator{
-		e:   ep,
-		ttl: 15 * time.Second,
-	}
-
-	// WHEN
-	key1 := a1.calculateCacheKey("authentication-data")
-	key2 := a2.calculateCacheKey("authentication-data")
-
-	// THEN
-	assert.NotEqual(t, key1, key2)
 }


### PR DESCRIPTION
## Related issue(s)

closes #3454

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

This PR fixes the issue referenced above. The cache key now also takes the configured forwarded header and cookie names together with their effective values into account.
