### PR TITLE
refactor: Apply endpoint authentication in the HTTP transport

### DIFF
--- a/internal/rules/endpoint/authentication_round_tripper.go
+++ b/internal/rules/endpoint/authentication_round_tripper.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package endpoint
+
+import (
+	"net/http"
+
+	"github.com/rs/zerolog"
+
+	"github.com/dadrus/heimdall/internal/heimdall"
+	"github.com/dadrus/heimdall/internal/x/errorchain"
+)
+
+type authenticationRoundTripper struct {
+	next     http.RoundTripper
+	strategy AuthenticationStrategy
+}
+
+func (rt *authenticationRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	zerolog.Ctx(req.Context()).Debug().Msg("Authenticating request")
+
+	authenticated := *req
+
+	if err := rt.strategy.Apply(&authenticated); err != nil {
+		return nil, errorchain.
+			NewWithMessage(heimdall.ErrInternal, "failed to authenticate request").
+			CausedBy(err)
+	}
+
+	return rt.next.RoundTrip(&authenticated)
+}

--- a/internal/rules/endpoint/authentication_round_tripper_benchmark_test.go
+++ b/internal/rules/endpoint/authentication_round_tripper_benchmark_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package endpoint
+
+import (
+	"net/http"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func BenchmarkRequestCopy(b *testing.B) {
+	for _, tc := range []struct {
+		name      string
+		populated bool
+	}{
+		{
+			name: "minimal",
+		},
+		{
+			name:      "populated",
+			populated: true,
+		},
+	} {
+		b.Run("shallow/"+tc.name, func(b *testing.B) {
+			req := newRequestCopyBenchmarkRequest(b, tc.populated)
+
+			var result http.Request
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				result = *req
+			}
+
+			runtime.KeepAlive(result)
+		})
+
+		b.Run("clone/"+tc.name, func(b *testing.B) {
+			req := newRequestCopyBenchmarkRequest(b, tc.populated)
+
+			var result *http.Request
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				result = req.Clone(req.Context())
+			}
+
+			runtime.KeepAlive(result)
+		})
+	}
+}
+
+func newRequestCopyBenchmarkRequest(
+	b *testing.B,
+	populated bool,
+) *http.Request {
+	b.Helper()
+
+	req, err := http.NewRequestWithContext(
+		b.Context(),
+		http.MethodPost,
+		"https://example.com/resource?foo=bar&bar=baz&tenant=tenant-a",
+		strings.NewReader(`{"foo":"bar","tenant":"tenant-a"}`),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	if populated {
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("User-Agent", "heimdall")
+		req.Header.Set("X-Request-ID", "01K2E7T0W5M8ZKQKRQZQ4Y5KQZ")
+		req.Header.Set("X-Tenant-ID", "tenant-a")
+		req.Header.Set(
+			"Traceparent",
+			"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		)
+		req.Header.Add("X-Forwarded-For", "10.0.0.1")
+		req.Header.Add("X-Forwarded-For", "10.0.0.2")
+		req.Header.Set("Cookie", "session=foobar; locale=en")
+	}
+
+	return req
+}

--- a/internal/rules/endpoint/authentication_round_tripper_test.go
+++ b/internal/rules/endpoint/authentication_round_tripper_test.go
@@ -1,0 +1,149 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package endpoint
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dadrus/heimdall/internal/heimdall"
+	"github.com/dadrus/heimdall/internal/rules/endpoint/mocks"
+	httpxmocks "github.com/dadrus/heimdall/internal/x/httpx/mocks"
+)
+
+func TestAuthenticationRoundTripperRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		configureStrategy func(t *testing.T, strategy *mocks.AuthenticationStrategyMock)
+		configureNext     func(t *testing.T, next *httpxmocks.RoundTripperMock, req *http.Request)
+		assert            func(t *testing.T, response *http.Response, err error, req *http.Request)
+	}{
+		"successful": {
+			configureStrategy: func(t *testing.T, strategy *mocks.AuthenticationStrategyMock) {
+				t.Helper()
+
+				strategy.EXPECT().
+					Apply(mock.MatchedBy(func(req *http.Request) bool {
+						req.Method = http.MethodPatch
+
+						return true
+					})).
+					Return(nil)
+			},
+			configureNext: func(t *testing.T, next *httpxmocks.RoundTripperMock, req *http.Request) {
+				t.Helper()
+
+				next.EXPECT().
+					RoundTrip(mock.MatchedBy(func(actual *http.Request) bool {
+						assert.NotSame(t, req, actual)
+						assert.Equal(t, http.MethodPatch, actual.Method)
+						assert.Equal(t, req.Context(), actual.Context())
+
+						return true
+					})).
+					Return(&http.Response{StatusCode: http.StatusOK}, nil)
+			},
+			assert: func(t *testing.T, response *http.Response, err error, req *http.Request) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.NotNil(t, response)
+				assert.Equal(t, http.StatusOK, response.StatusCode)
+
+				// Applying authentication to the shallow copy must not modify
+				// fields stored directly on the original request.
+				assert.Equal(t, http.MethodGet, req.Method)
+			},
+		},
+		"failed authentication": {
+			configureStrategy: func(t *testing.T, strategy *mocks.AuthenticationStrategyMock) {
+				t.Helper()
+
+				strategy.EXPECT().
+					Apply(mock.Anything).
+					Return(errors.New("test error"))
+			},
+			assert: func(t *testing.T, response *http.Response, err error, _ *http.Request) {
+				t.Helper()
+
+				assert.Nil(t, response)
+				require.Error(t, err)
+				require.ErrorIs(t, err, heimdall.ErrInternal)
+				require.ErrorContains(t, err, "failed to authenticate request")
+				require.ErrorContains(t, err, "test error")
+			},
+		},
+		"failed round trip": {
+			configureStrategy: func(t *testing.T, strategy *mocks.AuthenticationStrategyMock) {
+				t.Helper()
+
+				strategy.EXPECT().
+					Apply(mock.Anything).
+					Return(nil)
+			},
+			configureNext: func(t *testing.T, next *httpxmocks.RoundTripperMock, _ *http.Request) {
+				t.Helper()
+
+				next.EXPECT().
+					RoundTrip(mock.Anything).
+					Return(nil, errors.New("test error"))
+			},
+			assert: func(t *testing.T, response *http.Response, err error, _ *http.Request) {
+				t.Helper()
+
+				assert.Nil(t, response)
+				require.EqualError(t, err, "test error")
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			// GIVEN
+			req, err := http.NewRequestWithContext(
+				t.Context(),
+				http.MethodGet,
+				"https://example.com",
+				nil,
+			)
+			require.NoError(t, err)
+
+			strategy := mocks.NewAuthenticationStrategyMock(t)
+			tc.configureStrategy(t, strategy)
+
+			next := httpxmocks.NewRoundTripperMock(t)
+			if tc.configureNext != nil {
+				tc.configureNext(t, next, req)
+			}
+
+			rt := &authenticationRoundTripper{
+				next:     next,
+				strategy: strategy,
+			}
+
+			// WHEN
+			response, err := rt.RoundTrip(req) //nolint:bodyclose
+
+			// THEN
+			tc.assert(t, response, err, req)
+		})
+	}
+}

--- a/internal/rules/endpoint/authentication_strategy.go
+++ b/internal/rules/endpoint/authentication_strategy.go
@@ -17,13 +17,12 @@
 package endpoint
 
 import (
-	"context"
 	"net/http"
 )
 
 //go:generate mockery --name AuthenticationStrategy --structname AuthenticationStrategyMock
 
 type AuthenticationStrategy interface {
-	Apply(ctx context.Context, req *http.Request) error
+	Apply(req *http.Request) error
 	Hash() []byte
 }

--- a/internal/rules/endpoint/authstrategy/api_key.go
+++ b/internal/rules/endpoint/authstrategy/api_key.go
@@ -17,7 +17,6 @@
 package authstrategy
 
 import (
-	"context"
 	"crypto/sha256"
 	"net/http"
 
@@ -32,7 +31,7 @@ type APIKey struct {
 	Value string `mapstructure:"value" validate:"required"`
 }
 
-func (c *APIKey) Apply(_ context.Context, req *http.Request) error {
+func (c *APIKey) Apply(req *http.Request) error {
 	switch c.In {
 	case "cookie":
 		req.AddCookie(&http.Cookie{Name: c.Name, Value: c.Value})

--- a/internal/rules/endpoint/authstrategy/api_key.go
+++ b/internal/rules/endpoint/authstrategy/api_key.go
@@ -34,16 +34,27 @@ type APIKey struct {
 func (c *APIKey) Apply(req *http.Request) error {
 	switch c.In {
 	case "cookie":
+		req.Header = req.Header.Clone()
 		req.AddCookie(&http.Cookie{Name: c.Name, Value: c.Value})
+
 	case "header":
+		req.Header = req.Header.Clone()
 		req.Header.Set(c.Name, c.Value)
+
 	case "query":
+		targetURL := *req.URL
+		req.URL = &targetURL
+
 		query := req.URL.Query()
 		query.Set(c.Name, c.Value)
 		req.URL.RawQuery = query.Encode()
+
 	default:
-		return errorchain.NewWithMessagef(heimdall.ErrConfiguration,
-			"unsupported in value (%s) in api key auth strategy", c.In)
+		return errorchain.NewWithMessagef(
+			heimdall.ErrConfiguration,
+			"unsupported in value (%s) in api key auth strategy",
+			c.In,
+		)
 	}
 
 	return nil

--- a/internal/rules/endpoint/authstrategy/api_key_benchmark_test.go
+++ b/internal/rules/endpoint/authstrategy/api_key_benchmark_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package authstrategy
+
+import (
+	"context"
+	"runtime"
+	"testing"
+)
+
+func BenchmarkAPIKeyApply(b *testing.B) {
+	for _, tc := range []struct {
+		name             string
+		strategy         *APIKey
+		target           string
+		populatedHeaders bool
+	}{
+		{
+			name: "header/empty_headers",
+			strategy: &APIKey{
+				In:    "header",
+				Name:  "X-API-Key",
+				Value: "secret",
+			},
+			target: "https://example.com/resource",
+		},
+		{
+			name: "header/populated_headers",
+			strategy: &APIKey{
+				In:    "header",
+				Name:  "X-API-Key",
+				Value: "secret",
+			},
+			target:           "https://example.com/resource",
+			populatedHeaders: true,
+		},
+		{
+			name: "cookie/empty_headers",
+			strategy: &APIKey{
+				In:    "cookie",
+				Name:  "api-key",
+				Value: "secret",
+			},
+			target: "https://example.com/resource",
+		},
+		{
+			name: "cookie/populated_headers",
+			strategy: &APIKey{
+				In:    "cookie",
+				Name:  "api-key",
+				Value: "secret",
+			},
+			target:           "https://example.com/resource",
+			populatedHeaders: true,
+		},
+		{
+			name: "query/empty_query",
+			strategy: &APIKey{
+				In:    "query",
+				Name:  "api_key",
+				Value: "secret",
+			},
+			target: "https://example.com/resource",
+		},
+		{
+			name: "query/populated_query",
+			strategy: &APIKey{
+				In:    "query",
+				Name:  "api_key",
+				Value: "secret",
+			},
+			target: "https://example.com/resource?foo=bar&bar=baz&tenant=tenant-a",
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			base := newAuthStrategyBenchmarkRequest(
+				b,
+				context.Background(),
+				tc.target,
+				tc.populatedHeaders,
+				"",
+			)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				req := *base
+
+				if err := tc.strategy.Apply(&req); err != nil {
+					b.Fatal(err)
+				}
+
+				runtime.KeepAlive(req)
+			}
+		})
+	}
+}

--- a/internal/rules/endpoint/authstrategy/api_key_test.go
+++ b/internal/rules/endpoint/authstrategy/api_key_test.go
@@ -80,8 +80,10 @@ func TestApplyApiKeyStrategy(t *testing.T) {
 	} {
 		t.Run(uc, func(t *testing.T) {
 			// GIVEN
-			req := &http.Request{
-				Header: http.Header{},
+			original := &http.Request{
+				Header: http.Header{
+					"X-Test": []string{"test"},
+				},
 				URL: &url.URL{
 					Scheme:   "http",
 					Host:     "foo.bar",
@@ -90,11 +92,24 @@ func TestApplyApiKeyStrategy(t *testing.T) {
 				},
 			}
 
+			req := *original
+
 			// WHEN
-			err := tc.strategy.Apply(req)
+			err := tc.strategy.Apply(&req)
 
 			// THEN
-			tc.assert(t, err, req)
+			tc.assert(t, err, &req)
+
+			assert.Equal(t, "test", original.Header.Get("X-Test"))
+			assert.Empty(t, original.Header.Get("Foo"))
+
+			query := original.URL.Query()
+			assert.Len(t, query, 1)
+			assert.Equal(t, "foo", query.Get("bar"))
+			assert.Empty(t, query.Get("Foo"))
+
+			_, err = original.Cookie("Foo")
+			assert.ErrorIs(t, err, http.ErrNoCookie)
 		})
 	}
 }

--- a/internal/rules/endpoint/authstrategy/api_key_test.go
+++ b/internal/rules/endpoint/authstrategy/api_key_test.go
@@ -91,7 +91,7 @@ func TestApplyApiKeyStrategy(t *testing.T) {
 			}
 
 			// WHEN
-			err := tc.strategy.Apply(t.Context(), req)
+			err := tc.strategy.Apply(req)
 
 			// THEN
 			tc.assert(t, err, req)

--- a/internal/rules/endpoint/authstrategy/basic_auth.go
+++ b/internal/rules/endpoint/authstrategy/basic_auth.go
@@ -29,6 +29,7 @@ type BasicAuth struct {
 }
 
 func (c *BasicAuth) Apply(req *http.Request) error {
+	req.Header = req.Header.Clone()
 	req.SetBasicAuth(c.User, c.Password)
 
 	return nil

--- a/internal/rules/endpoint/authstrategy/basic_auth.go
+++ b/internal/rules/endpoint/authstrategy/basic_auth.go
@@ -17,7 +17,6 @@
 package authstrategy
 
 import (
-	"context"
 	"crypto/sha256"
 	"net/http"
 
@@ -29,7 +28,7 @@ type BasicAuth struct {
 	Password string `mapstructure:"password" validate:"required"`
 }
 
-func (c *BasicAuth) Apply(_ context.Context, req *http.Request) error {
+func (c *BasicAuth) Apply(req *http.Request) error {
 	req.SetBasicAuth(c.User, c.Password)
 
 	return nil

--- a/internal/rules/endpoint/authstrategy/basic_auth_benchmark_test.go
+++ b/internal/rules/endpoint/authstrategy/basic_auth_benchmark_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package authstrategy
+
+import (
+	"context"
+	"runtime"
+	"testing"
+)
+
+func BenchmarkBasicAuthApply(b *testing.B) {
+	for _, tc := range []struct {
+		name             string
+		populatedHeaders bool
+	}{
+		{
+			name: "empty_headers",
+		},
+		{
+			name:             "populated_headers",
+			populatedHeaders: true,
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			strategy := &BasicAuth{
+				User:     "client",
+				Password: "secret",
+			}
+
+			base := newAuthStrategyBenchmarkRequest(
+				b,
+				context.Background(),
+				"https://example.com/resource",
+				tc.populatedHeaders,
+				"",
+			)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				req := *base
+
+				if err := strategy.Apply(&req); err != nil {
+					b.Fatal(err)
+				}
+
+				runtime.KeepAlive(req)
+			}
+		})
+	}
+}

--- a/internal/rules/endpoint/authstrategy/basic_auth_test.go
+++ b/internal/rules/endpoint/authstrategy/basic_auth_test.go
@@ -36,7 +36,7 @@ func TestApplyBasicAuthStrategy(t *testing.T) {
 	s := BasicAuth{User: user, Password: password}
 
 	// WHEN
-	err := s.Apply(t.Context(), req)
+	err := s.Apply(req)
 
 	// THEN
 	require.NoError(t, err)

--- a/internal/rules/endpoint/authstrategy/basic_auth_test.go
+++ b/internal/rules/endpoint/authstrategy/basic_auth_test.go
@@ -32,15 +32,27 @@ func TestApplyBasicAuthStrategy(t *testing.T) {
 	user := "Foo"
 	password := "Bar"
 	expectedValue := "Basic " + base64.StdEncoding.EncodeToString([]byte(user+":"+password))
-	req := &http.Request{Header: http.Header{}}
+
+	original := &http.Request{
+		Header: http.Header{
+			"X-Test": []string{"foo"},
+		},
+	}
+
+	req := *original
 	s := BasicAuth{User: user, Password: password}
 
 	// WHEN
-	err := s.Apply(req)
+	err := s.Apply(&req)
 
 	// THEN
 	require.NoError(t, err)
+
 	assert.Equal(t, expectedValue, req.Header.Get("Authorization"))
+	assert.Equal(t, "foo", req.Header.Get("X-Test"))
+
+	assert.Empty(t, original.Header.Get("Authorization"))
+	assert.Equal(t, "foo", original.Header.Get("X-Test"))
 }
 
 func TestBasicAuthStrategyHash(t *testing.T) {

--- a/internal/rules/endpoint/authstrategy/client_credentials.go
+++ b/internal/rules/endpoint/authstrategy/client_credentials.go
@@ -17,7 +17,6 @@
 package authstrategy
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/rs/zerolog"
@@ -36,7 +35,9 @@ type OAuth2ClientCredentials struct {
 	Header *HeaderConfig `mapstructure:"header"`
 }
 
-func (c *OAuth2ClientCredentials) Apply(ctx context.Context, req *http.Request) error {
+func (c *OAuth2ClientCredentials) Apply(req *http.Request) error {
+	ctx := req.Context()
+
 	logger := zerolog.Ctx(ctx)
 	logger.Debug().Msg("Applying oauth2_client_credentials strategy to authenticate request")
 

--- a/internal/rules/endpoint/authstrategy/client_credentials.go
+++ b/internal/rules/endpoint/authstrategy/client_credentials.go
@@ -37,7 +37,6 @@ type OAuth2ClientCredentials struct {
 
 func (c *OAuth2ClientCredentials) Apply(req *http.Request) error {
 	ctx := req.Context()
-
 	logger := zerolog.Ctx(ctx)
 	logger.Debug().Msg("Applying oauth2_client_credentials strategy to authenticate request")
 
@@ -56,6 +55,7 @@ func (c *OAuth2ClientCredentials) Apply(req *http.Request) error {
 		headerScheme = c.Header.Scheme
 	}
 
+	req.Header = req.Header.Clone()
 	req.Header.Set(headerName, headerScheme+" "+token.AccessToken)
 
 	return nil

--- a/internal/rules/endpoint/authstrategy/client_credentials_benchmark_test.go
+++ b/internal/rules/endpoint/authstrategy/client_credentials_benchmark_test.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package authstrategy
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/goccy/go-json"
+
+	"github.com/dadrus/heimdall/internal/cache"
+	"github.com/dadrus/heimdall/internal/rules/oauth2/clientcredentials"
+)
+
+type clientCredentialsBenchmarkCache struct {
+	value []byte
+}
+
+func (*clientCredentialsBenchmarkCache) Start(context.Context) error {
+	return nil
+}
+
+func (*clientCredentialsBenchmarkCache) Stop(context.Context) error {
+	return nil
+}
+
+func (c *clientCredentialsBenchmarkCache) Get(context.Context, string) ([]byte, error) {
+	return c.value, nil
+}
+
+func (*clientCredentialsBenchmarkCache) Set(
+	context.Context,
+	string,
+	[]byte,
+	time.Duration,
+) error {
+	return nil
+}
+
+func BenchmarkOAuth2ClientCredentialsApply(b *testing.B) {
+	rawToken, err := json.Marshal(clientcredentials.TokenInfo{
+		AccessToken: "foobar",
+		TokenType:   "Bearer",
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	ctx := cache.WithContext(
+		context.Background(),
+		&clientCredentialsBenchmarkCache{value: rawToken},
+	)
+
+	for _, tc := range []struct {
+		name             string
+		strategy         *OAuth2ClientCredentials
+		populatedHeaders bool
+	}{
+		{
+			name: "default_header/empty_headers",
+			strategy: &OAuth2ClientCredentials{
+				Config: clientcredentials.Config{
+					TokenURL:     "https://issuer.example.com/token",
+					ClientID:     "client",
+					ClientSecret: "secret",
+					Scopes:       []string{"read", "write"},
+				},
+			},
+		},
+		{
+			name: "default_header/populated_headers",
+			strategy: &OAuth2ClientCredentials{
+				Config: clientcredentials.Config{
+					TokenURL:     "https://issuer.example.com/token",
+					ClientID:     "client",
+					ClientSecret: "secret",
+					Scopes:       []string{"read", "write"},
+				},
+			},
+			populatedHeaders: true,
+		},
+		{
+			name: "custom_header/empty_headers",
+			strategy: &OAuth2ClientCredentials{
+				Config: clientcredentials.Config{
+					TokenURL:     "https://issuer.example.com/token",
+					ClientID:     "client",
+					ClientSecret: "secret",
+					Scopes:       []string{"read", "write"},
+				},
+				Header: &HeaderConfig{
+					Name:   "X-Access-Token",
+					Scheme: "Token",
+				},
+			},
+		},
+		{
+			name: "custom_header/populated_headers",
+			strategy: &OAuth2ClientCredentials{
+				Config: clientcredentials.Config{
+					TokenURL:     "https://issuer.example.com/token",
+					ClientID:     "client",
+					ClientSecret: "secret",
+					Scopes:       []string{"read", "write"},
+				},
+				Header: &HeaderConfig{
+					Name:   "X-Access-Token",
+					Scheme: "Token",
+				},
+			},
+			populatedHeaders: true,
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			base := newAuthStrategyBenchmarkRequest(
+				b,
+				ctx,
+				"https://example.com/resource",
+				tc.populatedHeaders,
+				"",
+			)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				req := *base
+
+				if err := tc.strategy.Apply(&req); err != nil {
+					b.Fatal(err)
+				}
+
+				runtime.KeepAlive(req)
+			}
+		})
+	}
+}

--- a/internal/rules/endpoint/authstrategy/client_credentials_test.go
+++ b/internal/rules/endpoint/authstrategy/client_credentials_test.go
@@ -142,7 +142,10 @@ func TestApplyClientCredentialsStrategy(t *testing.T) {
 
 				assert.True(t, tokenEndpointCalled)
 				require.Error(t, err)
-				assert.Empty(t, req.Header)
+
+				assert.Equal(t, "foo", req.Header.Get("X-Existing"))
+				assert.Empty(t, req.Header.Get("Authorization"))
+				assert.Empty(t, req.Header.Get("X-My-Header"))
 			},
 		},
 		"full configuration, no cache hit and token has expires_in claim": {
@@ -218,14 +221,27 @@ func TestApplyClientCredentialsStrategy(t *testing.T) {
 
 			configureMocks(t, cch)
 
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
+			originalReq, err := http.NewRequestWithContext(
+				ctx,
+				http.MethodGet,
+				"https://example.com",
+				nil,
+			)
 			require.NoError(t, err)
 
+			originalReq.Header.Set("X-Existing", "foo")
+
+			req := *originalReq
+
 			// WHEN
-			err = tc.strategy.Apply(req)
+			err = tc.strategy.Apply(&req)
 
 			// THEN
-			tc.assert(t, err, endpointCalled, req)
+			tc.assert(t, err, endpointCalled, &req)
+
+			assert.Equal(t, "foo", originalReq.Header.Get("X-Existing"))
+			assert.Empty(t, originalReq.Header.Get("Authorization"))
+			assert.Empty(t, originalReq.Header.Get("X-My-Header"))
 		})
 	}
 }

--- a/internal/rules/endpoint/authstrategy/client_credentials_test.go
+++ b/internal/rules/endpoint/authstrategy/client_credentials_test.go
@@ -218,10 +218,11 @@ func TestApplyClientCredentialsStrategy(t *testing.T) {
 
 			configureMocks(t, cch)
 
-			req := &http.Request{Header: http.Header{}}
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://example.com", nil)
+			require.NoError(t, err)
 
 			// WHEN
-			err := tc.strategy.Apply(ctx, req)
+			err = tc.strategy.Apply(req)
 
 			// THEN
 			tc.assert(t, err, endpointCalled, req)

--- a/internal/rules/endpoint/authstrategy/common_benchmark_test.go
+++ b/internal/rules/endpoint/authstrategy/common_benchmark_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package authstrategy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const benchmarkRequestBody = `{"foo":"bar","tenant":"tenant-a"}`
+
+func newAuthStrategyBenchmarkRequest(
+	tb testing.TB,
+	ctx context.Context,
+	target string,
+	populatedHeaders bool,
+	body string,
+) *http.Request {
+	tb.Helper()
+
+	var bodyReader io.Reader
+	if len(body) != 0 {
+		bodyReader = strings.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		target,
+		bodyReader,
+	)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	if populatedHeaders {
+		populateAuthStrategyBenchmarkHeaders(req)
+	}
+
+	return req
+}
+
+func populateAuthStrategyBenchmarkHeaders(req *http.Request) {
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "heimdall")
+	req.Header.Set("X-Request-ID", "01K2E7T0W5M8ZKQKRQZQ4Y5KQZ")
+	req.Header.Set("X-Tenant-ID", "tenant-a")
+	req.Header.Set(
+		"Traceparent",
+		"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+	)
+	req.Header.Add("X-Forwarded-For", "10.0.0.1")
+	req.Header.Add("X-Forwarded-For", "10.0.0.2")
+	req.Header.Set("Cookie", "session=foobar; locale=en")
+}
+
+func BenchmarkHeaderCOW(b *testing.B) {
+	for _, tc := range []struct {
+		name             string
+		populatedHeaders bool
+	}{
+		{
+			name: "empty_headers",
+		},
+		{
+			name:             "populated_headers",
+			populatedHeaders: true,
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			base := newAuthStrategyBenchmarkRequest(
+				b,
+				context.Background(),
+				"https://example.com/resource?foo=bar&bar=baz&tenant=tenant-a",
+				tc.populatedHeaders,
+				benchmarkRequestBody,
+			)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				req := *base
+				req.Header = req.Header.Clone()
+
+				runtime.KeepAlive(req)
+			}
+		})
+	}
+}
+
+func BenchmarkURLCOW(b *testing.B) {
+	base := newAuthStrategyBenchmarkRequest(
+		b,
+		context.Background(),
+		"https://example.com/resource?foo=bar&bar=baz&tenant=tenant-a",
+		true,
+		benchmarkRequestBody,
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		req := *base
+		targetURL := *req.URL
+		req.URL = &targetURL
+
+		runtime.KeepAlive(req)
+	}
+}

--- a/internal/rules/endpoint/authstrategy/http_message_signatures.go
+++ b/internal/rules/endpoint/authstrategy/http_message_signatures.go
@@ -17,7 +17,6 @@
 package authstrategy
 
 import (
-	"context"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/binary"
@@ -78,7 +77,9 @@ func (s *HTTPMessageSignatures) OnChanged(logger zerolog.Logger) {
 	}
 }
 
-func (s *HTTPMessageSignatures) Apply(ctx context.Context, req *http.Request) error {
+func (s *HTTPMessageSignatures) Apply(req *http.Request) error {
+	ctx := req.Context()
+	
 	logger := zerolog.Ctx(ctx)
 	logger.Debug().Msg("Applying http_message_signatures strategy to authenticate request")
 

--- a/internal/rules/endpoint/authstrategy/http_message_signatures.go
+++ b/internal/rules/endpoint/authstrategy/http_message_signatures.go
@@ -79,7 +79,7 @@ func (s *HTTPMessageSignatures) OnChanged(logger zerolog.Logger) {
 
 func (s *HTTPMessageSignatures) Apply(req *http.Request) error {
 	ctx := req.Context()
-	
+
 	logger := zerolog.Ctx(ctx)
 	logger.Debug().Msg("Applying http_message_signatures strategy to authenticate request")
 

--- a/internal/rules/endpoint/authstrategy/http_message_signatures_benchmark_test.go
+++ b/internal/rules/endpoint/authstrategy/http_message_signatures_benchmark_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package authstrategy
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"runtime"
+	"testing"
+
+	"github.com/dadrus/httpsig"
+)
+
+func BenchmarkHTTPMessageSignaturesApply(b *testing.B) {
+	for _, tc := range []struct {
+		name             string
+		components       []string
+		populatedHeaders bool
+		body             string
+	}{
+		{
+			name:       "derived_component",
+			components: []string{"@method"},
+		},
+		{
+			name: "header_components",
+			components: []string{
+				"@method",
+				"content-type",
+				"x-tenant-id",
+			},
+			populatedHeaders: true,
+		},
+		{
+			name:       "content_digest",
+			components: []string{"@method", "content-digest"},
+			body:       benchmarkRequestBody,
+		},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			strategy := newHTTPMessageSignaturesBenchmarkStrategy(
+				b,
+				tc.components...,
+			)
+
+			base := newAuthStrategyBenchmarkRequest(
+				b,
+				context.Background(),
+				"https://example.com/resource",
+				tc.populatedHeaders,
+				tc.body,
+			)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for b.Loop() {
+				req := *base
+
+				if err := strategy.Apply(&req); err != nil {
+					b.Fatal(err)
+				}
+
+				runtime.KeepAlive(req)
+			}
+		})
+	}
+}
+
+func newHTTPMessageSignaturesBenchmarkStrategy(
+	b *testing.B,
+	components ...string,
+) *HTTPMessageSignatures {
+	b.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	signer, err := httpsig.NewSigner(
+		httpsig.Key{
+			Algorithm: httpsig.EcdsaP384Sha384,
+			KeyID:     "benchmark",
+			Key:       privateKey,
+		},
+		httpsig.WithComponents(components...),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	return &HTTPMessageSignatures{
+		signer: signer,
+	}
+}

--- a/internal/rules/endpoint/authstrategy/http_message_signatures_test.go
+++ b/internal/rules/endpoint/authstrategy/http_message_signatures_test.go
@@ -340,7 +340,7 @@ func TestHTTPMessageSignaturesApply(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			err = tc.conf.Apply(t.Context(), req)
+			err = tc.conf.Apply(req)
 
 			tc.assert(t, err, req)
 		})

--- a/internal/rules/endpoint/authstrategy/http_message_signatures_test.go
+++ b/internal/rules/endpoint/authstrategy/http_message_signatures_test.go
@@ -332,7 +332,7 @@ func TestHTTPMessageSignaturesApply(t *testing.T) {
 			err := tc.conf.init()
 			require.NoError(t, err)
 
-			req, err := http.NewRequestWithContext(
+			originalReq, err := http.NewRequestWithContext(
 				t.Context(),
 				http.MethodGet,
 				"http//example.com/test",
@@ -340,9 +340,18 @@ func TestHTTPMessageSignaturesApply(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			err = tc.conf.Apply(req)
+			originalReq.Header.Set("X-Original", "foo")
 
-			tc.assert(t, err, req)
+			req := *originalReq
+
+			err = tc.conf.Apply(&req)
+
+			tc.assert(t, err, &req)
+
+			assert.Equal(t, "foo", originalReq.Header.Get("X-Original"))
+			assert.Empty(t, originalReq.Header.Get("Signature"))
+			assert.Empty(t, originalReq.Header.Get("Signature-Input"))
+			assert.Empty(t, originalReq.Header.Get("Content-Digest"))
 		})
 	}
 }

--- a/internal/rules/endpoint/endpoint.go
+++ b/internal/rules/endpoint/endpoint.go
@@ -80,6 +80,13 @@ func (e Endpoint) CreateClient(peerName string) *http.Client {
 		}
 	}
 
+	if e.AuthStrategy != nil {
+		client.Transport = &authenticationRoundTripper{
+			next:     client.Transport,
+			strategy: e.AuthStrategy,
+		}
+	}
+
 	return client
 }
 
@@ -105,17 +112,6 @@ func (e Endpoint) CreateRequest(ctx context.Context, body io.Reader, rndr Render
 		return nil, errorchain.
 			NewWithMessage(heimdall.ErrInternal, "failed to create a request instance").
 			CausedBy(err)
-	}
-
-	if e.AuthStrategy != nil {
-		logger.Debug().Msg("Authenticating request")
-
-		err = e.AuthStrategy.Apply(req)
-		if err != nil {
-			return nil, errorchain.
-				NewWithMessage(heimdall.ErrInternal, "failed to authenticate request").
-				CausedBy(err)
-		}
 	}
 
 	for headerName, valueTemplate := range e.Headers {
@@ -146,6 +142,10 @@ func (e Endpoint) SendRequest(
 
 	resp, err := e.CreateClient(req.URL.Hostname()).Do(req)
 	if err != nil {
+		if errors.Is(err, heimdall.ErrInternal) {
+			return nil, err
+		}
+
 		var clientErr *url.Error
 		if errors.As(err, &clientErr) && clientErr.Timeout() {
 			return nil, errorchain.New(heimdall.ErrCommunicationTimeout).CausedBy(err)

--- a/internal/rules/endpoint/endpoint.go
+++ b/internal/rules/endpoint/endpoint.go
@@ -110,7 +110,7 @@ func (e Endpoint) CreateRequest(ctx context.Context, body io.Reader, rndr Render
 	if e.AuthStrategy != nil {
 		logger.Debug().Msg("Authenticating request")
 
-		err = e.AuthStrategy.Apply(ctx, req)
+		err = e.AuthStrategy.Apply(req)
 		if err != nil {
 			return nil, errorchain.
 				NewWithMessage(heimdall.ErrInternal, "failed to authenticate request").

--- a/internal/rules/endpoint/endpoint_test.go
+++ b/internal/rules/endpoint/endpoint_test.go
@@ -201,7 +201,6 @@ func TestEndpointCreateRequest(t *testing.T) {
 				AuthStrategy: func() AuthenticationStrategy {
 					as := mocks.NewAuthenticationStrategyMock(t)
 					as.EXPECT().Apply(
-						mock.Anything,
 						mock.MatchedBy(func(req *http.Request) bool {
 							req.Header.Set("X-Test", "test")
 
@@ -228,7 +227,7 @@ func TestEndpointCreateRequest(t *testing.T) {
 				URL: "http://test.org",
 				AuthStrategy: func() AuthenticationStrategy {
 					as := mocks.NewAuthenticationStrategyMock(t)
-					as.EXPECT().Apply(mock.Anything, mock.Anything).Return(errors.New("test error"))
+					as.EXPECT().Apply(mock.Anything).Return(errors.New("test error"))
 
 					return as
 				}(),
@@ -247,7 +246,7 @@ func TestEndpointCreateRequest(t *testing.T) {
 				Method: "PATCH",
 				AuthStrategy: func() AuthenticationStrategy {
 					as := mocks.NewAuthenticationStrategyMock(t)
-					as.EXPECT().Apply(mock.Anything, mock.MatchedBy(func(req *http.Request) bool {
+					as.EXPECT().Apply(mock.MatchedBy(func(req *http.Request) bool {
 						req.Header.Set("X-Test", "test")
 
 						return true
@@ -423,7 +422,7 @@ func TestEndpointSendRequest(t *testing.T) {
 				t.Helper()
 
 				as := mocks.NewAuthenticationStrategyMock(t)
-				as.EXPECT().Apply(mock.Anything, mock.MatchedBy(func(req *http.Request) bool {
+				as.EXPECT().Apply(mock.MatchedBy(func(req *http.Request) bool {
 					req.Header.Set("X-Test", "test")
 
 					return true

--- a/internal/rules/endpoint/endpoint_test.go
+++ b/internal/rules/endpoint/endpoint_test.go
@@ -110,6 +110,39 @@ func TestEndpointCreateClient(t *testing.T) {
 				require.True(t, ok)
 			},
 		},
+		"for endpoint with auth strategy, configured retry policy and http cache": {
+			endpoint: Endpoint{
+				URL:          "http://foo.bar",
+				AuthStrategy: mocks.NewAuthenticationStrategyMock(t),
+				Retry: &Retry{
+					GiveUpAfter: 2 * time.Second,
+					MaxDelay:    10 * time.Second,
+				},
+				HTTPCache: &HTTPCache{
+					Enabled:    true,
+					DefaultTTL: 15 * time.Minute,
+				},
+			},
+			assert: func(t *testing.T, client *http.Client) {
+				t.Helper()
+
+				authTransport, ok := client.Transport.(*authenticationRoundTripper)
+				require.True(t, ok)
+
+				cacheTransport, ok := authTransport.next.(*httpcache.RoundTripper)
+				require.True(t, ok)
+				assert.Equal(t, 15*time.Minute, cacheTransport.DefaultCacheTTL)
+
+				retryTransport, ok := cacheTransport.Transport.(*httpretry.RetryRoundtripper)
+				require.True(t, ok)
+				assert.NotZero(t, retryTransport.MaxRetryCount)
+				assert.NotNil(t, retryTransport.ShouldRetry)
+				assert.NotNil(t, retryTransport.CalculateBackoff)
+
+				_, ok = retryTransport.Next.(*otelhttp.Transport)
+				require.True(t, ok)
+			},
+		},
 	} {
 		t.Run(uc, func(t *testing.T) {
 			// THEN
@@ -195,66 +228,12 @@ func TestEndpointCreateRequest(t *testing.T) {
 				assert.Empty(t, request.Header)
 			},
 		},
-		"with auth strategy, applied successfully": {
-			endpoint: Endpoint{
-				URL: "http://test.org",
-				AuthStrategy: func() AuthenticationStrategy {
-					as := mocks.NewAuthenticationStrategyMock(t)
-					as.EXPECT().Apply(
-						mock.MatchedBy(func(req *http.Request) bool {
-							req.Header.Set("X-Test", "test")
-
-							return true
-						}),
-					).Return(nil)
-
-					return as
-				}(),
-			},
-			assert: func(t *testing.T, request *http.Request, err error) {
-				t.Helper()
-
-				require.NoError(t, err)
-
-				assert.Equal(t, "POST", request.Method)
-				assert.Equal(t, "http://test.org", request.URL.String())
-				assert.Len(t, request.Header, 1)
-				assert.Equal(t, "test", request.Header.Get("X-Test"))
-			},
-		},
-		"with failing auth strategy": {
-			endpoint: Endpoint{
-				URL: "http://test.org",
-				AuthStrategy: func() AuthenticationStrategy {
-					as := mocks.NewAuthenticationStrategyMock(t)
-					as.EXPECT().Apply(mock.Anything).Return(errors.New("test error"))
-
-					return as
-				}(),
-			},
-			assert: func(t *testing.T, _ *http.Request, err error) {
-				t.Helper()
-
-				require.Error(t, err)
-				require.ErrorIs(t, err, heimdall.ErrInternal)
-				require.ErrorContains(t, err, "failed to authenticate request")
-			},
-		},
 		"with auth strategy and additional header": {
 			endpoint: Endpoint{
-				URL:    "http://test.org",
-				Method: "PATCH",
-				AuthStrategy: func() AuthenticationStrategy {
-					as := mocks.NewAuthenticationStrategyMock(t)
-					as.EXPECT().Apply(mock.MatchedBy(func(req *http.Request) bool {
-						req.Header.Set("X-Test", "test")
-
-						return true
-					})).Return(nil)
-
-					return as
-				}(),
-				Headers: map[string]string{"Foo-Bar": "baz"},
+				URL:          "http://test.org",
+				Method:       "PATCH",
+				AuthStrategy: mocks.NewAuthenticationStrategyMock(t),
+				Headers:      map[string]string{"Foo-Bar": "baz"},
 			},
 			assert: func(t *testing.T, request *http.Request, err error) {
 				t.Helper()
@@ -263,9 +242,7 @@ func TestEndpointCreateRequest(t *testing.T) {
 
 				assert.Equal(t, "PATCH", request.Method)
 				assert.Equal(t, "http://test.org", request.URL.String())
-
-				assert.Len(t, request.Header, 2)
-				assert.Equal(t, "test", request.Header.Get("X-Test"))
+				assert.Len(t, request.Header, 1)
 				assert.Equal(t, "baz", request.Header.Get("Foo-Bar"))
 			},
 		},
@@ -422,11 +399,15 @@ func TestEndpointSendRequest(t *testing.T) {
 				t.Helper()
 
 				as := mocks.NewAuthenticationStrategyMock(t)
-				as.EXPECT().Apply(mock.MatchedBy(func(req *http.Request) bool {
-					req.Header.Set("X-Test", "test")
+				as.EXPECT().
+					Apply(mock.MatchedBy(func(req *http.Request) bool {
+						assert.Equal(t, "baz", req.Header.Get("Foo-Bar"))
 
-					return true
-				})).Return(nil)
+						req.Header.Set("X-Test", "test")
+
+						return true
+					})).
+					Return(nil)
 
 				return Endpoint{
 					URL:          srv.URL,
@@ -461,6 +442,36 @@ func TestEndpointSendRequest(t *testing.T) {
 				require.NoError(t, err)
 
 				assert.Equal(t, []byte("hello from srv"), response)
+			},
+		},
+		"with failing auth strategy": {
+			endpoint: func(t *testing.T) Endpoint {
+				t.Helper()
+
+				as := mocks.NewAuthenticationStrategyMock(t)
+				as.EXPECT().Apply(mock.Anything).Return(errors.New("test error"))
+
+				return Endpoint{
+					URL:          srv.URL,
+					AuthStrategy: as,
+				}
+			},
+			instructServer: func(t *testing.T) {
+				t.Helper()
+
+				checkRequest = func(*http.Request) {
+					t.Fatal("server must not be called")
+				}
+			},
+			assert: func(t *testing.T, response []byte, err error) {
+				t.Helper()
+
+				assert.Nil(t, response)
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, heimdall.ErrInternal)
+				require.ErrorContains(t, err, "failed to authenticate request")
+				require.ErrorContains(t, err, "test error")
 			},
 		},
 	} {

--- a/internal/rules/endpoint/mocks/authentication_strategy.go
+++ b/internal/rules/endpoint/mocks/authentication_strategy.go
@@ -3,8 +3,6 @@
 package mocks
 
 import (
-	context "context"
-
 	http "net/http"
 
 	mock "github.com/stretchr/testify/mock"
@@ -23,13 +21,13 @@ func (_m *AuthenticationStrategyMock) EXPECT() *AuthenticationStrategyMock_Expec
 	return &AuthenticationStrategyMock_Expecter{mock: &_m.Mock}
 }
 
-// Apply provides a mock function with given fields: _a0, _a1
-func (_m *AuthenticationStrategyMock) Apply(_a0 context.Context, _a1 *http.Request) error {
-	ret := _m.Called(_a0, _a1)
+// Apply provides a mock function with given fields: _a0
+func (_m *AuthenticationStrategyMock) Apply(_a0 *http.Request) error {
+	ret := _m.Called(_a0)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *http.Request) error); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(*http.Request) error); ok {
+		r0 = rf(_a0)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -43,15 +41,14 @@ type AuthenticationStrategyMock_Apply_Call struct {
 }
 
 // Apply is a helper method to define mock.On call
-//   - _a0 context.Context
-//   - _a1 *http.Request
-func (_e *AuthenticationStrategyMock_Expecter) Apply(_a0 interface{}, _a1 interface{}) *AuthenticationStrategyMock_Apply_Call {
-	return &AuthenticationStrategyMock_Apply_Call{Call: _e.mock.On("Apply", _a0, _a1)}
+//   - _a0 *http.Request
+func (_e *AuthenticationStrategyMock_Expecter) Apply(_a0 interface{}) *AuthenticationStrategyMock_Apply_Call {
+	return &AuthenticationStrategyMock_Apply_Call{Call: _e.mock.On("Apply", _a0)}
 }
 
-func (_c *AuthenticationStrategyMock_Apply_Call) Run(run func(_a0 context.Context, _a1 *http.Request)) *AuthenticationStrategyMock_Apply_Call {
+func (_c *AuthenticationStrategyMock_Apply_Call) Run(run func(_a0 *http.Request)) *AuthenticationStrategyMock_Apply_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(*http.Request))
+		run(args[0].(*http.Request))
 	})
 	return _c
 }
@@ -61,7 +58,7 @@ func (_c *AuthenticationStrategyMock_Apply_Call) Return(_a0 error) *Authenticati
 	return _c
 }
 
-func (_c *AuthenticationStrategyMock_Apply_Call) RunAndReturn(run func(context.Context, *http.Request) error) *AuthenticationStrategyMock_Apply_Call {
+func (_c *AuthenticationStrategyMock_Apply_Call) RunAndReturn(run func(*http.Request) error) *AuthenticationStrategyMock_Apply_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/rules/oauth2/clientcredentials/clientcredentials.go
+++ b/internal/rules/oauth2/clientcredentials/clientcredentials.go
@@ -94,7 +94,7 @@ func (c *Config) Token(ctx context.Context) (*TokenInfo, error) {
 func (c *Config) Apply(req *http.Request) error {
 	if c.AuthMethod == AuthMethodRequestBody {
 		// This is not recommended, but there are non-compliant servers out there
-		// which do support the Basic Auth authentication method required by
+		// that do support the Basic Auth authentication method required by
 		// the spec. See also https://www.rfc-editor.org/rfc/rfc6749#section-2.3.1
 		data, _ := io.ReadAll(req.Body)
 		values, _ := url.ParseQuery(stringx.ToString(data))
@@ -107,6 +107,7 @@ func (c *Config) Apply(req *http.Request) error {
 		req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(body), nil }
 		req.ContentLength = int64(body.Len())
 	} else {
+		req.Header = req.Header.Clone()
 		req.SetBasicAuth(url.QueryEscape(c.ClientID), url.QueryEscape(c.ClientSecret))
 	}
 

--- a/internal/rules/oauth2/clientcredentials/clientcredentials.go
+++ b/internal/rules/oauth2/clientcredentials/clientcredentials.go
@@ -91,7 +91,7 @@ func (c *Config) Token(ctx context.Context) (*TokenInfo, error) {
 	return tokenInfo, nil
 }
 
-func (c *Config) Apply(_ context.Context, req *http.Request) error {
+func (c *Config) Apply(req *http.Request) error {
 	if c.AuthMethod == AuthMethodRequestBody {
 		// This is not recommended, but there are non-compliant servers out there
 		// which do support the Basic Auth authentication method required by

--- a/internal/rules/oauth2/clientcredentials/clientcredentials_benchmark_test.go
+++ b/internal/rules/oauth2/clientcredentials/clientcredentials_benchmark_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clientcredentials
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+)
+
+type clientCredentialsBenchmarkBody struct {
+	*bytes.Reader
+}
+
+func (clientCredentialsBenchmarkBody) Close() error {
+	return nil
+}
+
+func BenchmarkConfigApply(b *testing.B) {
+	b.Run("basic auth", func(b *testing.B) {
+		for _, tc := range []struct {
+			name             string
+			populatedHeaders bool
+		}{
+			{
+				name: "empty headers",
+			},
+			{
+				name:             "populated headers",
+				populatedHeaders: true,
+			},
+		} {
+			b.Run(tc.name, func(b *testing.B) {
+				config := &Config{
+					ClientID:     "client",
+					ClientSecret: "secret",
+				}
+
+				base := newClientCredentialsBenchmarkRequest(b, tc.populatedHeaders)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for b.Loop() {
+					req := *base
+
+					if err := config.Apply(&req); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	})
+
+	b.Run("request body", func(b *testing.B) {
+		for _, tc := range []struct {
+			name string
+			form string
+		}{
+			{
+				name: "minimal form",
+				form: "grant_type=client_credentials",
+			},
+			{
+				name: "populated form",
+				form: "grant_type=client_credentials" +
+					"&scope=read+write" +
+					"&audience=https%3A%2F%2Fapi.example.com" +
+					"&resource=orders",
+			},
+		} {
+			b.Run(tc.name, func(b *testing.B) {
+				config := &Config{
+					ClientID:     "client",
+					ClientSecret: "secret",
+					AuthMethod:   AuthMethodRequestBody,
+				}
+
+				data := []byte(tc.form)
+				reader := bytes.NewReader(data)
+				body := &clientCredentialsBenchmarkBody{Reader: reader}
+
+				base := newClientCredentialsBenchmarkRequest(b, true)
+
+				b.ReportAllocs()
+				b.ResetTimer()
+
+				for b.Loop() {
+					reader.Reset(data)
+
+					req := *base
+					req.Body = body
+					req.ContentLength = int64(len(data))
+
+					if err := config.Apply(&req); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	})
+}
+
+func newClientCredentialsBenchmarkRequest(
+	b *testing.B,
+	populatedHeaders bool,
+) *http.Request {
+	b.Helper()
+
+	req, err := http.NewRequestWithContext(
+		b.Context(),
+		http.MethodPost,
+		"https://issuer.example.com/token",
+		nil,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	if populatedHeaders {
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.Header.Set("User-Agent", "heimdall")
+		req.Header.Set("X-Request-ID", "01K2E7T0W5M8ZKQKRQZQ4Y5KQZ")
+		req.Header.Set("X-Tenant-ID", "tenant-a")
+		req.Header.Set(
+			"Traceparent",
+			"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+		)
+		req.Header.Add("X-Forwarded-For", "10.0.0.1")
+		req.Header.Add("X-Forwarded-For", "10.0.0.2")
+		req.Header.Set("Cookie", "session=foobar; locale=en")
+	}
+
+	return req
+}

--- a/internal/rules/oauth2/clientcredentials/clientcredentials_test.go
+++ b/internal/rules/oauth2/clientcredentials/clientcredentials_test.go
@@ -19,8 +19,10 @@ package clientcredentials
 import (
 	"encoding/base64"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -36,6 +38,73 @@ import (
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/x"
 )
+
+func TestConfigApply(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		config *Config
+		assert func(t *testing.T, req, original *http.Request)
+	}{
+		"basic auth": {
+			config: &Config{
+				ClientID:     "foo",
+				ClientSecret: "bar",
+			},
+			assert: func(t *testing.T, req, original *http.Request) {
+				t.Helper()
+
+				user, password, ok := req.BasicAuth()
+				require.True(t, ok)
+				assert.Equal(t, "foo", user)
+				assert.Equal(t, "bar", password)
+
+				_, _, ok = original.BasicAuth()
+				assert.False(t, ok)
+			},
+		},
+		"request body": {
+			config: &Config{
+				ClientID:     "foo",
+				ClientSecret: "bar",
+				AuthMethod:   AuthMethodRequestBody,
+			},
+			assert: func(t *testing.T, req, original *http.Request) {
+				t.Helper()
+
+				data, err := io.ReadAll(req.Body)
+				require.NoError(t, err)
+
+				values, err := url.ParseQuery(string(data))
+				require.NoError(t, err)
+
+				assert.Equal(t, "client_credentials", values.Get("grant_type"))
+				assert.Equal(t, "foo", values.Get("client_id"))
+				assert.Equal(t, "bar", values.Get("client_secret"))
+
+				// Direct fields must only have changed on the shallow copy.
+				assert.NotEqual(t, original.ContentLength, req.ContentLength)
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			original, err := http.NewRequestWithContext(
+				t.Context(),
+				http.MethodPost,
+				"https://example.com",
+				strings.NewReader("grant_type=client_credentials"),
+			)
+			require.NoError(t, err)
+
+			req := *original
+
+			err = tc.config.Apply(&req)
+			require.NoError(t, err)
+
+			tc.assert(t, &req, original)
+		})
+	}
+}
 
 func TestClientCredentialsToken(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have added tests that prove the correctness of my implementation.

## Description

This PR moves outbound endpoint authentication from request creation into a dedicated HTTP round tripper.

`Endpoint.CreateRequest` now only creates the fully rendered request, while the authentication strategy is applied immediately before the request enters the existing HTTP transport chain. This keeps request creation free of authentication side effects and ensures authentication operates on the effective endpoint request, including configured endpoint headers.

