### PR TITLE
fix: Ensure deterministic and unambiguous cache identities

### DIFF
--- a/docs/content/docs/configuration/types.adoc
+++ b/docs/content/docs/configuration/types.adoc
@@ -417,7 +417,8 @@ The scopes required for the access token.
 
 * *`cache_ttl`*: _link:{{< relref "#_duration" >}}[Duration]_ (optional)
 +
-How long to cache the token received from the token endpoint. Defaults to the token expiration information from the token endpoint (the value of the `expires_in` field) if present. If the token expiration information is not present and `cache_ttl` is not configured, the received token is not cached. If the token expiration information is present in the response and `cache_ttl` is configured the shorter value is taken. If caching is enabled, the token is cached until 5 seconds before its expiration. To disable caching, set it to `0s`. The cache key calculation is based on the values of `token_url`, `client_id`, `client_secret` and the `scopes` properties.
+How long to cache the token received from the token endpoint. Defaults to the token expiration information from the token endpoint (the value of the `expires_in` field) if present. If the token expiration information is not present and `cache_ttl` is not configured, the received token is not cached. If the token expiration information is present in the response and `cache_ttl` is configured, the shorter value is taken. If caching is enabled, the token is cached until 5 seconds before its expiration.
+To disable caching, set it to `0s`. The cache identity is derived from the token URL, resolved client credentials, authentication method, requested scopes and the configured cache TTL.
 
 * *`header`*: _object_ (optional, overridable)
 +

--- a/docs/content/docs/mechanisms/authenticators.adoc
+++ b/docs/content/docs/mechanisms/authenticators.adoc
@@ -127,7 +127,7 @@ Where to extract the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_
 
 * *`cache_ttl`*: _link:{{< relref "/docs/configuration/types.adoc#_duration" >}}[Duration]_ (optional, overridable)
 +
-How long to cache the response. If not set, response caching if disabled. The cache key is calculated from the `identity_info_endpoint` configuration and the actual authentication data value.
+How long to cache the response. If not set, response caching is disabled. The cache identity is derived from the authenticator, the configured cache TTL and the effective request to the `identity_info_endpoint`, including the HTTP method, rendered URL and headers, rendered payload and endpoint authentication strategy.
 
 * *`allow_fallback_on_error`*: _boolean_ (optional, overridable)
 +
@@ -299,7 +299,7 @@ Where to extract the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_
 
 * *`cache_ttl`*: _link:{{< relref "/docs/configuration/types.adoc#_duration" >}}[Duration]_ (optional, overridable)
 +
-How long to cache the response. If not set, caching of the introspection response is based on the available token expiration information. To disable caching, set it to `0s`. If you set the ttl to a custom value > 0, the expiration time (if available) of the token will be considered. The cache key is calculated from the `introspection_endpoint` configuration and the value of the access token.
+How long to cache the response. If not set, caching of the introspection response is based on the available token expiration information. To disable caching, set it to `0s`. If you set the ttl to a custom value > 0, the expiration time (if available) of the token will be considered. The cache identity is derived from the access token, the configured cache TTL and the effective request to the resolved introspection endpoint, including the HTTP method, rendered URL and headers and endpoint authentication strategy.
 
 * *`allow_fallback_on_error`*: _boolean_ (optional, overridable)
 +
@@ -401,7 +401,7 @@ Where to extract the subject id from the JWT, as well as which attributes to use
 
 * *`cache_ttl`*: _link:{{< relref "/docs/configuration/types.adoc#_duration" >}}[Duration]_ (optional, overridable)
 +
-How long to cache the key from the JWKS response, which was used for signature verification purposes. If not set, heimdall will cache this key for 10 minutes and not call JWKS endpoint again if the same `kid` is referenced in an JWT and same JWKS endpoint is used. The cache key is calculated from the `jwks_endpoint` configuration and the `kid` referenced in the JWT.
+How long to cache the key from the JWKS response, which was used for signature verification purposes. If not set, heimdall will cache this key for 10 minutes. The cache identity is derived from the `kid` referenced in the JWT, the configured cache TTL and the effective request to the resolved JWKS endpoint, including the HTTP method, rendered URL and headers and endpoint authentication strategy.
 
 * *`allow_fallback_on_error`*: _boolean_ (optional, overridable)
 +

--- a/docs/content/docs/mechanisms/authorizers.adoc
+++ b/docs/content/docs/mechanisms/authorizers.adoc
@@ -174,7 +174,7 @@ NOTE: This setting is deprecated and will be removed in the 0.18.0 release. Use 
 
 * *`cache_ttl`*: _link:{{< relref "/docs/configuration/types.adoc#_duration" >}}[Duration]_ (optional, overridable)
 +
-Allows caching of the authorization endpoint responses. Defaults to 0s, which means no caching. The cache key is calculated from the entire configuration of the authorizer instance and the available information about the current subject.
+Allows caching of the authorization endpoint responses. Defaults to `0s`, which means no caching. The cache identity is derived from the authorizer, the configured cache TTL and the effective request to the endpoint, including the HTTP method, rendered URL and headers, rendered payload and endpoint authentication strategy. Authorization expressions are evaluated for every execution, regardless of whether the authorization endpoint response was obtained remotely or reused from the cache.
 
 * *`values`* _map of strings_ (optional, overridable)
 +

--- a/docs/content/docs/mechanisms/contextualizers.adoc
+++ b/docs/content/docs/mechanisms/contextualizers.adoc
@@ -42,7 +42,7 @@ Your link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_templating" >}}[
 
 * *`cache_ttl`*: _link:{{< relref "/docs/configuration/types.adoc#_duration" >}}[Duration]_ (optional, overridable)
 +
-Allows caching of the API responses. Defaults to 10 seconds. The cache key is calculated from the entire configuration of the contextualizer instance and the available information about the current subject.
+Allows caching of the API responses. Defaults to 10 seconds. The cache identity is derived from the contextualizer, the configured cache TTL and the effective request to the endpoint, including the HTTP method, rendered URL and headers, rendered payload and endpoint authentication strategy.
 
 * *`continue_pipeline_on_error`*: _boolean_ (optional, overridable)
 +

--- a/internal/cache/cachekey/cachekey.go
+++ b/internal/cache/cachekey/cachekey.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cachekey
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"hash"
+	"net/http"
+	"slices"
+
+	"github.com/dadrus/heimdall/internal/x/stringx"
+)
+
+const namespace = "heimdall-cache-key:v1"
+
+type Builder struct {
+	hash hash.Hash
+}
+
+func New(domain string) *Builder {
+	result := &Builder{hash: sha256.New()}
+
+	result.WriteString(namespace)
+	result.WriteString(domain)
+
+	return result
+}
+
+func (key *Builder) WriteBool(value bool) {
+	if value {
+		key.WriteUint64(1)
+	} else {
+		key.WriteUint64(0)
+	}
+}
+
+func (key *Builder) WriteUint64(value uint64) {
+	var data [8]byte
+	binary.BigEndian.PutUint64(data[:], value)
+
+	_, _ = key.hash.Write(data[:])
+}
+
+func (key *Builder) WriteInt64(value int64) {
+	key.WriteUint64(uint64(value)) //nolint:gosec
+}
+
+func (key *Builder) WriteString(value string) {
+	key.WriteUint64(uint64(len(value)))
+
+	_, _ = key.hash.Write(stringx.ToBytes(value))
+}
+
+func (key *Builder) WriteBytes(value []byte) {
+	key.WriteUint64(uint64(len(value)))
+
+	_, _ = key.hash.Write(value)
+}
+
+func (key *Builder) WriteStrings(values []string) {
+	key.WriteUint64(uint64(len(values)))
+
+	for _, value := range values {
+		key.WriteString(value)
+	}
+}
+
+func (key *Builder) WriteHeader(header http.Header) {
+	names := make([]string, 0, len(header))
+
+	for name := range header {
+		names = append(names, name)
+	}
+
+	slices.Sort(names)
+
+	key.WriteUint64(uint64(len(names)))
+
+	for _, name := range names {
+		key.WriteString(name)
+		key.WriteStrings(header[name])
+	}
+}
+
+func (key *Builder) Sum() []byte {
+	return key.hash.Sum(nil)
+}
+
+func (key *Builder) SumString() string {
+	return hex.EncodeToString(key.Sum())
+}

--- a/internal/cache/cachekey/cachekey_test.go
+++ b/internal/cache/cachekey/cachekey_test.go
@@ -1,0 +1,291 @@
+// Copyright 2026 Dimitrij Drus <dadrus@gmx.de>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cachekey
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuilder(t *testing.T) {
+	t.Parallel()
+
+	for uc, tc := range map[string]struct {
+		key1        func() string
+		key2        func() string
+		expectEqual bool
+	}{
+		"same values": {
+			key1: func() string {
+				key := New("test")
+				key.WriteString("foo")
+				key.WriteBytes([]byte("bar"))
+				key.WriteBool(true)
+				key.WriteUint64(42)
+				key.WriteInt64(-42)
+
+				return key.SumString()
+			},
+			key2: func() string {
+				key := New("test")
+				key.WriteString("foo")
+				key.WriteBytes([]byte("bar"))
+				key.WriteBool(true)
+				key.WriteUint64(42)
+				key.WriteInt64(-42)
+
+				return key.SumString()
+			},
+			expectEqual: true,
+		},
+		"different domain": {
+			key1: func() string {
+				key := New("foo")
+				key.WriteString("bar")
+
+				return key.SumString()
+			},
+			key2: func() string {
+				key := New("foobar")
+				key.WriteString("")
+
+				return key.SumString()
+			},
+		},
+		"string boundaries are preserved": {
+			key1: func() string {
+				key := New("test")
+				key.WriteString("a")
+				key.WriteString("bc")
+
+				return key.SumString()
+			},
+			key2: func() string {
+				key := New("test")
+				key.WriteString("ab")
+				key.WriteString("c")
+
+				return key.SumString()
+			},
+		},
+		"byte boundaries are preserved": {
+			key1: func() string {
+				key := New("test")
+				key.WriteBytes([]byte("a"))
+				key.WriteBytes([]byte("bc"))
+
+				return key.SumString()
+			},
+			key2: func() string {
+				key := New("test")
+				key.WriteBytes([]byte("ab"))
+				key.WriteBytes([]byte("c"))
+
+				return key.SumString()
+			},
+		},
+		"string slice boundaries are preserved": {
+			key1: func() string {
+				key := New("test")
+				key.WriteStrings([]string{"a", "bc"})
+
+				return key.SumString()
+			},
+			key2: func() string {
+				key := New("test")
+				key.WriteStrings([]string{"ab", "c"})
+
+				return key.SumString()
+			},
+		},
+		"different bool": {
+			key1: func() string {
+				key := New("test")
+				key.WriteBool(false)
+
+				return key.SumString()
+			},
+			key2: func() string {
+				key := New("test")
+				key.WriteBool(true)
+
+				return key.SumString()
+			},
+		},
+		"different uint64": {
+			key1: func() string {
+				key := New("test")
+				key.WriteUint64(1)
+
+				return key.SumString()
+			},
+			key2: func() string {
+				key := New("test")
+				key.WriteUint64(2)
+
+				return key.SumString()
+			},
+		},
+		"different int64": {
+			key1: func() string {
+				key := New("test")
+				key.WriteInt64(-1)
+
+				return key.SumString()
+			},
+			key2: func() string {
+				key := New("test")
+				key.WriteInt64(1)
+
+				return key.SumString()
+			},
+		},
+		"presence can distinguish absent and empty values": {
+			key1: func() string {
+				key := New("test")
+				key.WriteBool(false)
+
+				return key.SumString()
+			},
+			key2: func() string {
+				key := New("test")
+				key.WriteBool(true)
+				key.WriteBytes(nil)
+
+				return key.SumString()
+			},
+		},
+		"headers are independent of map insertion order": {
+			key1: func() string {
+				header := make(http.Header)
+				header.Set("X-Foo", "foo")
+				header.Set("X-Bar", "bar")
+
+				key := New("test")
+				key.WriteHeader(header)
+
+				return key.SumString()
+			},
+			key2: func() string {
+				header := make(http.Header)
+				header.Set("X-Bar", "bar")
+				header.Set("X-Foo", "foo")
+
+				key := New("test")
+				key.WriteHeader(header)
+
+				return key.SumString()
+			},
+			expectEqual: true,
+		},
+		"different header name": {
+			key1: func() string {
+				header := make(http.Header)
+				header.Set("X-Foo", "value")
+
+				key := New("test")
+				key.WriteHeader(header)
+
+				return key.SumString()
+			},
+			key2: func() string {
+				header := make(http.Header)
+				header.Set("X-Bar", "value")
+
+				key := New("test")
+				key.WriteHeader(header)
+
+				return key.SumString()
+			},
+		},
+		"different header value": {
+			key1: func() string {
+				header := make(http.Header)
+				header.Set("X-Foo", "foo")
+
+				key := New("test")
+				key.WriteHeader(header)
+
+				return key.SumString()
+			},
+			key2: func() string {
+				header := make(http.Header)
+				header.Set("X-Foo", "bar")
+
+				key := New("test")
+				key.WriteHeader(header)
+
+				return key.SumString()
+			},
+		},
+		"header value boundaries are preserved": {
+			key1: func() string {
+				header := make(http.Header)
+				header["X-Foo"] = []string{"a", "bc"}
+
+				key := New("test")
+				key.WriteHeader(header)
+
+				return key.SumString()
+			},
+			key2: func() string {
+				header := make(http.Header)
+				header["X-Foo"] = []string{"ab", "c"}
+
+				key := New("test")
+				key.WriteHeader(header)
+
+				return key.SumString()
+			},
+		},
+		"header value order is preserved": {
+			key1: func() string {
+				header := make(http.Header)
+				header["X-Foo"] = []string{"foo", "bar"}
+
+				key := New("test")
+				key.WriteHeader(header)
+
+				return key.SumString()
+			},
+			key2: func() string {
+				header := make(http.Header)
+				header["X-Foo"] = []string{"bar", "foo"}
+
+				key := New("test")
+				key.WriteHeader(header)
+
+				return key.SumString()
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			// WHEN
+			key1 := tc.key1()
+			key2 := tc.key2()
+
+			// THEN
+			if tc.expectEqual {
+				assert.Equal(t, key1, key2)
+			} else {
+				assert.NotEqual(t, key1, key2)
+			}
+		})
+	}
+}

--- a/internal/rules/endpoint/authstrategy/api_key.go
+++ b/internal/rules/endpoint/authstrategy/api_key.go
@@ -17,12 +17,11 @@
 package authstrategy
 
 import (
-	"crypto/sha256"
 	"net/http"
 
+	"github.com/dadrus/heimdall/internal/cache/cachekey"
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
-	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 type APIKey struct {
@@ -61,11 +60,10 @@ func (c *APIKey) Apply(req *http.Request) error {
 }
 
 func (c *APIKey) Hash() []byte {
-	hash := sha256.New()
+	key := cachekey.New("auth-strategy:api-key")
+	key.WriteString(c.In)
+	key.WriteString(c.Name)
+	key.WriteString(c.Value)
 
-	hash.Write(stringx.ToBytes(c.In))
-	hash.Write(stringx.ToBytes(c.Name))
-	hash.Write(stringx.ToBytes(c.Value))
-
-	return hash.Sum(nil)
+	return key.Sum()
 }

--- a/internal/rules/endpoint/authstrategy/api_key_test.go
+++ b/internal/rules/endpoint/authstrategy/api_key_test.go
@@ -117,16 +117,47 @@ func TestApplyApiKeyStrategy(t *testing.T) {
 func TestAPIKeyStrategyHash(t *testing.T) {
 	t.Parallel()
 
-	// GIVEN
-	s1 := &APIKey{In: "header", Name: "Foo", Value: "Bar"}
-	s2 := &APIKey{In: "cookie", Name: "Foo", Value: "Bar"}
+	for uc, tc := range map[string]struct {
+		strategy1   *APIKey
+		strategy2   *APIKey
+		expectEqual bool
+	}{
+		"same configuration": {
+			strategy1:   &APIKey{In: "header", Name: "Foo", Value: "Bar"},
+			strategy2:   &APIKey{In: "header", Name: "Foo", Value: "Bar"},
+			expectEqual: true,
+		},
+		"different location": {
+			strategy1: &APIKey{In: "header", Name: "Foo", Value: "Bar"},
+			strategy2: &APIKey{In: "cookie", Name: "Foo", Value: "Bar"},
+		},
+		"different name": {
+			strategy1: &APIKey{In: "header", Name: "Foo", Value: "Bar"},
+			strategy2: &APIKey{In: "header", Name: "Baz", Value: "Bar"},
+		},
+		"different value": {
+			strategy1: &APIKey{In: "header", Name: "Foo", Value: "Bar"},
+			strategy2: &APIKey{In: "header", Name: "Foo", Value: "Baz"},
+		},
+		"field boundaries are preserved": {
+			strategy1: &APIKey{In: "header", Name: "a", Value: "bc"},
+			strategy2: &APIKey{In: "header", Name: "ab", Value: "c"},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			// WHEN
+			hash1 := tc.strategy1.Hash()
+			hash2 := tc.strategy2.Hash()
 
-	// WHEN
-	hash1 := s1.Hash()
-	hash2 := s2.Hash()
+			// THEN
+			assert.NotEmpty(t, hash1)
+			assert.NotEmpty(t, hash2)
 
-	// THEN
-	assert.NotEmpty(t, hash1)
-	assert.NotEmpty(t, hash2)
-	assert.NotEqual(t, hash1, hash2)
+			if tc.expectEqual {
+				assert.Equal(t, hash1, hash2)
+			} else {
+				assert.NotEqual(t, hash1, hash2)
+			}
+		})
+	}
 }

--- a/internal/rules/endpoint/authstrategy/basic_auth.go
+++ b/internal/rules/endpoint/authstrategy/basic_auth.go
@@ -17,10 +17,9 @@
 package authstrategy
 
 import (
-	"crypto/sha256"
 	"net/http"
 
-	"github.com/dadrus/heimdall/internal/x/stringx"
+	"github.com/dadrus/heimdall/internal/cache/cachekey"
 )
 
 type BasicAuth struct {
@@ -36,10 +35,9 @@ func (c *BasicAuth) Apply(req *http.Request) error {
 }
 
 func (c *BasicAuth) Hash() []byte {
-	hash := sha256.New()
+	key := cachekey.New("auth-strategy:basic")
+	key.WriteString(c.User)
+	key.WriteString(c.Password)
 
-	hash.Write(stringx.ToBytes(c.User))
-	hash.Write(stringx.ToBytes(c.Password))
-
-	return hash.Sum(nil)
+	return key.Sum()
 }

--- a/internal/rules/endpoint/authstrategy/basic_auth_test.go
+++ b/internal/rules/endpoint/authstrategy/basic_auth_test.go
@@ -58,16 +58,43 @@ func TestApplyBasicAuthStrategy(t *testing.T) {
 func TestBasicAuthStrategyHash(t *testing.T) {
 	t.Parallel()
 
-	// GIVEN
-	s1 := &BasicAuth{User: "Foo", Password: "Bar"}
-	s2 := &BasicAuth{User: "Foo", Password: "Baz"}
+	for uc, tc := range map[string]struct {
+		strategy1   *BasicAuth
+		strategy2   *BasicAuth
+		expectEqual bool
+	}{
+		"same configuration": {
+			strategy1:   &BasicAuth{User: "Foo", Password: "Bar"},
+			strategy2:   &BasicAuth{User: "Foo", Password: "Bar"},
+			expectEqual: true,
+		},
+		"different user": {
+			strategy1: &BasicAuth{User: "Foo", Password: "Bar"},
+			strategy2: &BasicAuth{User: "Baz", Password: "Bar"},
+		},
+		"different password": {
+			strategy1: &BasicAuth{User: "Foo", Password: "Bar"},
+			strategy2: &BasicAuth{User: "Foo", Password: "Baz"},
+		},
+		"field boundaries are preserved": {
+			strategy1: &BasicAuth{User: "a", Password: "bc"},
+			strategy2: &BasicAuth{User: "ab", Password: "c"},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			// WHEN
+			hash1 := tc.strategy1.Hash()
+			hash2 := tc.strategy2.Hash()
 
-	// WHEN
-	hash1 := s1.Hash()
-	hash2 := s2.Hash()
+			// THEN
+			assert.NotEmpty(t, hash1)
+			assert.NotEmpty(t, hash2)
 
-	// THEN
-	assert.NotEmpty(t, hash1)
-	assert.NotEmpty(t, hash2)
-	assert.NotEqual(t, hash1, hash2)
+			if tc.expectEqual {
+				assert.Equal(t, hash1, hash2)
+			} else {
+				assert.NotEqual(t, hash1, hash2)
+			}
+		})
+	}
 }

--- a/internal/rules/endpoint/authstrategy/client_credentials.go
+++ b/internal/rules/endpoint/authstrategy/client_credentials.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/rs/zerolog"
 
+	"github.com/dadrus/heimdall/internal/cache/cachekey"
 	"github.com/dadrus/heimdall/internal/rules/oauth2/clientcredentials"
 )
 
@@ -59,4 +60,24 @@ func (c *OAuth2ClientCredentials) Apply(req *http.Request) error {
 	req.Header.Set(headerName, headerScheme+" "+token.AccessToken)
 
 	return nil
+}
+
+func (c *OAuth2ClientCredentials) Hash() []byte {
+	headerName := "Authorization"
+	if c.Header != nil {
+		headerName = c.Header.Name
+	}
+
+	key := cachekey.New("auth-strategy:oauth2-client-credentials")
+	key.WriteBytes(c.Config.Hash())
+	key.WriteString(headerName)
+
+	hasFixedScheme := c.Header != nil && len(c.Header.Scheme) != 0
+	key.WriteBool(hasFixedScheme)
+
+	if hasFixedScheme {
+		key.WriteString(c.Header.Scheme)
+	}
+
+	return key.Sum()
 }

--- a/internal/rules/endpoint/authstrategy/client_credentials_test.go
+++ b/internal/rules/endpoint/authstrategy/client_credentials_test.go
@@ -245,3 +245,101 @@ func TestApplyClientCredentialsStrategy(t *testing.T) {
 		})
 	}
 }
+
+func TestOAuth2ClientCredentialsHash(t *testing.T) {
+	t.Parallel()
+
+	config := clientcredentials.Config{
+		TokenURL:     "https://example.com/token",
+		ClientID:     "client",
+		ClientSecret: "secret",
+	}
+
+	for uc, tc := range map[string]struct {
+		strategy1   *OAuth2ClientCredentials
+		strategy2   *OAuth2ClientCredentials
+		expectEqual bool
+	}{
+		"same configuration": {
+			strategy1: &OAuth2ClientCredentials{
+				Config: config,
+				Header: &HeaderConfig{
+					Name:   "X-Token",
+					Scheme: "Bearer",
+				},
+			},
+			strategy2: &OAuth2ClientCredentials{
+				Config: config,
+				Header: &HeaderConfig{
+					Name:   "X-Token",
+					Scheme: "Bearer",
+				},
+			},
+			expectEqual: true,
+		},
+		"default and explicit default header": {
+			strategy1: &OAuth2ClientCredentials{
+				Config: config,
+			},
+			strategy2: &OAuth2ClientCredentials{
+				Config: config,
+				Header: &HeaderConfig{
+					Name: "Authorization",
+				},
+			},
+			expectEqual: true,
+		},
+		"different header name": {
+			strategy1: &OAuth2ClientCredentials{
+				Config: config,
+				Header: &HeaderConfig{Name: "X-Token"},
+			},
+			strategy2: &OAuth2ClientCredentials{
+				Config: config,
+				Header: &HeaderConfig{Name: "X-Access-Token"},
+			},
+		},
+		"different fixed scheme": {
+			strategy1: &OAuth2ClientCredentials{
+				Config: config,
+				Header: &HeaderConfig{
+					Name:   "X-Token",
+					Scheme: "Bearer",
+				},
+			},
+			strategy2: &OAuth2ClientCredentials{
+				Config: config,
+				Header: &HeaderConfig{
+					Name:   "X-Token",
+					Scheme: "Token",
+				},
+			},
+		},
+		"dynamic and fixed scheme": {
+			strategy1: &OAuth2ClientCredentials{
+				Config: config,
+				Header: &HeaderConfig{
+					Name: "X-Token",
+				},
+			},
+			strategy2: &OAuth2ClientCredentials{
+				Config: config,
+				Header: &HeaderConfig{
+					Name:   "X-Token",
+					Scheme: "Bearer",
+				},
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			hash1 := tc.strategy1.Hash()
+			hash2 := tc.strategy2.Hash()
+
+			if tc.expectEqual {
+				assert.Equal(t, hash1, hash2)
+			} else {
+				assert.NotEqual(t, hash1, hash2)
+			}
+		})
+	}
+}

--- a/internal/rules/endpoint/authstrategy/http_message_signatures.go
+++ b/internal/rules/endpoint/authstrategy/http_message_signatures.go
@@ -17,9 +17,7 @@
 package authstrategy
 
 import (
-	"crypto/sha256"
 	"crypto/x509"
-	"encoding/binary"
 	"fmt"
 	"net/http"
 	"sync"
@@ -29,12 +27,11 @@ import (
 	"github.com/go-jose/go-jose/v4"
 	"github.com/rs/zerolog"
 
+	"github.com/dadrus/heimdall/internal/cache/cachekey"
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/keystore"
-	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
 	"github.com/dadrus/heimdall/internal/x/pkix"
-	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 type KeyStore struct {
@@ -105,29 +102,15 @@ func (s *HTTPMessageSignatures) Keys() []jose.JSONWebKey {
 }
 
 func (s *HTTPMessageSignatures) Hash() []byte {
-	const int64BytesCount = 8
+	key := cachekey.New("auth-strategy:http-message-signatures")
 
-	hash := sha256.New()
-	hash.Write(stringx.ToBytes(s.Label))
+	key.WriteString(s.Label)
+	key.WriteStrings(s.Components)
+	key.WriteInt64(int64(*s.TTL))
+	key.WriteString(s.Signer.Name)
+	key.WriteString(s.Signer.KeyID)
 
-	for _, component := range s.Components {
-		hash.Write(stringx.ToBytes(component))
-	}
-
-	if s.TTL != nil {
-		var ttlBytes [int64BytesCount]byte
-
-		//nolint:gosec
-		// no integer overflow during conversion possible
-		binary.LittleEndian.PutUint64(ttlBytes[:], uint64(*s.TTL))
-
-		hash.Write(ttlBytes[:])
-	}
-
-	hash.Write(stringx.ToBytes(s.Signer.Name))
-	hash.Write(stringx.ToBytes(s.Signer.KeyID))
-
-	return hash.Sum(nil)
+	return key.Sum()
 }
 
 func (s *HTTPMessageSignatures) Name() string { return "http message signer" }
@@ -182,15 +165,20 @@ func (s *HTTPMessageSignatures) init() error {
 		keys[idx] = entry.JWK()
 	}
 
+	if len(s.Signer.Name) == 0 {
+		s.Signer.Name = "heimdall"
+	}
+
+	if s.TTL == nil {
+		s.TTL = new(1 * time.Minute)
+	}
+
 	signer, err := httpsig.NewSigner(
 		toHTTPSigKey(kse),
 		httpsig.WithComponents(s.Components...),
-		httpsig.WithTag(x.IfThenElse(len(s.Signer.Name) != 0, s.Signer.Name, "heimdall")),
+		httpsig.WithTag(s.Signer.Name),
 		httpsig.WithLabel(s.Label),
-		httpsig.WithTTL(x.IfThenElseExec(s.TTL != nil,
-			func() time.Duration { return *s.TTL },
-			func() time.Duration { return 1 * time.Minute },
-		)),
+		httpsig.WithTTL(*s.TTL),
 	)
 	if err != nil {
 		return errorchain.NewWithMessage(heimdall.ErrConfiguration,

--- a/internal/rules/endpoint/authstrategy/http_message_signatures_test.go
+++ b/internal/rules/endpoint/authstrategy/http_message_signatures_test.go
@@ -237,18 +237,18 @@ func TestHTTPMessageSignaturesHash(t *testing.T) {
 	ttl := time.Hour
 
 	for uc, tc := range map[string]struct {
-		first     HTTPMessageSignatures
-		second    HTTPMessageSignatures
+		first     *HTTPMessageSignatures
+		second    *HTTPMessageSignatures
 		equalHash bool
 	}{
 		"same configuration": {
-			first: HTTPMessageSignatures{
+			first: &HTTPMessageSignatures{
 				Signer:     SignerConfig{Name: "heimdall", KeyID: "key1"},
 				Label:      "sig",
 				Components: []string{"@method"},
 				TTL:        &ttl,
 			},
-			second: HTTPMessageSignatures{
+			second: &HTTPMessageSignatures{
 				Signer:     SignerConfig{Name: "heimdall", KeyID: "key1"},
 				Label:      "sig",
 				Components: []string{"@method"},
@@ -257,13 +257,13 @@ func TestHTTPMessageSignaturesHash(t *testing.T) {
 			equalHash: true,
 		},
 		"different label": {
-			first: HTTPMessageSignatures{
+			first: &HTTPMessageSignatures{
 				Signer:     SignerConfig{Name: "heimdall", KeyID: "key1"},
 				Label:      "foo",
 				Components: []string{"@method"},
 				TTL:        &ttl,
 			},
-			second: HTTPMessageSignatures{
+			second: &HTTPMessageSignatures{
 				Signer:     SignerConfig{Name: "heimdall", KeyID: "key1"},
 				Label:      "bar",
 				Components: []string{"@method"},
@@ -271,24 +271,24 @@ func TestHTTPMessageSignaturesHash(t *testing.T) {
 			},
 		},
 		"component boundaries do not collide": {
-			first: HTTPMessageSignatures{
+			first: &HTTPMessageSignatures{
 				Signer:     SignerConfig{Name: "heimdall", KeyID: "key1"},
 				Components: []string{"ab", "c"},
 				TTL:        &ttl,
 			},
-			second: HTTPMessageSignatures{
+			second: &HTTPMessageSignatures{
 				Signer:     SignerConfig{Name: "heimdall", KeyID: "key1"},
 				Components: []string{"a", "bc"},
 				TTL:        &ttl,
 			},
 		},
 		"signer boundaries do not collide": {
-			first: HTTPMessageSignatures{
+			first: &HTTPMessageSignatures{
 				Signer:     SignerConfig{Name: "a", KeyID: "bc"},
 				Components: []string{"@method"},
 				TTL:        &ttl,
 			},
-			second: HTTPMessageSignatures{
+			second: &HTTPMessageSignatures{
 				Signer:     SignerConfig{Name: "ab", KeyID: "c"},
 				Components: []string{"@method"},
 				TTL:        &ttl,

--- a/internal/rules/endpoint/authstrategy/http_message_signatures_test.go
+++ b/internal/rules/endpoint/authstrategy/http_message_signatures_test.go
@@ -193,6 +193,9 @@ func TestHTTPMessageSignaturesInit(t *testing.T) {
 				assert.NotEmpty(t, conf.Certificates())
 				assert.NotEmpty(t, conf.Keys())
 				assert.Equal(t, "http message signer", conf.Name())
+				require.NotNil(t, conf.TTL)
+				assert.Equal(t, time.Minute, *conf.TTL)
+				assert.Equal(t, "heimdall", conf.Signer.Name)
 			},
 		},
 		"successful configuration with custom ttl": {
@@ -214,6 +217,9 @@ func TestHTTPMessageSignaturesInit(t *testing.T) {
 				assert.NotEmpty(t, conf.Certificates())
 				assert.NotEmpty(t, conf.Keys())
 				assert.Equal(t, "http message signer", conf.Name())
+				require.NotNil(t, conf.TTL)
+				assert.Equal(t, time.Hour, *conf.TTL)
+				assert.Equal(t, "heimdall", conf.Signer.Name)
 			},
 		},
 	} {

--- a/internal/rules/endpoint/authstrategy/http_message_signatures_test.go
+++ b/internal/rules/endpoint/authstrategy/http_message_signatures_test.go
@@ -234,27 +234,83 @@ func TestHTTPMessageSignaturesInit(t *testing.T) {
 func TestHTTPMessageSignaturesHash(t *testing.T) {
 	t.Parallel()
 
-	ttl := 1 * time.Hour
-	conf1 := &HTTPMessageSignatures{
-		Signer:     SignerConfig{KeyStore: KeyStore{Path: "/path/to/keystore.pem"}, KeyID: "key1"},
-		Components: []string{"@method"},
-		TTL:        &ttl,
-	}
-	conf2 := &HTTPMessageSignatures{
-		Signer:     SignerConfig{KeyStore: KeyStore{Path: "/path/to/keystore.pem"}, KeyID: "key1", Name: "foo"},
-		Components: []string{"@status"},
-		TTL:        &ttl,
-		Label:      "test",
-	}
+	ttl := time.Hour
 
-	hash1 := conf1.Hash()
-	hash2 := conf2.Hash()
+	for uc, tc := range map[string]struct {
+		first     HTTPMessageSignatures
+		second    HTTPMessageSignatures
+		equalHash bool
+	}{
+		"same configuration": {
+			first: HTTPMessageSignatures{
+				Signer:     SignerConfig{Name: "heimdall", KeyID: "key1"},
+				Label:      "sig",
+				Components: []string{"@method"},
+				TTL:        &ttl,
+			},
+			second: HTTPMessageSignatures{
+				Signer:     SignerConfig{Name: "heimdall", KeyID: "key1"},
+				Label:      "sig",
+				Components: []string{"@method"},
+				TTL:        &ttl,
+			},
+			equalHash: true,
+		},
+		"different label": {
+			first: HTTPMessageSignatures{
+				Signer:     SignerConfig{Name: "heimdall", KeyID: "key1"},
+				Label:      "foo",
+				Components: []string{"@method"},
+				TTL:        &ttl,
+			},
+			second: HTTPMessageSignatures{
+				Signer:     SignerConfig{Name: "heimdall", KeyID: "key1"},
+				Label:      "bar",
+				Components: []string{"@method"},
+				TTL:        &ttl,
+			},
+		},
+		"component boundaries do not collide": {
+			first: HTTPMessageSignatures{
+				Signer:     SignerConfig{Name: "heimdall", KeyID: "key1"},
+				Components: []string{"ab", "c"},
+				TTL:        &ttl,
+			},
+			second: HTTPMessageSignatures{
+				Signer:     SignerConfig{Name: "heimdall", KeyID: "key1"},
+				Components: []string{"a", "bc"},
+				TTL:        &ttl,
+			},
+		},
+		"signer boundaries do not collide": {
+			first: HTTPMessageSignatures{
+				Signer:     SignerConfig{Name: "a", KeyID: "bc"},
+				Components: []string{"@method"},
+				TTL:        &ttl,
+			},
+			second: HTTPMessageSignatures{
+				Signer:     SignerConfig{Name: "ab", KeyID: "c"},
+				Components: []string{"@method"},
+				TTL:        &ttl,
+			},
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			firstHash := tc.first.Hash()
+			secondHash := tc.second.Hash()
 
-	assert.NotEmpty(t, hash1)
-	assert.NotEmpty(t, hash2)
-	assert.NotEqual(t, hash1, hash2)
-	assert.Equal(t, hash1, conf1.Hash())
-	assert.Equal(t, hash2, conf2.Hash())
+			assert.NotEmpty(t, firstHash)
+			assert.NotEmpty(t, secondHash)
+			assert.Equal(t, firstHash, tc.first.Hash())
+			assert.Equal(t, secondHash, tc.second.Hash())
+
+			if tc.equalHash {
+				assert.Equal(t, firstHash, secondHash)
+			} else {
+				assert.NotEqual(t, firstHash, secondHash)
+			}
+		})
+	}
 }
 
 func TestHTTPMessageSignaturesApply(t *testing.T) {

--- a/internal/rules/endpoint/endpoint.go
+++ b/internal/rules/endpoint/endpoint.go
@@ -17,9 +17,7 @@
 package endpoint
 
 import (
-	"bytes"
 	"context"
-	"crypto/sha256"
 	"errors"
 	"io"
 	"net/http"
@@ -35,7 +33,6 @@ import (
 	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
 	"github.com/dadrus/heimdall/internal/x/httpx"
-	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 type HTTPCache struct {
@@ -161,29 +158,6 @@ func (e Endpoint) SendRequest(
 	}
 
 	return e.readResponse(resp)
-}
-
-func (e Endpoint) Hash() []byte {
-	hash := sha256.New()
-
-	hash.Write(stringx.ToBytes(e.URL))
-	hash.Write(stringx.ToBytes(e.Method))
-
-	buf := bytes.NewBufferString("")
-	for k, v := range e.Headers {
-		buf.Write(stringx.ToBytes(k))
-		buf.Write(stringx.ToBytes(v))
-	}
-
-	hash.Write(buf.Bytes())
-
-	if e.AuthStrategy != nil {
-		hash.Write(e.AuthStrategy.Hash())
-	}
-
-	var result [sha256.Size]byte
-
-	return hash.Sum(result[:0])
 }
 
 func (e Endpoint) readResponse(resp *http.Response) ([]byte, error) {

--- a/internal/rules/endpoint/endpoint_test.go
+++ b/internal/rules/endpoint/endpoint_test.go
@@ -501,37 +501,3 @@ func TestEndpointSendRequest(t *testing.T) {
 		})
 	}
 }
-
-func TestEndpointHash(t *testing.T) {
-	t.Parallel()
-
-	// GIVEN
-	e1 := Endpoint{URL: "foo.bar"}
-	e2 := Endpoint{URL: "foo.bar", Method: "FOO", Headers: map[string]string{"baz": "foo"}}
-	e3 := Endpoint{URL: "foo.bar", Method: "FOO", AuthStrategy: func() AuthenticationStrategy {
-		as := mocks.NewAuthenticationStrategyMock(t)
-		as.EXPECT().Hash().Return([]byte{1, 2, 3})
-
-		return as
-	}()}
-	e4 := Endpoint{URL: "foo.bar", Retry: &Retry{GiveUpAfter: 2}}
-
-	// WHEN
-	hash1 := e1.Hash()
-	hash2 := e2.Hash()
-	hash3 := e3.Hash()
-	hash4 := e4.Hash()
-
-	// THEN
-	assert.NotEmpty(t, hash1)
-	assert.NotEmpty(t, hash2)
-	assert.NotEmpty(t, hash3)
-	assert.NotEmpty(t, hash4)
-
-	assert.NotEqual(t, hash1, hash2)
-	assert.NotEqual(t, hash1, hash3)
-	assert.Equal(t, hash1, hash4)
-	assert.NotEqual(t, hash2, hash3)
-	assert.NotEqual(t, hash2, hash4)
-	assert.NotEqual(t, hash3, hash4)
-}

--- a/internal/rules/mechanisms/authenticators/generic_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/generic_authenticator.go
@@ -17,9 +17,6 @@
 package authenticators
 
 import (
-	"crypto/sha256"
-	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"io"
 	"net/http"
@@ -31,6 +28,7 @@ import (
 
 	"github.com/dadrus/heimdall/internal/app"
 	"github.com/dadrus/heimdall/internal/cache"
+	"github.com/dadrus/heimdall/internal/cache/cachekey"
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/rules/endpoint"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/authenticators/extractors"
@@ -38,7 +36,6 @@ import (
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/template"
 	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
-	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 // by intention. Used only during application bootstrap
@@ -214,9 +211,20 @@ func (a *genericAuthenticator) ID() string { return a.id }
 
 func (a *genericAuthenticator) IsInsecure() bool { return false }
 
+//nolint:cyclop
 func (a *genericAuthenticator) getSubjectInformation(ctx heimdall.RequestContext, authData string) ([]byte, error) {
 	logger := zerolog.Ctx(ctx.Context())
 	cch := cache.Ctx(ctx.Context())
+
+	renderedPayload, err := a.renderPayload(authData)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := a.createRequest(ctx, authData, renderedPayload)
+	if err != nil {
+		return nil, err
+	}
 
 	var (
 		cacheKey string
@@ -224,7 +232,7 @@ func (a *genericAuthenticator) getSubjectInformation(ctx heimdall.RequestContext
 	)
 
 	if a.ttl > 0 {
-		cacheKey = a.calculateCacheKey(ctx, authData)
+		cacheKey = a.calculateCacheKey(req, renderedPayload)
 		if entry, err := cch.Get(ctx.Context(), cacheKey); err == nil {
 			logger.Debug().Msg("Reusing subject information from cache")
 
@@ -232,7 +240,7 @@ func (a *genericAuthenticator) getSubjectInformation(ctx heimdall.RequestContext
 		}
 	}
 
-	payload, err := a.fetchSubjectInformation(ctx, authData)
+	payload, err := a.fetchSubjectInformation(req)
 	if err != nil {
 		return nil, err
 	}
@@ -259,12 +267,7 @@ func (a *genericAuthenticator) getSubjectInformation(ctx heimdall.RequestContext
 	return payload, nil
 }
 
-func (a *genericAuthenticator) fetchSubjectInformation(ctx heimdall.RequestContext, authData string) ([]byte, error) {
-	req, err := a.createRequest(ctx, authData)
-	if err != nil {
-		return nil, err
-	}
-
+func (a *genericAuthenticator) fetchSubjectInformation(req *http.Request) ([]byte, error) {
 	resp, err := a.e.CreateClient(req.URL.Hostname()).Do(req)
 	if err != nil {
 		var clientErr *url.Error
@@ -288,24 +291,37 @@ func (a *genericAuthenticator) fetchSubjectInformation(ctx heimdall.RequestConte
 	return a.readResponse(resp)
 }
 
-func (a *genericAuthenticator) createRequest(ctx heimdall.RequestContext, authData string) (*http.Request, error) {
+func (a *genericAuthenticator) renderPayload(authData string) (string, error) {
+	if a.payload == nil {
+		return "", nil
+	}
+
+	value, err := a.payload.Render(map[string]any{
+		"AuthenticationData": authData,
+	})
+	if err != nil {
+		return "", errorchain.NewWithMessage(heimdall.ErrInternal,
+			"failed to render payload for the authenticator endpoint").
+			WithErrorContext(a).CausedBy(err)
+	}
+
+	return value, nil
+}
+
+func (a *genericAuthenticator) createRequest(
+	ctx heimdall.RequestContext,
+	authData string,
+	payload string,
+) (*http.Request, error) {
 	logger := zerolog.Ctx(ctx.Context())
 
 	var body io.Reader
+	if len(payload) != 0 {
+		body = strings.NewReader(payload)
+	}
 
 	templateData := map[string]any{
 		"AuthenticationData": authData,
-	}
-
-	if a.payload != nil {
-		value, err := a.payload.Render(templateData)
-		if err != nil {
-			return nil, errorchain.NewWithMessage(heimdall.ErrInternal,
-				"failed to render payload for the authenticator endpoint").
-				WithErrorContext(a).CausedBy(err)
-		}
-
-		body = strings.NewReader(value)
 	}
 
 	req, err := a.e.CreateRequest(ctx.Context(), body,
@@ -393,42 +409,20 @@ func (a *genericAuthenticator) getCacheTTL(sessionLifespan *SessionLifespan) tim
 	return a.ttl
 }
 
-func (a *genericAuthenticator) calculateCacheKey(ctx heimdall.RequestContext, reference string) string {
-	digest := sha256.New()
-	digest.Write(a.e.Hash())
-	digest.Write(stringx.ToBytes(reference))
+func (a *genericAuthenticator) calculateCacheKey(req *http.Request, payload string) string {
+	key := cachekey.New("generic-authenticator:response")
 
-	if len(a.fwdHeaders) != 0 || len(a.fwdCookies) != 0 {
-		req := ctx.Request()
+	key.WriteString(a.name)
+	key.WriteInt64(int64(a.ttl))
+	key.WriteString(req.Method)
+	key.WriteString(req.URL.String())
+	key.WriteHeader(req.Header)
+	key.WriteString(payload)
 
-		var (
-			headerKind = [1]byte{0x01}
-			cookieKind = [1]byte{0x02}
-			separator  = [1]byte{0x00}
-		)
-
-		for _, headerName := range a.fwdHeaders {
-			digest.Write(headerKind[:])
-			digest.Write(stringx.ToBytes(headerName))
-			digest.Write(separator[:])
-			digest.Write(stringx.ToBytes(req.Header(headerName)))
-			digest.Write(separator[:])
-		}
-
-		for _, cookieName := range a.fwdCookies {
-			digest.Write(cookieKind[:])
-			digest.Write(stringx.ToBytes(cookieName))
-			digest.Write(separator[:])
-			digest.Write(stringx.ToBytes(req.Cookie(cookieName)))
-			digest.Write(separator[:])
-		}
+	key.WriteBool(a.e.AuthStrategy != nil)
+	if a.e.AuthStrategy != nil {
+		key.WriteBytes(a.e.AuthStrategy.Hash())
 	}
 
-	var ttl [8]byte
-	binary.BigEndian.PutUint64(ttl[:], uint64(a.ttl)) //nolint:gosec
-	digest.Write(ttl[:])
-
-	var result [sha256.Size]byte
-
-	return hex.EncodeToString(digest.Sum(result[:0]))
+	return key.SumString()
 }

--- a/internal/rules/mechanisms/authenticators/generic_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/generic_authenticator.go
@@ -211,17 +211,11 @@ func (a *genericAuthenticator) ID() string { return a.id }
 
 func (a *genericAuthenticator) IsInsecure() bool { return false }
 
-//nolint:cyclop
 func (a *genericAuthenticator) getSubjectInformation(ctx heimdall.RequestContext, authData string) ([]byte, error) {
 	logger := zerolog.Ctx(ctx.Context())
 	cch := cache.Ctx(ctx.Context())
 
-	renderedPayload, err := a.renderPayload(authData)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := a.createRequest(ctx, authData, renderedPayload)
+	req, renderedPayload, err := a.createRequest(ctx, authData)
 	if err != nil {
 		return nil, err
 	}
@@ -291,52 +285,55 @@ func (a *genericAuthenticator) fetchSubjectInformation(req *http.Request) ([]byt
 	return a.readResponse(resp)
 }
 
-func (a *genericAuthenticator) renderPayload(authData string) (string, error) {
-	if a.payload == nil {
-		return "", nil
-	}
-
-	value, err := a.payload.Render(map[string]any{
-		"AuthenticationData": authData,
-	})
-	if err != nil {
-		return "", errorchain.NewWithMessage(heimdall.ErrInternal,
-			"failed to render payload for the authenticator endpoint").
-			WithErrorContext(a).CausedBy(err)
-	}
-
-	return value, nil
-}
-
 func (a *genericAuthenticator) createRequest(
 	ctx heimdall.RequestContext,
 	authData string,
-	payload string,
-) (*http.Request, error) {
+) (*http.Request, string, error) {
 	logger := zerolog.Ctx(ctx.Context())
-
-	var body io.Reader
-	if len(payload) != 0 {
-		body = strings.NewReader(payload)
-	}
 
 	templateData := map[string]any{
 		"AuthenticationData": authData,
 	}
 
-	req, err := a.e.CreateRequest(ctx.Context(), body,
+	var (
+		body    io.Reader
+		payload string
+	)
+
+	if a.payload != nil {
+		value, err := a.payload.Render(templateData)
+		if err != nil {
+			return nil, "", errorchain.NewWithMessage(
+				heimdall.ErrInternal,
+				"failed to render payload for the authenticator endpoint",
+			).
+				WithErrorContext(a).
+				CausedBy(err)
+		}
+
+		payload = value
+		body = strings.NewReader(payload)
+	}
+
+	req, err := a.e.CreateRequest(
+		ctx.Context(),
+		body,
 		endpoint.RenderFunc(func(value string) (string, error) {
 			tpl, err := template.New(value)
 			if err != nil {
-				return "", errorchain.NewWithMessage(heimdall.ErrInternal, "failed to create template").
+				return "", errorchain.NewWithMessage(
+					heimdall.ErrInternal,
+					"failed to create template",
+				).
 					WithErrorContext(a).
 					CausedBy(err)
 			}
 
 			return tpl.Render(templateData)
-		}))
+		}),
+	)
 	if err != nil {
-		return nil, errorchain.
+		return nil, "", errorchain.
 			NewWithMessage(heimdall.ErrInternal, "failed creating request").
 			WithErrorContext(a).
 			CausedBy(err)
@@ -364,7 +361,7 @@ func (a *genericAuthenticator) createRequest(
 		}
 	}
 
-	return req, nil
+	return req, payload, nil
 }
 
 func (a *genericAuthenticator) readResponse(resp *http.Response) ([]byte, error) {

--- a/internal/rules/mechanisms/authenticators/generic_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/generic_authenticator_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/dadrus/heimdall/internal/heimdall"
 	heimdallmocks "github.com/dadrus/heimdall/internal/heimdall/mocks"
 	"github.com/dadrus/heimdall/internal/rules/endpoint"
+	"github.com/dadrus/heimdall/internal/rules/endpoint/authstrategy"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/authenticators/extractors"
 	mocks2 "github.com/dadrus/heimdall/internal/rules/mechanisms/authenticators/extractors/mocks"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/subject"
@@ -1469,172 +1470,344 @@ func TestGenericAuthenticatorReadResponse(t *testing.T) {
 func TestGenericAuthenticatorCalculateCacheKey(t *testing.T) {
 	t.Parallel()
 
-	ep := endpoint.Endpoint{
-		URL: "https://example.com/identity",
-	}
-
 	for uc, tc := range map[string]struct {
 		authenticator1 *genericAuthenticator
+		request1       *http.Request
+		payload1       string
 		authenticator2 *genericAuthenticator
-		headers1       map[string]string
-		headers2       map[string]string
-		cookies1       map[string]string
-		cookies2       map[string]string
+		request2       *http.Request
+		payload2       string
 		expectEqual    bool
 	}{
-		"same configuration and request": {
+		"same effective input": {
 			authenticator1: &genericAuthenticator{
-				e:          ep,
-				fwdHeaders: []string{"X-Tenant-ID"},
-				fwdCookies: []string{"tenant"},
-				ttl:        5 * time.Second,
+				name: "auth",
+				ttl:  5 * time.Second,
 			},
+			request1: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload1: `{"foo":"bar"}`,
 			authenticator2: &genericAuthenticator{
-				e:          ep,
-				fwdHeaders: []string{"X-Tenant-ID"},
-				fwdCookies: []string{"tenant"},
-				ttl:        5 * time.Second,
+				name: "auth",
+				ttl:  5 * time.Second,
 			},
-			headers1:    map[string]string{"X-Tenant-ID": "tenant-a"},
-			headers2:    map[string]string{"X-Tenant-ID": "tenant-a"},
-			cookies1:    map[string]string{"tenant": "tenant-a"},
-			cookies2:    map[string]string{"tenant": "tenant-a"},
+			request2: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload2:    `{"foo":"bar"}`,
+			expectEqual: true,
+		},
+		"different authenticator name": {
+			authenticator1: &genericAuthenticator{
+				name: "auth-a",
+				ttl:  5 * time.Second,
+			},
+			request1: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload1: `{"foo":"bar"}`,
+			authenticator2: &genericAuthenticator{
+				name: "auth-b",
+				ttl:  5 * time.Second,
+			},
+			request2: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload2: `{"foo":"bar"}`,
+		},
+		"different step id of same authenticator": {
+			authenticator1: &genericAuthenticator{
+				name: "auth",
+				id:   "step-a",
+				ttl:  5 * time.Second,
+			},
+			request1: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload1: `{"foo":"bar"}`,
+			authenticator2: &genericAuthenticator{
+				name: "auth",
+				id:   "step-b",
+				ttl:  5 * time.Second,
+			},
+			request2: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload2:    `{"foo":"bar"}`,
 			expectEqual: true,
 		},
 		"different cache ttl": {
 			authenticator1: &genericAuthenticator{
-				e:   ep,
-				ttl: 5 * time.Second,
+				name: "auth",
+				ttl:  5 * time.Second,
 			},
+			request1: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload1: `{"foo":"bar"}`,
 			authenticator2: &genericAuthenticator{
-				e:   ep,
-				ttl: 15 * time.Second,
+				name: "auth",
+				ttl:  15 * time.Second,
 			},
+			request2: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload2: `{"foo":"bar"}`,
 		},
-		"different forwarded header value": {
+		"different effective request method": {
 			authenticator1: &genericAuthenticator{
-				e:          ep,
-				fwdHeaders: []string{"X-Tenant-ID"},
-				ttl:        5 * time.Second,
+				name: "auth",
+				ttl:  5 * time.Second,
 			},
+			request1: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload1: `{"foo":"bar"}`,
 			authenticator2: &genericAuthenticator{
-				e:          ep,
-				fwdHeaders: []string{"X-Tenant-ID"},
-				ttl:        5 * time.Second,
+				name: "auth",
+				ttl:  5 * time.Second,
 			},
-			headers1: map[string]string{"X-Tenant-ID": "tenant-a"},
-			headers2: map[string]string{"X-Tenant-ID": "tenant-b"},
+			request2: httptest.NewRequest(
+				http.MethodPut,
+				"https://example.com/identity",
+				nil,
+			),
+			payload2: `{"foo":"bar"}`,
 		},
-		"different forwarded header name": {
+		"different effective request url": {
 			authenticator1: &genericAuthenticator{
-				e:          ep,
-				fwdHeaders: []string{"X-Tenant-ID"},
-				ttl:        5 * time.Second,
+				name: "auth",
+				ttl:  5 * time.Second,
 			},
+			request1: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity-a",
+				nil,
+			),
+			payload1: `{"foo":"bar"}`,
 			authenticator2: &genericAuthenticator{
-				e:          ep,
-				fwdHeaders: []string{"X-Organization-ID"},
-				ttl:        5 * time.Second,
+				name: "auth",
+				ttl:  5 * time.Second,
 			},
-			headers1: map[string]string{"X-Tenant-ID": "foo"},
-			headers2: map[string]string{"X-Organization-ID": "foo"},
+			request2: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity-b",
+				nil,
+			),
+			payload2: `{"foo":"bar"}`,
 		},
-		"different forwarded cookie value": {
+		"different effective request header": {
 			authenticator1: &genericAuthenticator{
-				e:          ep,
-				fwdCookies: []string{"tenant"},
-				ttl:        5 * time.Second,
+				name: "auth",
+				ttl:  5 * time.Second,
 			},
+			request1: func() *http.Request {
+				req := httptest.NewRequest(
+					http.MethodPost,
+					"https://example.com/identity",
+					nil,
+				)
+				req.Header.Set("X-Tenant-ID", "tenant-a")
+
+				return req
+			}(),
+			payload1: `{"foo":"bar"}`,
 			authenticator2: &genericAuthenticator{
-				e:          ep,
-				fwdCookies: []string{"tenant"},
-				ttl:        5 * time.Second,
+				name: "auth",
+				ttl:  5 * time.Second,
 			},
-			cookies1: map[string]string{"tenant": "tenant-a"},
-			cookies2: map[string]string{"tenant": "tenant-b"},
+			request2: func() *http.Request {
+				req := httptest.NewRequest(
+					http.MethodPost,
+					"https://example.com/identity",
+					nil,
+				)
+				req.Header.Set("X-Tenant-ID", "tenant-b")
+
+				return req
+			}(),
+			payload2: `{"foo":"bar"}`,
 		},
-		"different forwarded cookie name": {
+		"different effective request cookie": {
 			authenticator1: &genericAuthenticator{
-				e:          ep,
-				fwdCookies: []string{"tenant"},
-				ttl:        5 * time.Second,
+				name: "auth",
+				ttl:  5 * time.Second,
 			},
+			request1: func() *http.Request {
+				req := httptest.NewRequest(
+					http.MethodPost,
+					"https://example.com/identity",
+					nil,
+				)
+				req.AddCookie(&http.Cookie{
+					Name:  "tenant",
+					Value: "tenant-a",
+				})
+
+				return req
+			}(),
+			payload1: `{"foo":"bar"}`,
 			authenticator2: &genericAuthenticator{
-				e:          ep,
-				fwdCookies: []string{"organization"},
-				ttl:        5 * time.Second,
+				name: "auth",
+				ttl:  5 * time.Second,
 			},
-			cookies1: map[string]string{"tenant": "foo"},
-			cookies2: map[string]string{"organization": "foo"},
+			request2: func() *http.Request {
+				req := httptest.NewRequest(
+					http.MethodPost,
+					"https://example.com/identity",
+					nil,
+				)
+				req.AddCookie(&http.Cookie{
+					Name:  "tenant",
+					Value: "tenant-b",
+				})
+
+				return req
+			}(),
+			payload2: `{"foo":"bar"}`,
 		},
-		"different forwarded value type": {
+		"different rendered payload": {
 			authenticator1: &genericAuthenticator{
-				e:          ep,
-				fwdHeaders: []string{"tenant"},
-				ttl:        5 * time.Second,
+				name: "auth",
+				ttl:  5 * time.Second,
 			},
+			request1: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload1: `{"tenant":"tenant-a"}`,
 			authenticator2: &genericAuthenticator{
-				e:          ep,
-				fwdCookies: []string{"tenant"},
-				ttl:        5 * time.Second,
+				name: "auth",
+				ttl:  5 * time.Second,
 			},
-			headers1: map[string]string{"tenant": "foo"},
-			cookies2: map[string]string{"tenant": "foo"},
+			request2: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload2: `{"tenant":"tenant-b"}`,
+		},
+		"without vs with authentication strategy": {
+			authenticator1: &genericAuthenticator{
+				name: "auth",
+				ttl:  5 * time.Second,
+			},
+			request1: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload1: `{"foo":"bar"}`,
+			authenticator2: &genericAuthenticator{
+				name: "auth",
+				ttl:  5 * time.Second,
+				e: endpoint.Endpoint{
+					AuthStrategy: &authstrategy.APIKey{
+						In:    "header",
+						Name:  "X-API-Key",
+						Value: "secret",
+					},
+				},
+			},
+			request2: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload2: `{"foo":"bar"}`,
+		},
+		"different authentication strategy": {
+			authenticator1: &genericAuthenticator{
+				name: "auth",
+				ttl:  5 * time.Second,
+				e: endpoint.Endpoint{
+					AuthStrategy: &authstrategy.APIKey{
+						In:    "header",
+						Name:  "X-API-Key",
+						Value: "secret-a",
+					},
+				},
+			},
+			request1: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload1: `{"foo":"bar"}`,
+			authenticator2: &genericAuthenticator{
+				name: "auth",
+				ttl:  5 * time.Second,
+				e: endpoint.Endpoint{
+					AuthStrategy: &authstrategy.APIKey{
+						In:    "header",
+						Name:  "X-API-Key",
+						Value: "secret-b",
+					},
+				},
+			},
+			request2: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload2: `{"foo":"bar"}`,
+		},
+		"different endpoint configuration with same effective request": {
+			authenticator1: &genericAuthenticator{
+				name: "auth",
+				ttl:  5 * time.Second,
+				e: endpoint.Endpoint{
+					URL: "https://{{ .AuthenticationData }}/identity",
+				},
+			},
+			request1: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload1: `{"foo":"bar"}`,
+			authenticator2: &genericAuthenticator{
+				name: "auth",
+				ttl:  5 * time.Second,
+				e: endpoint.Endpoint{
+					URL: "https://example.com/{{ .AuthenticationData }}",
+				},
+			},
+			request2: httptest.NewRequest(
+				http.MethodPost,
+				"https://example.com/identity",
+				nil,
+			),
+			payload2:    `{"foo":"bar"}`,
+			expectEqual: true,
 		},
 	} {
 		t.Run(uc, func(t *testing.T) {
-			// GIVEN
-			ctx1 := heimdallmocks.NewRequestContextMock(t)
-
-			if len(tc.authenticator1.fwdHeaders) != 0 || len(tc.authenticator1.fwdCookies) != 0 {
-				reqFuns1 := heimdallmocks.NewRequestFunctionsMock(t)
-
-				for _, headerName := range tc.authenticator1.fwdHeaders {
-					reqFuns1.EXPECT().
-						Header(headerName).
-						Return(tc.headers1[headerName])
-				}
-
-				for _, cookieName := range tc.authenticator1.fwdCookies {
-					reqFuns1.EXPECT().
-						Cookie(cookieName).
-						Return(tc.cookies1[cookieName])
-				}
-
-				ctx1.EXPECT().
-					Request().
-					Return(&heimdall.Request{
-						RequestFunctions: reqFuns1,
-					})
-			}
-
-			ctx2 := heimdallmocks.NewRequestContextMock(t)
-
-			if len(tc.authenticator2.fwdHeaders) != 0 || len(tc.authenticator2.fwdCookies) != 0 {
-				reqFuns2 := heimdallmocks.NewRequestFunctionsMock(t)
-
-				for _, headerName := range tc.authenticator2.fwdHeaders {
-					reqFuns2.EXPECT().
-						Header(headerName).
-						Return(tc.headers2[headerName])
-				}
-
-				for _, cookieName := range tc.authenticator2.fwdCookies {
-					reqFuns2.EXPECT().
-						Cookie(cookieName).
-						Return(tc.cookies2[cookieName])
-				}
-
-				ctx2.EXPECT().
-					Request().
-					Return(&heimdall.Request{
-						RequestFunctions: reqFuns2,
-					})
-			}
+			t.Parallel()
 
 			// WHEN
-			key1 := tc.authenticator1.calculateCacheKey(ctx1, "authentication-data")
-			key2 := tc.authenticator2.calculateCacheKey(ctx2, "authentication-data")
+			key1 := tc.authenticator1.calculateCacheKey(tc.request1, tc.payload1)
+			key2 := tc.authenticator2.calculateCacheKey(tc.request2, tc.payload2)
 
 			// THEN
 			if tc.expectEqual {

--- a/internal/rules/mechanisms/authenticators/jwt_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator.go
@@ -461,7 +461,7 @@ func (a *jwtAuthenticator) getKey(
 	}
 
 	if a.isCacheEnabled() {
-		cacheKey = a.calculateCacheKey(ep, req.URL.String(), keyID)
+		cacheKey = a.calculateCacheKey(ep, req, keyID)
 		if entry, err := cch.Get(ctx.Context(), cacheKey); err == nil {
 			var key jose.JSONWebKey
 
@@ -635,16 +635,38 @@ func (a *jwtAuthenticator) verifyTokenWithKey(
 	return rawPayload, nil
 }
 
-func (a *jwtAuthenticator) calculateCacheKey(ep *endpoint.Endpoint, renderedURL, reference string) string {
+func (a *jwtAuthenticator) calculateCacheKey(
+	ep *endpoint.Endpoint,
+	req *http.Request,
+	reference string,
+) string {
+	var separator [1]byte
+
 	digest := sha256.New()
-	digest.Write(ep.Hash())
-	digest.Write(stringx.ToBytes(renderedURL))
+	digest.Write(stringx.ToBytes("jwt-authenticator:jwk:v2"))
+	digest.Write(separator[:])
+	digest.Write(stringx.ToBytes(req.Method))
+	digest.Write(separator[:])
+	digest.Write(stringx.ToBytes(req.URL.String()))
+	digest.Write(separator[:])
+
+	_ = req.Header.Write(digest)
+
+	digest.Write(separator[:])
 	digest.Write(stringx.ToBytes(reference))
+	digest.Write(separator[:])
+
+	if ep.AuthStrategy == nil {
+		digest.Write(separator[:])
+	} else {
+		digest.Write(separator[:])
+		digest.Write(ep.AuthStrategy.Hash())
+	}
 
 	if a.ttl == nil {
-		digest.Write([]byte{0})
+		digest.Write(separator[:])
 	} else {
-		digest.Write([]byte{1})
+		digest.Write(separator[:])
 
 		var ttl [8]byte
 		binary.BigEndian.PutUint64(ttl[:], uint64(*a.ttl)) //nolint:gosec

--- a/internal/rules/mechanisms/authenticators/jwt_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator.go
@@ -18,10 +18,7 @@ package authenticators
 
 import (
 	"context"
-	"crypto/sha256"
 	"crypto/x509"
-	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"net/http"
 	"net/url"
@@ -35,6 +32,7 @@ import (
 
 	"github.com/dadrus/heimdall/internal/app"
 	"github.com/dadrus/heimdall/internal/cache"
+	"github.com/dadrus/heimdall/internal/cache/cachekey"
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/rules/endpoint"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/authenticators/extractors"
@@ -45,7 +43,6 @@ import (
 	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
 	"github.com/dadrus/heimdall/internal/x/pkix"
-	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 const defaultJWTAuthenticatorTTL = 10 * time.Minute
@@ -640,42 +637,24 @@ func (a *jwtAuthenticator) calculateCacheKey(
 	req *http.Request,
 	reference string,
 ) string {
-	var separator [1]byte
+	key := cachekey.New("jwt-authenticator:jwk")
 
-	digest := sha256.New()
-	digest.Write(stringx.ToBytes("jwt-authenticator:jwk:v2"))
-	digest.Write(separator[:])
-	digest.Write(stringx.ToBytes(req.Method))
-	digest.Write(separator[:])
-	digest.Write(stringx.ToBytes(req.URL.String()))
-	digest.Write(separator[:])
+	key.WriteString(req.Method)
+	key.WriteString(req.URL.String())
+	key.WriteHeader(req.Header)
+	key.WriteString(reference)
 
-	_ = req.Header.Write(digest)
-
-	digest.Write(separator[:])
-	digest.Write(stringx.ToBytes(reference))
-	digest.Write(separator[:])
-
-	if ep.AuthStrategy == nil {
-		digest.Write(separator[:])
-	} else {
-		digest.Write(separator[:])
-		digest.Write(ep.AuthStrategy.Hash())
+	key.WriteBool(ep.AuthStrategy != nil)
+	if ep.AuthStrategy != nil {
+		key.WriteBytes(ep.AuthStrategy.Hash())
 	}
 
-	if a.ttl == nil {
-		digest.Write(separator[:])
-	} else {
-		digest.Write(separator[:])
-
-		var ttl [8]byte
-		binary.BigEndian.PutUint64(ttl[:], uint64(*a.ttl)) //nolint:gosec
-		digest.Write(ttl[:])
+	key.WriteBool(a.ttl != nil)
+	if a.ttl != nil {
+		key.WriteInt64(int64(*a.ttl))
 	}
 
-	var result [sha256.Size]byte
-
-	return hex.EncodeToString(digest.Sum(result[:0]))
+	return key.SumString()
 }
 
 func (a *jwtAuthenticator) validateJWK(jwk *jose.JSONWebKey) error {

--- a/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/jwt_authenticator_test.go
@@ -67,6 +67,24 @@ const (
 	kidRSAKey         = "key_rsa"
 )
 
+func createJWKSRequest(
+	t *testing.T,
+	method string,
+	rawURL string,
+	headers map[string]string,
+) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), method, rawURL, nil)
+	require.NoError(t, err)
+
+	for name, value := range headers {
+		req.Header.Set(name, value)
+	}
+
+	return req
+}
+
 func TestJwtAuthenticatorCreate(t *testing.T) {
 	t.Parallel()
 
@@ -179,8 +197,10 @@ assertions:
 				// token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
 				assert.Len(t, auth.ads, 2)
-				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"})
-				assert.Contains(t, auth.ads, extractors.QueryParameterExtractStrategy{Name: "access_token"})
+				assert.Contains(t, auth.ads,
+					extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"})
+				assert.Contains(t, auth.ads,
+					extractors.QueryParameterExtractStrategy{Name: "access_token"})
 
 				// assertions settings
 				require.NoError(t, auth.a.ScopesMatcher.Match([]string{}))
@@ -210,7 +230,9 @@ assertions:
 
 				// handler id
 				assert.Equal(t, auth.Name(), auth.ID())
-				assert.Equal(t, "minimal jwks endpoint based configuration with defaults, without cache and TLS enforcement", auth.ID())
+				assert.Equal(t,
+					"minimal jwks endpoint based configuration with defaults, without cache and TLS enforcement",
+					auth.ID())
 			},
 		},
 		"minimal jwks endpoint based configuration with cache and TLS enforcement": {
@@ -241,8 +263,10 @@ cache_ttl: 5s`),
 				// token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
 				assert.Len(t, auth.ads, 2)
-				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"})
-				assert.Contains(t, auth.ads, extractors.QueryParameterExtractStrategy{Name: "access_token"})
+				assert.Contains(t, auth.ads,
+					extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"})
+				assert.Contains(t, auth.ads,
+					extractors.QueryParameterExtractStrategy{Name: "access_token"})
 
 				// assertions settings
 				require.NoError(t, auth.a.ScopesMatcher.Match([]string{}))
@@ -273,7 +297,9 @@ cache_ttl: 5s`),
 
 				// handler id
 				assert.Equal(t, auth.Name(), auth.ID())
-				assert.Equal(t, "minimal jwks endpoint based configuration with cache and TLS enforcement", auth.ID())
+				assert.Equal(t,
+					"minimal jwks endpoint based configuration with cache and TLS enforcement",
+					auth.ID())
 			},
 		},
 		"minimal jwks endpoint based configuration with enforced but disabled TLS": {
@@ -340,8 +366,10 @@ trust_store: ` + trustStorePath),
 				assert.Contains(t, auth.ads, &extractors.HeaderValueExtractStrategy{
 					Name: "foo-header", Scheme: "foo",
 				})
-				assert.Contains(t, auth.ads, &extractors.QueryParameterExtractStrategy{Name: "foo_query_param"})
-				assert.Contains(t, auth.ads, &extractors.BodyParameterExtractStrategy{Name: "foo_body_param"})
+				assert.Contains(t, auth.ads,
+					&extractors.QueryParameterExtractStrategy{Name: "foo_query_param"})
+				assert.Contains(t, auth.ads,
+					&extractors.BodyParameterExtractStrategy{Name: "foo_body_param"})
 
 				// assertions settings
 				assert.NotNil(t, auth.a.ScopesMatcher)
@@ -418,8 +446,10 @@ cache_ttl: 5s`),
 				// token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
 				assert.Len(t, auth.ads, 2)
-				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"})
-				assert.Contains(t, auth.ads, extractors.QueryParameterExtractStrategy{Name: "access_token"})
+				assert.Contains(t, auth.ads,
+					extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"})
+				assert.Contains(t, auth.ads,
+					extractors.QueryParameterExtractStrategy{Name: "access_token"})
 
 				// assertions settings
 				require.NoError(t, auth.a.ScopesMatcher.Match([]string{}))
@@ -448,7 +478,9 @@ cache_ttl: 5s`),
 
 				// handler id
 				assert.Equal(t, auth.Name(), auth.ID())
-				assert.Equal(t, "metadata endpoint based configuration with cache and enabled TLS enforcement", auth.ID())
+				assert.Equal(t,
+					"metadata endpoint based configuration with cache and enabled TLS enforcement",
+					auth.ID())
 			},
 		},
 		"metadata endpoint with resolved endpoints configuration and enabled TLS enforcement": {
@@ -503,8 +535,10 @@ cache_ttl: 5s`),
 				// token extractor settings
 				assert.IsType(t, extractors.CompositeExtractStrategy{}, auth.ads)
 				assert.Len(t, auth.ads, 2)
-				assert.Contains(t, auth.ads, extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"})
-				assert.Contains(t, auth.ads, extractors.QueryParameterExtractStrategy{Name: "access_token"})
+				assert.Contains(t, auth.ads,
+					extractors.HeaderValueExtractStrategy{Name: "Authorization", Scheme: "Bearer"})
+				assert.Contains(t, auth.ads,
+					extractors.QueryParameterExtractStrategy{Name: "access_token"})
 
 				// assertions settings
 				require.NoError(t, auth.a.ScopesMatcher.Match([]string{}))
@@ -533,7 +567,9 @@ cache_ttl: 5s`),
 
 				// handler id
 				assert.Equal(t, auth.Name(), auth.ID())
-				assert.Equal(t, "metadata endpoint with resolved endpoints configuration and enabled TLS enforcement", auth.ID())
+				assert.Equal(t,
+					"metadata endpoint with resolved endpoints configuration and enabled TLS enforcement",
+					auth.ID())
 			},
 		},
 	} {
@@ -597,7 +633,6 @@ cache_ttl: 5s`),
 			assert: func(t *testing.T, err error, prototype *jwtAuthenticator, configured *jwtAuthenticator) {
 				t.Helper()
 
-				// THEN
 				require.NoError(t, err)
 
 				assert.Equal(t, prototype, configured)
@@ -615,7 +650,6 @@ cache_ttl: 5s`),
 			assert: func(t *testing.T, err error, prototype *jwtAuthenticator, configured *jwtAuthenticator) {
 				t.Helper()
 
-				// THEN
 				require.NoError(t, err)
 
 				assert.NotEqual(t, prototype, configured)
@@ -643,7 +677,6 @@ cache_ttl: 5s`),
 			assert: func(t *testing.T, err error, _ *jwtAuthenticator, _ *jwtAuthenticator) {
 				t.Helper()
 
-				// THEN
 				require.Error(t, err)
 				require.ErrorIs(t, err, heimdall.ErrConfiguration)
 				require.ErrorContains(t, err, "failed decoding")
@@ -665,7 +698,6 @@ assertions:
 			assert: func(t *testing.T, err error, prototype *jwtAuthenticator, configured *jwtAuthenticator) {
 				t.Helper()
 
-				// THEN
 				require.NoError(t, err)
 
 				assert.Equal(t, fmt.Sprintf("%v", prototype.r), fmt.Sprintf("%v", configured.r))
@@ -682,7 +714,9 @@ assertions:
 				assert.Equal(t, prototype.validateJWKCert, configured.validateJWKCert)
 				assert.Equal(t, prototype.trustStore, configured.trustStore)
 
-				assert.Equal(t, "prototype config without cache, target config with overwrites, but without cache", configured.ID())
+				assert.Equal(t,
+					"prototype config without cache, target config with overwrites, but without cache",
+					configured.ID())
 			},
 		},
 		"prototype config without cache, config with overwrites incl cache": {
@@ -704,7 +738,6 @@ cache_ttl: 5s`),
 			assert: func(t *testing.T, err error, prototype *jwtAuthenticator, configured *jwtAuthenticator) {
 				t.Helper()
 
-				// THEN
 				require.NoError(t, err)
 
 				assert.Equal(t, prototype.r, configured.r)
@@ -722,7 +755,9 @@ cache_ttl: 5s`),
 				assert.Equal(t, prototype.validateJWKCert, configured.validateJWKCert)
 				assert.Equal(t, prototype.trustStore, configured.trustStore)
 
-				assert.Equal(t, "prototype config without cache, config with overwrites incl cache", configured.ID())
+				assert.Equal(t,
+					"prototype config without cache, config with overwrites incl cache",
+					configured.ID())
 			},
 		},
 		"prototype config with cache, config without": {
@@ -742,7 +777,6 @@ assertions:
 			assert: func(t *testing.T, err error, prototype *jwtAuthenticator, configured *jwtAuthenticator) {
 				t.Helper()
 
-				// THEN
 				require.NoError(t, err)
 
 				assert.Equal(t, fmt.Sprintf("%v", prototype.r), fmt.Sprintf("%v", configured.r))
@@ -775,7 +809,6 @@ cache_ttl: 5s`),
 			assert: func(t *testing.T, err error, prototype *jwtAuthenticator, configured *jwtAuthenticator) {
 				t.Helper()
 
-				// THEN
 				require.NoError(t, err)
 
 				assert.Equal(t, fmt.Sprintf("%v", prototype.r), fmt.Sprintf("%v", configured.r))
@@ -788,7 +821,9 @@ cache_ttl: 5s`),
 				assert.Equal(t, prototype.validateJWKCert, configured.validateJWKCert)
 				assert.Equal(t, prototype.trustStore, configured.trustStore)
 
-				assert.Equal(t, "prototype config with cache, target config with cache only", configured.ID())
+				assert.Equal(t,
+					"prototype config with cache, target config with cache only",
+					configured.ID())
 			},
 		},
 		"prototype without scopes configured, created authenticator configures them and merges other fields": {
@@ -828,7 +863,9 @@ assertions:
 				assert.Equal(t, prototype.validateJWKCert, configured.validateJWKCert)
 				assert.Equal(t, prototype.trustStore, configured.trustStore)
 
-				assert.Equal(t, "prototype without scopes configured, created authenticator configures them and merges other fields", configured.ID())
+				assert.Equal(t,
+					"prototype without scopes configured, created authenticator configures them and merges other fields",
+					configured.ID())
 			},
 		},
 		"prototype with defaults, configured does not allow jwk trust store override": {
@@ -996,16 +1033,19 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 	for uc, tc := range map[string]struct {
 		authenticator  *jwtAuthenticator
 		instructServer func(t *testing.T)
-		configureMocks func(t *testing.T,
+		configureMocks func(
+			t *testing.T,
 			ctx *heimdallmocks.RequestContextMock,
 			cch *mocks.CacheMock,
 			ads *mocks2.AuthDataExtractStrategyMock,
-			auth *jwtAuthenticator)
+			auth *jwtAuthenticator,
+		)
 		assert func(t *testing.T, err error, sub *subject.Subject)
 	}{
 		"with failing auth data source": {
 			authenticator: &jwtAuthenticator{id: "auth3"},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				_ *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1033,7 +1073,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		},
 		"with unsupported JWT format": {
 			authenticator: &jwtAuthenticator{id: "auth3"},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				_ *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1061,7 +1102,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		},
 		"with JWT parsing error": {
 			authenticator: &jwtAuthenticator{id: "auth3"},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				_ *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1090,12 +1132,17 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		"with jwks endpoint rendering error": {
 			authenticator: &jwtAuthenticator{
 				id: "auth3",
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{JWKSEndpoint: &endpoint.Endpoint{URL: jwksSrv.URL + "{{ Foo }}"}}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{URL: jwksSrv.URL + "{{ Foo }}"},
+						}, nil
+					},
+				),
 				ttl: &disabledTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				_ *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1124,12 +1171,19 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		"with jwks endpoint communication error (dns)": {
 			authenticator: &jwtAuthenticator{
 				id: "auth3",
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{JWKSEndpoint: &endpoint.Endpoint{URL: "http://jwks.heimdall.test.local"}}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL: "http://jwks.heimdall.test.local",
+							},
+						}, nil
+					},
+				),
 				ttl: &disabledTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				_ *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1158,12 +1212,17 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		"with unexpected response code from jwks endpoint": {
 			authenticator: &jwtAuthenticator{
 				id: "auth3",
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{JWKSEndpoint: &endpoint.Endpoint{URL: jwksSrv.URL}}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{URL: jwksSrv.URL},
+						}, nil
+					},
+				),
 				ttl: &disabledTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				_ *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1197,17 +1256,20 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		"with jwks unmarshalling error": {
 			authenticator: &jwtAuthenticator{
 				id: "auth3",
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL,
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL,
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
 				ttl: &disabledTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				_ *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1247,17 +1309,20 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		"without unique key id": {
 			authenticator: &jwtAuthenticator{
 				id: "auth3",
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL,
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL,
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
 				ttl: &disabledTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				_ *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1300,7 +1365,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				r:   &oauth2.MetadataEndpoint{Endpoint: endpoint.Endpoint{URL: oidcSrv.URL}},
 				ttl: &disabledTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				cch *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1309,7 +1375,9 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				t.Helper()
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyOnlyJWK, nil)
-				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil, errors.New("no cache entry"))
+				cch.EXPECT().
+					Get(mock.Anything, mock.Anything).
+					Return(nil, errors.New("no cache entry"))
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -1341,7 +1409,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				r:   &oauth2.MetadataEndpoint{Endpoint: endpoint.Endpoint{URL: oidcSrv.URL}},
 				ttl: &disabledTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				cch *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1350,11 +1419,19 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				t.Helper()
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyOnlyJWK, nil)
-				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil, errors.New("no cache entry"))
-				// http cache
-				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(
-					func(ttl time.Duration) bool { return ttl.Round(time.Minute) == 30*time.Minute },
-				)).Return(nil)
+				cch.EXPECT().
+					Get(mock.Anything, mock.Anything).
+					Return(nil, errors.New("no cache entry"))
+				cch.EXPECT().
+					Set(
+						mock.Anything,
+						mock.Anything,
+						mock.Anything,
+						mock.MatchedBy(func(ttl time.Duration) bool {
+							return ttl.Round(time.Minute) == 30*time.Minute
+						}),
+					).
+					Return(nil)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -1385,18 +1462,21 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		"with positive cache hit, but unsupported algorithm": {
 			authenticator: &jwtAuthenticator{
 				id: "auth3",
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL,
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL,
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
 				a:   oauth2.Expectation{AllowedAlgorithms: []string{"foo"}},
 				ttl: &tenSecondsTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				cch *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1408,7 +1488,13 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					URL:     jwksSrv.URL,
 					Headers: map[string]string{"Accept": "application/json"},
 				}
-				cacheKey := auth.calculateCacheKey(ep, jwksSrv.URL, kidKeyWithoutCert)
+				req := createJWKSRequest(
+					t,
+					http.MethodPost,
+					jwksSrv.URL,
+					map[string]string{"Accept": "application/json"},
+				)
+				cacheKey := auth.calculateCacheKey(ep, req, kidKeyWithoutCert)
 
 				var jwks jose.JSONWebKeySet
 				err := json.Unmarshal(jwksWithOneKeyOnlyEntry, &jwks)
@@ -1441,18 +1527,21 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		"with positive cache hit, but signature verification error": {
 			authenticator: &jwtAuthenticator{
 				id: "auth3",
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL,
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL,
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
 				a:   oauth2.Expectation{AllowedAlgorithms: []string{"ES384"}},
 				ttl: &tenSecondsTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				cch *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1464,7 +1553,13 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					URL:     jwksSrv.URL,
 					Headers: map[string]string{"Accept": "application/json"},
 				}
-				cacheKey := auth.calculateCacheKey(ep, jwksSrv.URL, kidKeyWithCert)
+				req := createJWKSRequest(
+					t,
+					http.MethodPost,
+					jwksSrv.URL,
+					map[string]string{"Accept": "application/json"},
+				)
+				cacheKey := auth.calculateCacheKey(ep, req, kidKeyWithCert)
 
 				var jwks jose.JSONWebKeySet
 				err := json.Unmarshal(jwksWithOneKeyOnlyEntry, &jwks)
@@ -1497,18 +1592,24 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		"with positive cache hit, but claims verification error": {
 			authenticator: &jwtAuthenticator{
 				id: "auth3",
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL,
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
-				a:   oauth2.Expectation{AllowedAlgorithms: []string{"ES384"}, TrustedIssuers: []string{"untrusted"}},
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL,
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
+				a: oauth2.Expectation{
+					AllowedAlgorithms: []string{"ES384"},
+					TrustedIssuers:    []string{"untrusted"},
+				},
 				ttl: &tenSecondsTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				cch *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1520,7 +1621,13 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					URL:     jwksSrv.URL,
 					Headers: map[string]string{"Accept": "application/json"},
 				}
-				cacheKey := auth.calculateCacheKey(ep, jwksSrv.URL, kidKeyWithoutCert)
+				req := createJWKSRequest(
+					t,
+					http.MethodPost,
+					jwksSrv.URL,
+					map[string]string{"Accept": "application/json"},
+				)
+				cacheKey := auth.calculateCacheKey(ep, req, kidKeyWithoutCert)
 
 				var jwks jose.JSONWebKeySet
 				err := json.Unmarshal(jwksWithOneKeyOnlyEntry, &jwks)
@@ -1553,14 +1660,16 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		"with positive cache hit, but subject creation error": {
 			authenticator: &jwtAuthenticator{
 				id: "auth3",
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL,
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL,
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
 				a: oauth2.Expectation{
 					AllowedAlgorithms: []string{"ES384"},
 					TrustedIssuers:    []string{issuer},
@@ -1569,7 +1678,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				sf:  &SubjectInfo{IDFrom: "foobar"},
 				ttl: &tenSecondsTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				cch *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1581,7 +1691,13 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					URL:     jwksSrv.URL,
 					Headers: map[string]string{"Accept": "application/json"},
 				}
-				cacheKey := auth.calculateCacheKey(ep, jwksSrv.URL, kidKeyWithoutCert)
+				req := createJWKSRequest(
+					t,
+					http.MethodPost,
+					jwksSrv.URL,
+					map[string]string{"Accept": "application/json"},
+				)
+				cacheKey := auth.calculateCacheKey(ep, req, kidKeyWithoutCert)
 
 				var jwks jose.JSONWebKeySet
 				err := json.Unmarshal(jwksWithOneKeyOnlyEntry, &jwks)
@@ -1613,14 +1729,16 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		},
 		"successful with positive cache hit": {
 			authenticator: &jwtAuthenticator{
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL,
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL,
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
 				a: oauth2.Expectation{
 					AllowedAlgorithms: []string{"ES384"},
 					TrustedIssuers:    []string{issuer},
@@ -1629,7 +1747,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				sf:  &SubjectInfo{IDFrom: "sub"},
 				ttl: &tenSecondsTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				cch *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1641,7 +1760,13 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					URL:     jwksSrv.URL,
 					Headers: map[string]string{"Accept": "application/json"},
 				}
-				cacheKey := auth.calculateCacheKey(ep, jwksSrv.URL, kidKeyWithoutCert)
+				req := createJWKSRequest(
+					t,
+					http.MethodPost,
+					jwksSrv.URL,
+					map[string]string{"Accept": "application/json"},
+				)
+				cacheKey := auth.calculateCacheKey(ep, req, kidKeyWithoutCert)
 
 				var jwks jose.JSONWebKeySet
 				err := json.Unmarshal(jwksWithOneKeyOnlyEntry, &jwks)
@@ -1677,16 +1802,22 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				assert.Equal(t, subjectID, sub.Attributes["sub"])
 			},
 		},
-		"successful without cache hit using key only": {
+		"successful without cache hit using rendered endpoint header": {
 			authenticator: &jwtAuthenticator{
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL + "/{{ .TokenIssuer }}",
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:    jwksSrv.URL,
+								Method: http.MethodGet,
+								Headers: map[string]string{
+									"Accept":   "application/json",
+									"X-Issuer": "{{ .TokenIssuer }}",
+								},
+							},
+						}, nil
+					},
+				),
 				a: oauth2.Expectation{
 					AllowedAlgorithms: []string{"ES384"},
 					TrustedIssuers:    []string{issuer},
@@ -1695,7 +1826,121 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				sf:  &SubjectInfo{IDFrom: "sub"},
 				ttl: &tenSecondsTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
+				ctx *heimdallmocks.RequestContextMock,
+				cch *mocks.CacheMock,
+				ads *mocks2.AuthDataExtractStrategyMock,
+				auth *jwtAuthenticator,
+			) {
+				t.Helper()
+
+				ep := &endpoint.Endpoint{
+					URL:    jwksSrv.URL,
+					Method: http.MethodGet,
+					Headers: map[string]string{
+						"Accept":   "application/json",
+						"X-Issuer": "{{ .TokenIssuer }}",
+					},
+				}
+
+				previousReq := createJWKSRequest(
+					t,
+					http.MethodGet,
+					jwksSrv.URL,
+					map[string]string{
+						"Accept":   "application/json",
+						"X-Issuer": "other-issuer",
+					},
+				)
+				currentReq := createJWKSRequest(
+					t,
+					http.MethodGet,
+					jwksSrv.URL,
+					map[string]string{
+						"Accept":   "application/json",
+						"X-Issuer": issuer,
+					},
+				)
+
+				previousCacheKey := auth.calculateCacheKey(
+					ep,
+					previousReq,
+					kidKeyWithoutCert,
+				)
+				currentCacheKey := auth.calculateCacheKey(
+					ep,
+					currentReq,
+					kidKeyWithoutCert,
+				)
+
+				require.NotEqual(t, previousCacheKey, currentCacheKey)
+
+				var jwks jose.JSONWebKeySet
+				err := json.Unmarshal(jwksWithOneKeyOnlyEntry, &jwks)
+				require.NoError(t, err)
+
+				keys := jwks.Key(kidKeyWithoutCert)
+
+				rawKey, err := json.Marshal(keys[0])
+				require.NoError(t, err)
+
+				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyOnlyJWK, nil)
+				cch.EXPECT().
+					Get(mock.Anything, currentCacheKey).
+					Return(nil, errors.New("no cache entry"))
+				cch.EXPECT().
+					Set(mock.Anything, currentCacheKey, rawKey, *auth.ttl).
+					Return(nil)
+			},
+			instructServer: func(t *testing.T) {
+				t.Helper()
+
+				checkJWKSRequest = func(req *http.Request) {
+					assert.Equal(t, http.MethodGet, req.Method)
+					assert.Equal(t, "application/json", req.Header.Get("Accept"))
+					assert.Equal(t, issuer, req.Header.Get("X-Issuer"))
+				}
+
+				jwksResponseCode = http.StatusOK
+				jwksResponseContent = jwksWithOneKeyOnlyEntry
+				jwksResponseContentType = "application/json"
+			},
+			assert: func(t *testing.T, err error, sub *subject.Subject) {
+				t.Helper()
+
+				assert.True(t, jwksEndpointCalled)
+				assert.False(t, metadataEndpointCalled)
+
+				require.NoError(t, err)
+
+				require.NotNil(t, sub)
+				assert.Equal(t, subjectID, sub.ID)
+				assert.Equal(t, issuer, sub.Attributes["iss"])
+			},
+		},
+		"successful without cache hit using key only": {
+			authenticator: &jwtAuthenticator{
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL + "/{{ .TokenIssuer }}",
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
+				a: oauth2.Expectation{
+					AllowedAlgorithms: []string{"ES384"},
+					TrustedIssuers:    []string{issuer},
+					ScopesMatcher:     oauth2.ExactScopeStrategyMatcher{},
+				},
+				sf:  &SubjectInfo{IDFrom: "sub"},
+				ttl: &tenSecondsTTL,
+			},
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				cch *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1707,7 +1952,13 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					URL:     jwksSrv.URL + "/{{ .TokenIssuer }}",
 					Headers: map[string]string{"Accept": "application/json"},
 				}
-				cacheKey := auth.calculateCacheKey(ep, fmt.Sprintf("%s/%s", jwksSrv.URL, issuer), kidKeyWithoutCert)
+				req := createJWKSRequest(
+					t,
+					http.MethodPost,
+					fmt.Sprintf("%s/%s", jwksSrv.URL, issuer),
+					map[string]string{"Accept": "application/json"},
+				)
+				cacheKey := auth.calculateCacheKey(ep, req, kidKeyWithoutCert)
 
 				var jwks jose.JSONWebKeySet
 				err := json.Unmarshal(jwksWithOneKeyOnlyEntry, &jwks)
@@ -1758,14 +2009,16 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		},
 		"successful without cache hit using key & cert with disabled jwk validation": {
 			authenticator: &jwtAuthenticator{
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL,
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL,
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
 				a: oauth2.Expectation{
 					AllowedAlgorithms: []string{"ES384"},
 					TrustedIssuers:    []string{issuer},
@@ -1774,7 +2027,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				sf:  &SubjectInfo{IDFrom: "sub"},
 				ttl: &tenSecondsTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				cch *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1786,10 +2040,19 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					URL:     jwksSrv.URL,
 					Headers: map[string]string{"Accept": "application/json"},
 				}
-				cacheKey := auth.calculateCacheKey(ep, jwksSrv.URL, kidKeyWithCert)
+				req := createJWKSRequest(
+					t,
+					http.MethodPost,
+					jwksSrv.URL,
+					map[string]string{"Accept": "application/json"},
+				)
+				cacheKey := auth.calculateCacheKey(ep, req, kidKeyWithCert)
 
 				var jwks jose.JSONWebKeySet
-				err := json.Unmarshal(jwksWithOneEntryWithKeyOnlyAndOneWithCertificate, &jwks)
+				err := json.Unmarshal(
+					jwksWithOneEntryWithKeyOnlyAndOneWithCertificate,
+					&jwks,
+				)
 				require.NoError(t, err)
 
 				keys := jwks.Key(kidKeyWithCert)
@@ -1837,7 +2100,9 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		"successful without cache hit using key & cert with disabled jwk validation using metadata discovery": {
 			authenticator: &jwtAuthenticator{
 				r: &oauth2.MetadataEndpoint{
-					Endpoint:                            endpoint.Endpoint{URL: oidcSrv.URL + "/{{ .TokenIssuer }}"},
+					Endpoint: endpoint.Endpoint{
+						URL: oidcSrv.URL + "/{{ .TokenIssuer }}",
+					},
 					DisableIssuerIdentifierVerification: true,
 				},
 				a: oauth2.Expectation{
@@ -1847,7 +2112,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				sf:  &SubjectInfo{IDFrom: "sub"},
 				ttl: &tenSecondsTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				cch *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1860,10 +2126,19 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					Headers: map[string]string{"Accept": "application/json"},
 					Method:  http.MethodGet,
 				}
-				cacheKey := auth.calculateCacheKey(ep, jwksSrv.URL, kidKeyWithCert)
+				req := createJWKSRequest(
+					t,
+					http.MethodGet,
+					jwksSrv.URL,
+					map[string]string{"Accept": "application/json"},
+				)
+				cacheKey := auth.calculateCacheKey(ep, req, kidKeyWithCert)
 
 				var jwks jose.JSONWebKeySet
-				err := json.Unmarshal(jwksWithOneEntryWithKeyOnlyAndOneWithCertificate, &jwks)
+				err := json.Unmarshal(
+					jwksWithOneEntryWithKeyOnlyAndOneWithCertificate,
+					&jwks,
+				)
 				require.NoError(t, err)
 
 				keys := jwks.Key(kidKeyWithCert)
@@ -1872,12 +2147,22 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				require.NoError(t, err)
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyAndCertJWK, nil)
-				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil, errors.New("no cache entry"))
-				cch.EXPECT().Set(mock.Anything, cacheKey, rawKey, *auth.ttl).Return(nil)
-				// http cache
-				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(
-					func(ttl time.Duration) bool { return ttl.Round(time.Minute) == 30*time.Minute },
-				)).Return(nil)
+				cch.EXPECT().
+					Get(mock.Anything, mock.Anything).
+					Return(nil, errors.New("no cache entry"))
+				cch.EXPECT().
+					Set(mock.Anything, cacheKey, rawKey, *auth.ttl).
+					Return(nil)
+				cch.EXPECT().
+					Set(
+						mock.Anything,
+						mock.Anything,
+						mock.Anything,
+						mock.MatchedBy(func(ttl time.Duration) bool {
+							return ttl.Round(time.Minute) == 30*time.Minute
+						}),
+					).
+					Return(nil)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -1927,14 +2212,16 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		"successful without cache hit using key & cert with enabled jwk validation using system trust store": {
 			authenticator: &jwtAuthenticator{
 				id: "auth3",
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL,
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL,
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
 				a: oauth2.Expectation{
 					AllowedAlgorithms: []string{"ES384"},
 					TrustedIssuers:    []string{issuer},
@@ -1944,7 +2231,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				ttl:             &tenSecondsTTL,
 				validateJWKCert: true,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				cch *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -1956,10 +2244,19 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					URL:     jwksSrv.URL,
 					Headers: map[string]string{"Accept": "application/json"},
 				}
-				cacheKey := auth.calculateCacheKey(ep, jwksSrv.URL, kidKeyWithCert)
+				req := createJWKSRequest(
+					t,
+					http.MethodPost,
+					jwksSrv.URL,
+					map[string]string{"Accept": "application/json"},
+				)
+				cacheKey := auth.calculateCacheKey(ep, req, kidKeyWithCert)
 
 				var jwks jose.JSONWebKeySet
-				err := json.Unmarshal(jwksWithOneEntryWithKeyOnlyAndOneWithCertificate, &jwks)
+				err := json.Unmarshal(
+					jwksWithOneEntryWithKeyOnlyAndOneWithCertificate,
+					&jwks,
+				)
 				require.NoError(t, err)
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyAndCertJWK, nil)
@@ -1994,14 +2291,16 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		},
 		"successful without cache hit using key & cert with jwk validation using custom trust store": {
 			authenticator: &jwtAuthenticator{
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL,
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL,
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
 				a: oauth2.Expectation{
 					AllowedAlgorithms: []string{"ES384"},
 					TrustedIssuers:    []string{issuer},
@@ -2012,7 +2311,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				validateJWKCert: true,
 				trustStore:      truststore.TrustStore{keyAndCertEntry.CertChain[2]},
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				cch *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -2024,10 +2324,19 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					URL:     jwksSrv.URL,
 					Headers: map[string]string{"Accept": "application/json"},
 				}
-				cacheKey := auth.calculateCacheKey(ep, jwksSrv.URL, kidKeyWithCert)
+				req := createJWKSRequest(
+					t,
+					http.MethodPost,
+					jwksSrv.URL,
+					map[string]string{"Accept": "application/json"},
+				)
+				cacheKey := auth.calculateCacheKey(ep, req, kidKeyWithCert)
 
 				var jwks jose.JSONWebKeySet
-				err := json.Unmarshal(jwksWithOneEntryWithKeyOnlyAndOneWithCertificate, &jwks)
+				err := json.Unmarshal(
+					jwksWithOneEntryWithKeyOnlyAndOneWithCertificate,
+					&jwks,
+				)
 				require.NoError(t, err)
 
 				keys := jwks.Key(kidKeyWithCert)
@@ -2074,14 +2383,16 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		},
 		"successful validation of token without kid": {
 			authenticator: &jwtAuthenticator{
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL,
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL,
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
 				a: oauth2.Expectation{
 					AllowedAlgorithms: []string{"ES384"},
 					TrustedIssuers:    []string{issuer},
@@ -2091,7 +2402,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				validateJWKCert: true,
 				trustStore:      truststore.TrustStore{keyAndCertEntry.CertChain[2]},
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				_ *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -2099,7 +2411,9 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 			) {
 				t.Helper()
 
-				ads.EXPECT().GetAuthData(ctx).Return(jwtWithoutKIDSignedWithKeyAndCertJWK, nil)
+				ads.EXPECT().
+					GetAuthData(ctx).
+					Return(jwtWithoutKIDSignedWithKeyAndCertJWK, nil)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -2137,16 +2451,19 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		"validation of token without kid fails because of jwks response unmarshalling error": {
 			authenticator: &jwtAuthenticator{
 				id: "auth3",
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL,
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL,
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				_ *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -2154,7 +2471,9 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 			) {
 				t.Helper()
 
-				ads.EXPECT().GetAuthData(ctx).Return(jwtWithoutKIDSignedWithKeyAndCertJWK, nil)
+				ads.EXPECT().
+					GetAuthData(ctx).
+					Return(jwtWithoutKIDSignedWithKeyAndCertJWK, nil)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -2185,16 +2504,19 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		"validation of token without kid fails as available keys don't have matching algorithms": {
 			authenticator: &jwtAuthenticator{
 				id: "auth3",
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL,
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL,
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				_ *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -2202,7 +2524,9 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 			) {
 				t.Helper()
 
-				ads.EXPECT().GetAuthData(ctx).Return(jwtWithoutKIDSignedWithKeyAndCertJWK, nil)
+				ads.EXPECT().
+					GetAuthData(ctx).
+					Return(jwtWithoutKIDSignedWithKeyAndCertJWK, nil)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -2233,17 +2557,20 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		"validation of token without kid fails as available keys could not be verified": {
 			authenticator: &jwtAuthenticator{
 				id: "auth3",
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL,
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL,
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
 				validateJWKCert: true,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				_ *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -2251,7 +2578,9 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 			) {
 				t.Helper()
 
-				ads.EXPECT().GetAuthData(ctx).Return(jwtWithoutKIDSignedWithKeyAndCertJWK, nil)
+				ads.EXPECT().
+					GetAuthData(ctx).
+					Return(jwtWithoutKIDSignedWithKeyAndCertJWK, nil)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -2293,7 +2622,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				sf:  &SubjectInfo{IDFrom: "sub"},
 				ttl: &disabledTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				cch *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -2302,11 +2632,20 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				t.Helper()
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyAndCertJWK, nil)
-				// http cache
-				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil, errors.New("no cache entry"))
-				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(
-					func(ttl time.Duration) bool { return ttl.Round(time.Minute) == 30*time.Minute },
-				)).Return(nil)
+
+				cch.EXPECT().
+					Get(mock.Anything, mock.Anything).
+					Return(nil, errors.New("no cache entry"))
+				cch.EXPECT().
+					Set(
+						mock.Anything,
+						mock.Anything,
+						mock.Anything,
+						mock.MatchedBy(func(ttl time.Duration) bool {
+							return ttl.Round(time.Minute) == 30*time.Minute
+						}),
+					).
+					Return(nil)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -2364,7 +2703,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				sf:  &SubjectInfo{IDFrom: "sub"},
 				ttl: &disabledTTL,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				cch *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -2373,11 +2713,20 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				t.Helper()
 
 				ads.EXPECT().GetAuthData(ctx).Return(jwtSignedWithKeyAndCertJWK, nil)
-				// http cache
-				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil, errors.New("no cache entry"))
-				cch.EXPECT().Set(mock.Anything, mock.Anything, mock.Anything, mock.MatchedBy(
-					func(ttl time.Duration) bool { return ttl.Round(time.Minute) == 30*time.Minute },
-				)).Return(nil)
+
+				cch.EXPECT().
+					Get(mock.Anything, mock.Anything).
+					Return(nil, errors.New("no cache entry"))
+				cch.EXPECT().
+					Set(
+						mock.Anything,
+						mock.Anything,
+						mock.Anything,
+						mock.MatchedBy(func(ttl time.Duration) bool {
+							return ttl.Round(time.Minute) == 30*time.Minute
+						}),
+					).
+					Return(nil)
 			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
@@ -2416,14 +2765,16 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 		"failed with positive cache hit due to invalid JWK certificate": {
 			authenticator: &jwtAuthenticator{
 				id: "auth3",
-				r: oauth2.ResolverAdapterFunc(func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
-					return oauth2.ServerMetadata{
-						JWKSEndpoint: &endpoint.Endpoint{
-							URL:     jwksSrv.URL,
-							Headers: map[string]string{"Accept": "application/json"},
-						},
-					}, nil
-				}),
+				r: oauth2.ResolverAdapterFunc(
+					func(_ context.Context, _ map[string]any) (oauth2.ServerMetadata, error) {
+						return oauth2.ServerMetadata{
+							JWKSEndpoint: &endpoint.Endpoint{
+								URL:     jwksSrv.URL,
+								Headers: map[string]string{"Accept": "application/json"},
+							},
+						}, nil
+					},
+				),
 				a: oauth2.Expectation{
 					AllowedAlgorithms: []string{"ES384"},
 					TrustedIssuers:    []string{issuer},
@@ -2433,7 +2784,8 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 				ttl:             &tenSecondsTTL,
 				validateJWKCert: true,
 			},
-			configureMocks: func(t *testing.T,
+			configureMocks: func(
+				t *testing.T,
 				ctx *heimdallmocks.RequestContextMock,
 				cch *mocks.CacheMock,
 				ads *mocks2.AuthDataExtractStrategyMock,
@@ -2445,7 +2797,13 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 					URL:     jwksSrv.URL,
 					Headers: map[string]string{"Accept": "application/json"},
 				}
-				cacheKey := auth.calculateCacheKey(ep, jwksSrv.URL, kidKeyWithCert)
+				req := createJWKSRequest(
+					t,
+					http.MethodPost,
+					jwksSrv.URL,
+					map[string]string{"Accept": "application/json"},
+				)
+				cacheKey := auth.calculateCacheKey(ep, req, kidKeyWithCert)
 
 				rawKey, err := json.Marshal(keyAndCertEntry.JWK())
 				require.NoError(t, err)
@@ -2485,20 +2843,25 @@ func TestJwtAuthenticatorExecute(t *testing.T) {
 			checkJWKSRequest = func(*http.Request) { t.Helper() }
 			checkMetadataRequest = func(*http.Request) { t.Helper() }
 
-			instructServer := x.IfThenElse(tc.instructServer != nil,
+			instructServer := x.IfThenElse(
+				tc.instructServer != nil,
 				tc.instructServer,
-				func(t *testing.T) { t.Helper() })
+				func(t *testing.T) { t.Helper() },
+			)
 
-			configureMocks := x.IfThenElse(tc.configureMocks != nil,
+			configureMocks := x.IfThenElse(
+				tc.configureMocks != nil,
 				tc.configureMocks,
-				func(t *testing.T,
+				func(
+					t *testing.T,
 					_ *heimdallmocks.RequestContextMock,
 					_ *mocks.CacheMock,
 					_ *mocks2.AuthDataExtractStrategyMock,
 					_ *jwtAuthenticator,
 				) {
 					t.Helper()
-				})
+				},
+			)
 
 			ads := mocks2.NewAuthDataExtractStrategyMock(t)
 			tc.authenticator.ads = ads
@@ -2542,7 +2905,8 @@ func createKS(t *testing.T) keystore.KeyStore {
 		}),
 		testsupport.WithIsCA(),
 		testsupport.WithValidity(time.Now(), time.Hour*24),
-		testsupport.WithSubjectPubKey(&intCA1PrivKey.PublicKey, x509.ECDSAWithSHA384))
+		testsupport.WithSubjectPubKey(&intCA1PrivKey.PublicKey, x509.ECDSAWithSHA384),
+	)
 	require.NoError(t, err)
 
 	intCA1 := testsupport.NewCA(intCA1PrivKey, intCA1Cert)
@@ -2558,7 +2922,8 @@ func createKS(t *testing.T) keystore.KeyStore {
 		}),
 		testsupport.WithValidity(time.Now(), time.Hour*24),
 		testsupport.WithSubjectPubKey(&ee1PrivKey.PublicKey, x509.ECDSAWithSHA384),
-		testsupport.WithKeyUsage(x509.KeyUsageDigitalSignature))
+		testsupport.WithKeyUsage(x509.KeyUsageDigitalSignature),
+	)
 	require.NoError(t, err)
 
 	ee2PrivKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
@@ -2583,7 +2948,14 @@ func createKS(t *testing.T) keystore.KeyStore {
 	return ks
 }
 
-func createJWT(t *testing.T, keyEntry *keystore.Entry, subject, issuer, audience string, setKid bool) string {
+func createJWT(
+	t *testing.T,
+	keyEntry *keystore.Entry,
+	subject,
+	issuer,
+	audience string,
+	setKid bool,
+) string {
 	t.Helper()
 
 	signerOpts := &jose.SignerOptions{}
@@ -2598,7 +2970,8 @@ func createJWT(t *testing.T, keyEntry *keystore.Entry, subject, issuer, audience
 			Algorithm: keyEntry.JOSEAlgorithm(),
 			Key:       keyEntry.PrivateKey,
 		},
-		signerOpts)
+		signerOpts,
+	)
 	require.NoError(t, err)
 
 	builder := jwt.Signed(signer)
@@ -2641,7 +3014,8 @@ func TestJwtAuthenticatorGetCacheTTL(t *testing.T) {
 			Country:      []string{"EU"},
 		}),
 		testsupport.WithValidity(time.Now(), time.Hour*24),
-		testsupport.WithSubjectPubKey(&ee1PrivKey.PublicKey, x509.ECDSAWithSHA384))
+		testsupport.WithSubjectPubKey(&ee1PrivKey.PublicKey, x509.ECDSAWithSHA384),
+	)
 	require.NoError(t, err)
 
 	for uc, tc := range map[string]struct {
@@ -2760,19 +3134,333 @@ func TestJwtAuthenticatorIsInsecure(t *testing.T) {
 	require.False(t, auth.IsInsecure())
 }
 
-func TestJwtAuthenticatorCalculateCacheKeyWithDefaultAndExplicitTTL(t *testing.T) {
+func TestJwtAuthenticatorCalculateCacheKey(t *testing.T) {
 	t.Parallel()
 
-	// GIVEN
-	ep := &endpoint.Endpoint{URL: "https://example.com/.well-known/jwks.json"}
+	fiveSeconds := 5 * time.Second
+	tenSeconds := 10 * time.Second
 
-	withDefaultTTL := &jwtAuthenticator{}
-	withExplicitTTL := &jwtAuthenticator{ttl: new(5 * time.Second)}
+	for uc, tc := range map[string]struct {
+		authenticator1 *jwtAuthenticator
+		authenticator2 *jwtAuthenticator
+		endpoint1      *endpoint.Endpoint
+		endpoint2      *endpoint.Endpoint
+		request1       *http.Request
+		request2       *http.Request
+		reference1     string
+		reference2     string
+		expectEqual    bool
+	}{
+		"same effective request": {
+			authenticator1: &jwtAuthenticator{ttl: &fiveSeconds},
+			authenticator2: &jwtAuthenticator{ttl: &fiveSeconds},
+			endpoint1:      &endpoint.Endpoint{},
+			endpoint2:      &endpoint.Endpoint{},
+			request1: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				map[string]string{
+					"Accept":      "application/json",
+					"X-Tenant-ID": "tenant-a",
+				},
+			),
+			request2: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				map[string]string{
+					"Accept":      "application/json",
+					"X-Tenant-ID": "tenant-a",
+				},
+			),
+			reference1:  "kid",
+			reference2:  "kid",
+			expectEqual: true,
+		},
+		"different authenticator identity": {
+			authenticator1: &jwtAuthenticator{
+				name: "jwt-a",
+				id:   "step-a",
+				ttl:  &fiveSeconds,
+			},
+			authenticator2: &jwtAuthenticator{
+				name: "jwt-b",
+				id:   "step-b",
+				ttl:  &fiveSeconds,
+			},
+			endpoint1: &endpoint.Endpoint{},
+			endpoint2: &endpoint.Endpoint{},
+			request1: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				nil,
+			),
+			request2: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				nil,
+			),
+			reference1:  "kid",
+			reference2:  "kid",
+			expectEqual: true,
+		},
+		"different method": {
+			authenticator1: &jwtAuthenticator{ttl: &fiveSeconds},
+			authenticator2: &jwtAuthenticator{ttl: &fiveSeconds},
+			endpoint1:      &endpoint.Endpoint{},
+			endpoint2:      &endpoint.Endpoint{},
+			request1: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				nil,
+			),
+			request2: createJWKSRequest(
+				t,
+				http.MethodPost,
+				"https://example.com/.well-known/jwks.json",
+				nil,
+			),
+			reference1: "kid",
+			reference2: "kid",
+		},
+		"different rendered url": {
+			authenticator1: &jwtAuthenticator{ttl: &fiveSeconds},
+			authenticator2: &jwtAuthenticator{ttl: &fiveSeconds},
+			endpoint1:      &endpoint.Endpoint{},
+			endpoint2:      &endpoint.Endpoint{},
+			request1: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/issuer-a",
+				nil,
+			),
+			request2: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/issuer-b",
+				nil,
+			),
+			reference1: "kid",
+			reference2: "kid",
+		},
+		"different rendered header value": {
+			authenticator1: &jwtAuthenticator{ttl: &fiveSeconds},
+			authenticator2: &jwtAuthenticator{ttl: &fiveSeconds},
+			endpoint1:      &endpoint.Endpoint{},
+			endpoint2:      &endpoint.Endpoint{},
+			request1: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				map[string]string{"X-Issuer": "issuer-a"},
+			),
+			request2: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				map[string]string{"X-Issuer": "issuer-b"},
+			),
+			reference1: "kid",
+			reference2: "kid",
+		},
+		"different rendered header name": {
+			authenticator1: &jwtAuthenticator{ttl: &fiveSeconds},
+			authenticator2: &jwtAuthenticator{ttl: &fiveSeconds},
+			endpoint1:      &endpoint.Endpoint{},
+			endpoint2:      &endpoint.Endpoint{},
+			request1: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				map[string]string{"X-Issuer": "foo"},
+			),
+			request2: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				map[string]string{"X-Tenant": "foo"},
+			),
+			reference1: "kid",
+			reference2: "kid",
+		},
+		"same headers with different insertion order": {
+			authenticator1: &jwtAuthenticator{ttl: &fiveSeconds},
+			authenticator2: &jwtAuthenticator{ttl: &fiveSeconds},
+			endpoint1:      &endpoint.Endpoint{},
+			endpoint2:      &endpoint.Endpoint{},
+			request1: func() *http.Request {
+				req := createJWKSRequest(
+					t,
+					http.MethodGet,
+					"https://example.com/.well-known/jwks.json",
+					nil,
+				)
+				req.Header.Set("X-Foo", "foo")
+				req.Header.Set("X-Bar", "bar")
 
-	// WHEN
-	key1 := withDefaultTTL.calculateCacheKey(ep, ep.URL, "kid")
-	key2 := withExplicitTTL.calculateCacheKey(ep, ep.URL, "kid")
+				return req
+			}(),
+			request2: func() *http.Request {
+				req := createJWKSRequest(
+					t,
+					http.MethodGet,
+					"https://example.com/.well-known/jwks.json",
+					nil,
+				)
+				req.Header.Set("X-Bar", "bar")
+				req.Header.Set("X-Foo", "foo")
 
-	// THEN
-	assert.NotEqual(t, key1, key2)
+				return req
+			}(),
+			reference1:  "kid",
+			reference2:  "kid",
+			expectEqual: true,
+		},
+		"different reference": {
+			authenticator1: &jwtAuthenticator{ttl: &fiveSeconds},
+			authenticator2: &jwtAuthenticator{ttl: &fiveSeconds},
+			endpoint1:      &endpoint.Endpoint{},
+			endpoint2:      &endpoint.Endpoint{},
+			request1: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				nil,
+			),
+			request2: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				nil,
+			),
+			reference1: "kid-a",
+			reference2: "kid-b",
+		},
+		"different authentication strategy": {
+			authenticator1: &jwtAuthenticator{ttl: &fiveSeconds},
+			authenticator2: &jwtAuthenticator{ttl: &fiveSeconds},
+			endpoint1: &endpoint.Endpoint{
+				AuthStrategy: &authstrategy.BasicAuth{
+					User:     "foo",
+					Password: "bar",
+				},
+			},
+			endpoint2: &endpoint.Endpoint{
+				AuthStrategy: &authstrategy.BasicAuth{
+					User:     "foo",
+					Password: "baz",
+				},
+			},
+			request1: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				nil,
+			),
+			request2: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				nil,
+			),
+			reference1: "kid",
+			reference2: "kid",
+		},
+		"default and explicit ttl": {
+			authenticator1: &jwtAuthenticator{},
+			authenticator2: &jwtAuthenticator{ttl: &fiveSeconds},
+			endpoint1:      &endpoint.Endpoint{},
+			endpoint2:      &endpoint.Endpoint{},
+			request1: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				nil,
+			),
+			request2: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				nil,
+			),
+			reference1: "kid",
+			reference2: "kid",
+		},
+		"different explicit ttl": {
+			authenticator1: &jwtAuthenticator{ttl: &fiveSeconds},
+			authenticator2: &jwtAuthenticator{ttl: &tenSeconds},
+			endpoint1:      &endpoint.Endpoint{},
+			endpoint2:      &endpoint.Endpoint{},
+			request1: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				nil,
+			),
+			request2: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/.well-known/jwks.json",
+				nil,
+			),
+			reference1: "kid",
+			reference2: "kid",
+		},
+		"same effective request despite different endpoint configuration": {
+			authenticator1: &jwtAuthenticator{ttl: &fiveSeconds},
+			authenticator2: &jwtAuthenticator{ttl: &fiveSeconds},
+			endpoint1: &endpoint.Endpoint{
+				URL: "https://example.com/{{ .TokenIssuer }}",
+				Headers: map[string]string{
+					"X-Issuer": "{{ .TokenIssuer }}",
+				},
+			},
+			endpoint2: &endpoint.Endpoint{
+				URL: "https://example.com/foobar",
+				Headers: map[string]string{
+					"X-Issuer": "foobar",
+				},
+			},
+			request1: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/foobar",
+				map[string]string{"X-Issuer": "foobar"},
+			),
+			request2: createJWKSRequest(
+				t,
+				http.MethodGet,
+				"https://example.com/foobar",
+				map[string]string{"X-Issuer": "foobar"},
+			),
+			reference1:  "kid",
+			reference2:  "kid",
+			expectEqual: true,
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			// WHEN
+			key1 := tc.authenticator1.calculateCacheKey(
+				tc.endpoint1,
+				tc.request1,
+				tc.reference1,
+			)
+			key2 := tc.authenticator2.calculateCacheKey(
+				tc.endpoint2,
+				tc.request2,
+				tc.reference2,
+			)
+
+			// THEN
+			if tc.expectEqual {
+				assert.Equal(t, key1, key2)
+			} else {
+				assert.NotEqual(t, key1, key2)
+			}
+		})
+	}
 }

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator.go
@@ -19,9 +19,6 @@ package authenticators
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"io"
 	"net/http"
@@ -35,6 +32,7 @@ import (
 
 	"github.com/dadrus/heimdall/internal/app"
 	"github.com/dadrus/heimdall/internal/cache"
+	"github.com/dadrus/heimdall/internal/cache/cachekey"
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/rules/endpoint"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/authenticators/extractors"
@@ -43,7 +41,6 @@ import (
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/template"
 	"github.com/dadrus/heimdall/internal/x"
 	"github.com/dadrus/heimdall/internal/x/errorchain"
-	"github.com/dadrus/heimdall/internal/x/stringx"
 )
 
 // by intention. Used only during application bootstrap
@@ -340,7 +337,7 @@ func (a *oauth2IntrospectionAuthenticator) getSubjectInformation(
 	}
 
 	if a.isCacheEnabled() {
-		cacheKey = a.calculateCacheKey(metadata.IntrospectionEndpoint, req.URL.String(), token)
+		cacheKey = a.calculateCacheKey(metadata.IntrospectionEndpoint, req, token)
 
 		if entry, err := cch.Get(ctx.Context(), cacheKey); err == nil {
 			var response oauth2.IntrospectionResponse
@@ -526,24 +523,25 @@ func (a *oauth2IntrospectionAuthenticator) getCacheTTL(introspectResp *oauth2.In
 
 func (a *oauth2IntrospectionAuthenticator) calculateCacheKey(
 	ep *endpoint.Endpoint,
-	templatedURL, token string,
+	req *http.Request,
+	token string,
 ) string {
-	digest := sha256.New()
-	digest.Write(ep.Hash())
-	digest.Write(stringx.ToBytes(templatedURL))
-	digest.Write(stringx.ToBytes(token))
+	key := cachekey.New("oauth2-introspection-authenticator:response")
 
-	if a.ttl == nil {
-		digest.Write([]byte{0})
-	} else {
-		digest.Write([]byte{1})
+	key.WriteString(req.Method)
+	key.WriteString(req.URL.String())
+	key.WriteHeader(req.Header)
+	key.WriteString(token)
 
-		var ttl [8]byte
-		binary.BigEndian.PutUint64(ttl[:], uint64(*a.ttl)) //nolint:gosec
-		digest.Write(ttl[:])
+	key.WriteBool(ep.AuthStrategy != nil)
+	if ep.AuthStrategy != nil {
+		key.WriteBytes(ep.AuthStrategy.Hash())
 	}
 
-	var result [sha256.Size]byte
+	key.WriteBool(a.ttl != nil)
+	if a.ttl != nil {
+		key.WriteInt64(int64(*a.ttl))
+	}
 
-	return hex.EncodeToString(digest.Sum(result[:0]))
+	return key.SumString()
 }

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
@@ -2280,7 +2280,6 @@ func TestOAuth2IntrospectionAuthenticatorCalculateCacheKey(t *testing.T) {
 				},
 			},
 			firstToken: "token",
-
 			secondAuthenticator: &oauth2IntrospectionAuthenticator{
 				ttl: new(5 * time.Second),
 			},
@@ -2293,10 +2292,28 @@ func TestOAuth2IntrospectionAuthenticatorCalculateCacheKey(t *testing.T) {
 				},
 			},
 			secondToken: "token",
-
-			equal: true,
+			equal:       true,
 		},
-
+		"different effective request method": {
+			firstAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			firstEndpoint: &endpoint.Endpoint{},
+			firstRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+			},
+			firstToken: "token",
+			secondAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			secondEndpoint: &endpoint.Endpoint{},
+			secondRequest: &http.Request{
+				Method: http.MethodPut,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+			},
+			secondToken: "token",
+		},
 		"different effective request url": {
 			firstAuthenticator: &oauth2IntrospectionAuthenticator{
 				ttl: new(5 * time.Second),
@@ -2307,7 +2324,6 @@ func TestOAuth2IntrospectionAuthenticatorCalculateCacheKey(t *testing.T) {
 				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/a"},
 			},
 			firstToken: "token",
-
 			secondAuthenticator: &oauth2IntrospectionAuthenticator{
 				ttl: new(5 * time.Second),
 			},
@@ -2318,7 +2334,6 @@ func TestOAuth2IntrospectionAuthenticatorCalculateCacheKey(t *testing.T) {
 			},
 			secondToken: "token",
 		},
-
 		"different effective request header": {
 			firstAuthenticator: &oauth2IntrospectionAuthenticator{
 				ttl: new(5 * time.Second),
@@ -2332,7 +2347,6 @@ func TestOAuth2IntrospectionAuthenticatorCalculateCacheKey(t *testing.T) {
 				},
 			},
 			firstToken: "token",
-
 			secondAuthenticator: &oauth2IntrospectionAuthenticator{
 				ttl: new(5 * time.Second),
 			},
@@ -2346,7 +2360,6 @@ func TestOAuth2IntrospectionAuthenticatorCalculateCacheKey(t *testing.T) {
 			},
 			secondToken: "token",
 		},
-
 		"different token": {
 			firstAuthenticator: &oauth2IntrospectionAuthenticator{
 				ttl: new(5 * time.Second),
@@ -2357,7 +2370,6 @@ func TestOAuth2IntrospectionAuthenticatorCalculateCacheKey(t *testing.T) {
 				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
 			},
 			firstToken: "token-a",
-
 			secondAuthenticator: &oauth2IntrospectionAuthenticator{
 				ttl: new(5 * time.Second),
 			},
@@ -2368,7 +2380,82 @@ func TestOAuth2IntrospectionAuthenticatorCalculateCacheKey(t *testing.T) {
 			},
 			secondToken: "token-b",
 		},
-
+		"without vs with authentication strategy": {
+			firstAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			firstEndpoint: &endpoint.Endpoint{},
+			firstRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+			},
+			firstToken: "token",
+			secondAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			secondEndpoint: &endpoint.Endpoint{
+				AuthStrategy: &authstrategy.APIKey{
+					In:    "header",
+					Name:  "X-API-Key",
+					Value: "secret",
+				},
+			},
+			secondRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+			},
+			secondToken: "token",
+		},
+		"different authentication strategy": {
+			firstAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			firstEndpoint: &endpoint.Endpoint{
+				AuthStrategy: &authstrategy.APIKey{
+					In:    "header",
+					Name:  "X-API-Key",
+					Value: "secret-a",
+				},
+			},
+			firstRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+			},
+			firstToken: "token",
+			secondAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			secondEndpoint: &endpoint.Endpoint{
+				AuthStrategy: &authstrategy.APIKey{
+					In:    "header",
+					Name:  "X-API-Key",
+					Value: "secret-b",
+				},
+			},
+			secondRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+			},
+			secondToken: "token",
+		},
+		"default vs configured ttl": {
+			firstAuthenticator: &oauth2IntrospectionAuthenticator{},
+			firstEndpoint:      &endpoint.Endpoint{},
+			firstRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+			},
+			firstToken: "token",
+			secondAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			secondEndpoint: &endpoint.Endpoint{},
+			secondRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+			},
+			secondToken: "token",
+		},
 		"different ttl": {
 			firstAuthenticator: &oauth2IntrospectionAuthenticator{
 				ttl: new(5 * time.Second),
@@ -2379,7 +2466,6 @@ func TestOAuth2IntrospectionAuthenticatorCalculateCacheKey(t *testing.T) {
 				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
 			},
 			firstToken: "token",
-
 			secondAuthenticator: &oauth2IntrospectionAuthenticator{
 				ttl: new(15 * time.Second),
 			},
@@ -2390,7 +2476,6 @@ func TestOAuth2IntrospectionAuthenticatorCalculateCacheKey(t *testing.T) {
 			},
 			secondToken: "token",
 		},
-
 		"url and token boundaries do not collide": {
 			firstAuthenticator: &oauth2IntrospectionAuthenticator{
 				ttl: new(5 * time.Second),
@@ -2401,7 +2486,6 @@ func TestOAuth2IntrospectionAuthenticatorCalculateCacheKey(t *testing.T) {
 				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/a"},
 			},
 			firstToken: "bc",
-
 			secondAuthenticator: &oauth2IntrospectionAuthenticator{
 				ttl: new(5 * time.Second),
 			},
@@ -2421,7 +2505,6 @@ func TestOAuth2IntrospectionAuthenticatorCalculateCacheKey(t *testing.T) {
 				tc.firstRequest,
 				tc.firstToken,
 			)
-
 			second := tc.secondAuthenticator.calculateCacheKey(
 				tc.secondEndpoint,
 				tc.secondRequest,

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -2255,18 +2256,183 @@ func TestOauth2IntrospectionAuthenticatorIsInsecure(t *testing.T) {
 func TestOAuth2IntrospectionAuthenticatorCalculateCacheKey(t *testing.T) {
 	t.Parallel()
 
-	// GIVEN
-	ep := &endpoint.Endpoint{
-		URL: "https://example.com/introspect",
+	for uc, tc := range map[string]struct {
+		firstAuthenticator  *oauth2IntrospectionAuthenticator
+		firstEndpoint       *endpoint.Endpoint
+		firstRequest        *http.Request
+		firstToken          string
+		secondAuthenticator *oauth2IntrospectionAuthenticator
+		secondEndpoint      *endpoint.Endpoint
+		secondRequest       *http.Request
+		secondToken         string
+		equal               bool
+	}{
+		"same inputs": {
+			firstAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			firstEndpoint: &endpoint.Endpoint{},
+			firstRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+				Header: http.Header{
+					"Content-Type": {"application/x-www-form-urlencoded"},
+				},
+			},
+			firstToken: "token",
+
+			secondAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			secondEndpoint: &endpoint.Endpoint{},
+			secondRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+				Header: http.Header{
+					"Content-Type": {"application/x-www-form-urlencoded"},
+				},
+			},
+			secondToken: "token",
+
+			equal: true,
+		},
+
+		"different effective request url": {
+			firstAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			firstEndpoint: &endpoint.Endpoint{},
+			firstRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/a"},
+			},
+			firstToken: "token",
+
+			secondAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			secondEndpoint: &endpoint.Endpoint{},
+			secondRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/b"},
+			},
+			secondToken: "token",
+		},
+
+		"different effective request header": {
+			firstAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			firstEndpoint: &endpoint.Endpoint{},
+			firstRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+				Header: http.Header{
+					"X-Tenant": {"tenant-a"},
+				},
+			},
+			firstToken: "token",
+
+			secondAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(15 * time.Second),
+			},
+			secondEndpoint: &endpoint.Endpoint{},
+			secondRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+				Header: http.Header{
+					"X-Tenant": {"tenant-b"},
+				},
+			},
+			secondToken: "token",
+		},
+
+		"different token": {
+			firstAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			firstEndpoint: &endpoint.Endpoint{},
+			firstRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+			},
+			firstToken: "token-a",
+
+			secondAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			secondEndpoint: &endpoint.Endpoint{},
+			secondRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+			},
+			secondToken: "token-b",
+		},
+
+		"different ttl": {
+			firstAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			firstEndpoint: &endpoint.Endpoint{},
+			firstRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+			},
+			firstToken: "token",
+
+			secondAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(15 * time.Second),
+			},
+			secondEndpoint: &endpoint.Endpoint{},
+			secondRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/introspect"},
+			},
+			secondToken: "token",
+		},
+
+		"url and token boundaries do not collide": {
+			firstAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			firstEndpoint: &endpoint.Endpoint{},
+			firstRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/a"},
+			},
+			firstToken: "bc",
+
+			secondAuthenticator: &oauth2IntrospectionAuthenticator{
+				ttl: new(5 * time.Second),
+			},
+			secondEndpoint: &endpoint.Endpoint{},
+			secondRequest: &http.Request{
+				Method: http.MethodPost,
+				URL:    &url.URL{Scheme: "https", Host: "example.com", Path: "/ab"},
+			},
+			secondToken: "c",
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			t.Parallel()
+
+			first := tc.firstAuthenticator.calculateCacheKey(
+				tc.firstEndpoint,
+				tc.firstRequest,
+				tc.firstToken,
+			)
+
+			second := tc.secondAuthenticator.calculateCacheKey(
+				tc.secondEndpoint,
+				tc.secondRequest,
+				tc.secondToken,
+			)
+
+			if tc.equal {
+				assert.Equal(t, first, second)
+			} else {
+				assert.NotEqual(t, first, second)
+			}
+		})
 	}
-
-	a1 := &oauth2IntrospectionAuthenticator{ttl: new(5 * time.Second)}
-	a2 := &oauth2IntrospectionAuthenticator{ttl: new(15 * time.Second)}
-
-	// WHEN
-	key1 := a1.calculateCacheKey(ep, ep.URL, "token")
-	key2 := a2.calculateCacheKey(ep, ep.URL, "token")
-
-	// THEN
-	assert.NotEqual(t, key1, key2)
 }

--- a/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
+++ b/internal/rules/mechanisms/authenticators/oauth2_introspection_authenticator_test.go
@@ -2334,7 +2334,7 @@ func TestOAuth2IntrospectionAuthenticatorCalculateCacheKey(t *testing.T) {
 			firstToken: "token",
 
 			secondAuthenticator: &oauth2IntrospectionAuthenticator{
-				ttl: new(15 * time.Second),
+				ttl: new(5 * time.Second),
 			},
 			secondEndpoint: &endpoint.Endpoint{},
 			secondRequest: &http.Request{

--- a/internal/rules/mechanisms/authorizers/remote_authorizer.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer.go
@@ -185,8 +185,13 @@ func (a *remoteAuthorizer) Execute(ctx heimdall.RequestContext, sub *subject.Sub
 		return err
 	}
 
+	req, err := a.createRequest(ctx, sub, vals, payload)
+	if err != nil {
+		return err
+	}
+
 	if a.ttl > 0 {
-		cacheKey = a.calculateCacheKey(sub, vals, payload)
+		cacheKey = a.calculateCacheKey(req, payload)
 
 		if entry, err := cch.Get(ctx.Context(), cacheKey); err == nil {
 			var ai authorizationInformation
@@ -200,7 +205,7 @@ func (a *remoteAuthorizer) Execute(ctx heimdall.RequestContext, sub *subject.Sub
 	}
 
 	if authInfo == nil {
-		authInfo, err = a.fetchAuthorizationInformation(ctx, sub, vals, payload)
+		authInfo, err = a.fetchAuthorizationInformation(ctx, req)
 		if err != nil {
 			return err
 		}
@@ -287,15 +292,12 @@ func (a *remoteAuthorizer) ID() string { return a.id }
 
 func (a *remoteAuthorizer) ContinueOnError() bool { return false }
 
-func (a *remoteAuthorizer) fetchAuthorizationInformation(
+func (a *remoteAuthorizer) createRequest(
 	ctx heimdall.RequestContext,
 	sub *subject.Subject,
 	values map[string]string,
 	payload string,
-) (*authorizationInformation, error) {
-	logger := zerolog.Ctx(ctx.Context())
-	logger.Debug().Msg("Calling remote authorization endpoint")
-
+) (*http.Request, error) {
 	endpointRenderer := endpoint.RenderFunc(func(tplString string) (string, error) {
 		tpl, err := template.New(tplString)
 		if err != nil {
@@ -318,6 +320,16 @@ func (a *remoteAuthorizer) fetchAuthorizationInformation(
 			WithErrorContext(a).
 			CausedBy(err)
 	}
+
+	return req, nil
+}
+
+func (a *remoteAuthorizer) fetchAuthorizationInformation(
+	ctx heimdall.RequestContext,
+	req *http.Request,
+) (*authorizationInformation, error) {
+	logger := zerolog.Ctx(ctx.Context())
+	logger.Debug().Msg("Calling remote authorization endpoint")
 
 	resp, err := a.e.CreateClient(req.URL.Hostname()).Do(req)
 	if err != nil {
@@ -387,7 +399,10 @@ func (a *remoteAuthorizer) readResponse(ctx heimdall.RequestContext, resp *http.
 	return result, nil
 }
 
-func (a *remoteAuthorizer) calculateCacheKey(sub *subject.Subject, values map[string]string, payload string) string {
+func (a *remoteAuthorizer) calculateCacheKey(
+	req *http.Request,
+	payload string,
+) string {
 	const int64BytesCount = 8
 
 	var ttlBytes [int64BytesCount]byte
@@ -396,17 +411,27 @@ func (a *remoteAuthorizer) calculateCacheKey(sub *subject.Subject, values map[st
 	// no integer overflow during conversion possible
 	binary.LittleEndian.PutUint64(ttlBytes[:], uint64(a.ttl))
 
-	hash := sha256.New()
-	hash.Write(a.e.Hash())
-	hash.Write(stringx.ToBytes(a.id))
-	hash.Write(stringx.ToBytes(strings.Join(a.headersForUpstream, ",")))
-	hash.Write(stringx.ToBytes(payload))
-	hash.Write(ttlBytes[:])
-	hash.Write(sub.Hash())
+	var separator [1]byte
 
-	for k, v := range values {
-		hash.Write(stringx.ToBytes(k))
-		hash.Write(stringx.ToBytes(v))
+	hash := sha256.New()
+	hash.Write(stringx.ToBytes("remote-authorizer:v2"))
+	hash.Write(separator[:])
+	hash.Write(stringx.ToBytes(a.name))
+	hash.Write(separator[:])
+	hash.Write(ttlBytes[:])
+	hash.Write(stringx.ToBytes(req.Method))
+	hash.Write(separator[:])
+	hash.Write(stringx.ToBytes(req.URL.String()))
+	hash.Write(separator[:])
+
+	_ = req.Header.Write(hash)
+
+	hash.Write(separator[:])
+	hash.Write(stringx.ToBytes(payload))
+	hash.Write(separator[:])
+
+	if a.e.AuthStrategy != nil {
+		hash.Write(a.e.AuthStrategy.Hash())
 	}
 
 	var result [sha256.Size]byte

--- a/internal/rules/mechanisms/authorizers/remote_authorizer.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer.go
@@ -17,9 +17,6 @@
 package authorizers
 
 import (
-	"crypto/sha256"
-	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"io"
 	"net/http"
@@ -33,6 +30,7 @@ import (
 
 	"github.com/dadrus/heimdall/internal/app"
 	"github.com/dadrus/heimdall/internal/cache"
+	"github.com/dadrus/heimdall/internal/cache/cachekey"
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/rules/endpoint"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/cellib"
@@ -403,40 +401,21 @@ func (a *remoteAuthorizer) calculateCacheKey(
 	req *http.Request,
 	payload string,
 ) string {
-	const int64BytesCount = 8
+	key := cachekey.New("remote-authorizer:response")
 
-	var ttlBytes [int64BytesCount]byte
+	key.WriteString(a.name)
+	key.WriteInt64(int64(a.ttl))
+	key.WriteString(req.Method)
+	key.WriteString(req.URL.String())
+	key.WriteHeader(req.Header)
+	key.WriteString(payload)
 
-	//nolint:gosec
-	// no integer overflow during conversion possible
-	binary.LittleEndian.PutUint64(ttlBytes[:], uint64(a.ttl))
-
-	var separator [1]byte
-
-	hash := sha256.New()
-	hash.Write(stringx.ToBytes("remote-authorizer:v2"))
-	hash.Write(separator[:])
-	hash.Write(stringx.ToBytes(a.name))
-	hash.Write(separator[:])
-	hash.Write(ttlBytes[:])
-	hash.Write(stringx.ToBytes(req.Method))
-	hash.Write(separator[:])
-	hash.Write(stringx.ToBytes(req.URL.String()))
-	hash.Write(separator[:])
-
-	_ = req.Header.Write(hash)
-
-	hash.Write(separator[:])
-	hash.Write(stringx.ToBytes(payload))
-	hash.Write(separator[:])
-
+	key.WriteBool(a.e.AuthStrategy != nil)
 	if a.e.AuthStrategy != nil {
-		hash.Write(a.e.AuthStrategy.Hash())
+		key.WriteBytes(a.e.AuthStrategy.Hash())
 	}
 
-	var result [sha256.Size]byte
-
-	return hex.EncodeToString(hash.Sum(result[:0]))
+	return key.SumString()
 }
 
 func (a *remoteAuthorizer) verify(ctx heimdall.RequestContext, result any) error {

--- a/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/dadrus/heimdall/internal/heimdall"
 	heimdallmocks "github.com/dadrus/heimdall/internal/heimdall/mocks"
 	"github.com/dadrus/heimdall/internal/rules/endpoint"
+	"github.com/dadrus/heimdall/internal/rules/endpoint/authstrategy"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/cellib"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/subject"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/template"
@@ -210,7 +211,13 @@ values:
 					"Subject": &subject.Subject{ID: "bar"},
 					"Request": &heimdall.Request{
 						RequestFunctions: rfunc,
-						URL:              &heimdall.URL{URL: url.URL{Scheme: "http", Host: "foo.bar", Path: "/foo/bar"}},
+						URL: &heimdall.URL{
+							URL: url.URL{
+								Scheme: "http",
+								Host:   "foo.bar",
+								Path:   "/foo/bar",
+							},
+						},
 					},
 				})
 				require.NoError(t, err)
@@ -604,7 +611,9 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 					return values.Values{"foo": tpl}
 				}(),
 				payload: func() template.Template {
-					tpl, _ := template.New("{{ .Subject.ID }}-{{ .Values.foo }}-{{ .Outputs.foo }}-{{ .Results.foo.Payload }}")
+					tpl, _ := template.New(
+						"{{ .Subject.ID }}-{{ .Values.foo }}-{{ .Outputs.foo }}-{{ .Results.foo.Payload }}",
+					)
 
 					return tpl
 				}(),
@@ -637,7 +646,13 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 				ctx.EXPECT().Request().Return(nil)
 			},
-			assert: func(t *testing.T, err error, sub *subject.Subject, outputs map[string]any, results heimdall.Results) {
+			assert: func(
+				t *testing.T,
+				err error,
+				sub *subject.Subject,
+				outputs map[string]any,
+				results heimdall.Results,
+			) {
 				t.Helper()
 
 				require.NoError(t, err)
@@ -718,7 +733,13 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 				ctx.EXPECT().AddHeaderForUpstream("X-Foo-Bar", "HeyFoo")
 				ctx.EXPECT().Request().Return(nil)
 			},
-			assert: func(t *testing.T, err error, sub *subject.Subject, outputs map[string]any, results heimdall.Results) {
+			assert: func(
+				t *testing.T,
+				err error,
+				sub *subject.Subject,
+				outputs map[string]any,
+				results heimdall.Results,
+			) {
 				t.Helper()
 
 				require.NoError(t, err)
@@ -772,7 +793,9 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 					return values.Values{"foo": tpl}
 				}(),
 				payload: func() template.Template {
-					tpl, _ := template.New(`user_id={{ urlenc .Subject.ID }}&{{ .Subject.Attributes.bar }}={{ .Values.foo }}&{{ .Values.foo }}={{ .Outputs.foo }}`)
+					tpl, _ := template.New(
+						`user_id={{ urlenc .Subject.ID }}&{{ .Subject.Attributes.bar }}={{ .Values.foo }}&{{ .Values.foo }}={{ .Outputs.foo }}`,
+					)
 
 					return tpl
 				}(),
@@ -813,19 +836,40 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 				ctx.EXPECT().AddHeaderForUpstream("X-Foo-Bar", "HeyFoo")
 				ctx.EXPECT().Request().Return(nil)
 			},
-			configureCache: func(t *testing.T, cch *mocks.CacheMock, auth *remoteAuthorizer, _ *subject.Subject) {
+			configureCache: func(
+				t *testing.T,
+				cch *mocks.CacheMock,
+				auth *remoteAuthorizer,
+				_ *subject.Subject,
+			) {
 				t.Helper()
 
-				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil, errors.New("no cache entry"))
-				cch.EXPECT().Set(mock.Anything, mock.Anything,
-					mock.MatchedBy(func(data []byte) bool {
-						var ai authorizationInformation
-						err := json.Unmarshal(data, &ai)
+				cch.EXPECT().
+					Get(mock.Anything, mock.Anything).
+					Return(nil, errors.New("no cache entry"))
+				cch.EXPECT().
+					Set(
+						mock.Anything,
+						mock.Anything,
+						mock.MatchedBy(func(data []byte) bool {
+							var ai authorizationInformation
+							err := json.Unmarshal(data, &ai)
 
-						return err == nil && ai.Payload == nil && len(ai.Headers.Get("X-Foo-Bar")) != 0
-					}), auth.ttl).Return(nil)
+							return err == nil &&
+								ai.Payload == nil &&
+								len(ai.Headers.Get("X-Foo-Bar")) != 0
+						}),
+						auth.ttl,
+					).
+					Return(nil)
 			},
-			assert: func(t *testing.T, err error, sub *subject.Subject, outputs map[string]any, results heimdall.Results) {
+			assert: func(
+				t *testing.T,
+				err error,
+				sub *subject.Subject,
+				outputs map[string]any,
+				results heimdall.Results,
+			) {
 				t.Helper()
 
 				require.NoError(t, err)
@@ -840,7 +884,8 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 		},
 		"successful without headers and payload and with cache": {
 			authorizer: &remoteAuthorizer{
-				id: "authorizer",
+				name: "authorizer",
+				id:   "authorizer",
 				e: endpoint.Endpoint{
 					URL:     srv.URL + "/{{ .Subject.ID }}",
 					Headers: map[string]string{"Accept": "application/x-www-form-urlencoded"},
@@ -869,15 +914,41 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 				ctx.EXPECT().Request().Return(nil)
 			},
-			configureCache: func(t *testing.T, cch *mocks.CacheMock, auth *remoteAuthorizer, sub *subject.Subject) {
+			configureCache: func(
+				t *testing.T,
+				cch *mocks.CacheMock,
+				auth *remoteAuthorizer,
+				_ *subject.Subject,
+			) {
 				t.Helper()
 
-				cacheKey := auth.calculateCacheKey(sub, nil, "")
+				req, err := http.NewRequestWithContext(
+					t.Context(),
+					http.MethodPost,
+					srv.URL+"/foobar",
+					nil,
+				)
+				require.NoError(t, err)
 
-				cch.EXPECT().Get(mock.Anything, cacheKey).Return(nil, errors.New("no cache entry"))
-				cch.EXPECT().Set(mock.Anything, cacheKey, mock.Anything, auth.ttl).Return(nil)
+				req.Header.Set("Accept", "application/x-www-form-urlencoded")
+
+				cacheKey := auth.calculateCacheKey(req, "")
+
+				cch.EXPECT().
+					Get(mock.Anything, cacheKey).
+					Return(nil, errors.New("no cache entry"))
+
+				cch.EXPECT().
+					Set(mock.Anything, cacheKey, mock.Anything, auth.ttl).
+					Return(nil)
 			},
-			assert: func(t *testing.T, err error, sub *subject.Subject, outputs map[string]any, results heimdall.Results) {
+			assert: func(
+				t *testing.T,
+				err error,
+				sub *subject.Subject,
+				outputs map[string]any,
+				results heimdall.Results,
+			) {
 				t.Helper()
 
 				require.NoError(t, err)
@@ -902,7 +973,9 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 					},
 				},
 				payload: func() template.Template {
-					tpl, _ := template.New(`user_id={{ urlenc .Subject.ID }}&{{ urlenc .Subject.Attributes.bar }}=foo`)
+					tpl, _ := template.New(
+						`user_id={{ urlenc .Subject.ID }}&{{ urlenc .Subject.Attributes.bar }}=foo`,
+					)
 
 					return tpl
 				}(),
@@ -920,7 +993,12 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 				ctx.EXPECT().AddHeaderForUpstream("X-Bar-Foo", "HeyBar")
 				ctx.EXPECT().Request().Return(nil)
 			},
-			configureCache: func(t *testing.T, cch *mocks.CacheMock, _ *remoteAuthorizer, _ *subject.Subject) {
+			configureCache: func(
+				t *testing.T,
+				cch *mocks.CacheMock,
+				_ *remoteAuthorizer,
+				_ *subject.Subject,
+			) {
 				t.Helper()
 
 				rawInfo, err := json.Marshal(authorizationInformation{
@@ -932,9 +1010,17 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(rawInfo, nil)
+				cch.EXPECT().
+					Get(mock.Anything, mock.Anything).
+					Return(rawInfo, nil)
 			},
-			assert: func(t *testing.T, err error, sub *subject.Subject, outputs map[string]any, _ heimdall.Results) {
+			assert: func(
+				t *testing.T,
+				err error,
+				sub *subject.Subject,
+				outputs map[string]any,
+				_ heimdall.Results,
+			) {
 				t.Helper()
 
 				require.NoError(t, err)
@@ -976,7 +1062,13 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 				ctx.EXPECT().Request().Return(nil)
 			},
-			assert: func(t *testing.T, err error, _ *subject.Subject, _ map[string]any, _ heimdall.Results) {
+			assert: func(
+				t *testing.T,
+				err error,
+				_ *subject.Subject,
+				_ map[string]any,
+				_ heimdall.Results,
+			) {
 				t.Helper()
 
 				require.Error(t, err)
@@ -997,7 +1089,10 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 					Headers: map[string]string{"X-User-ID": "{{ .Subject.ID }}"},
 				},
 			},
-			subject: &subject.Subject{ID: "foo", Attributes: map[string]any{}},
+			subject: &subject.Subject{
+				ID:         "foo",
+				Attributes: map[string]any{},
+			},
 			instructServer: func(t *testing.T) {
 				t.Helper()
 
@@ -1010,7 +1105,13 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 				ctx.EXPECT().Request().Return(nil)
 			},
-			assert: func(t *testing.T, err error, sub *subject.Subject, outputs map[string]any, _ heimdall.Results) {
+			assert: func(
+				t *testing.T,
+				err error,
+				sub *subject.Subject,
+				outputs map[string]any,
+				_ heimdall.Results,
+			) {
 				t.Helper()
 
 				require.NoError(t, err)
@@ -1037,7 +1138,13 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 				ctx.EXPECT().Request().Return(nil)
 			},
-			assert: func(t *testing.T, err error, _ *subject.Subject, _ map[string]any, _ heimdall.Results) {
+			assert: func(
+				t *testing.T,
+				err error,
+				_ *subject.Subject,
+				_ map[string]any,
+				_ heimdall.Results,
+			) {
 				t.Helper()
 
 				require.Error(t, err)
@@ -1067,7 +1174,11 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 					return tpl
 				}(),
 				expressions: func() []*cellib.CompiledExpression {
-					exp, err := cellib.CompileExpression(env, "false == true", "false != true")
+					exp, err := cellib.CompileExpression(
+						env,
+						"false == true",
+						"false != true",
+					)
 					require.NoError(t, err)
 
 					return []*cellib.CompiledExpression{exp}
@@ -1114,7 +1225,13 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 				ctx.EXPECT().Request().Return(nil)
 			},
-			assert: func(t *testing.T, err error, _ *subject.Subject, _ map[string]any, _ heimdall.Results) {
+			assert: func(
+				t *testing.T,
+				err error,
+				_ *subject.Subject,
+				_ map[string]any,
+				_ heimdall.Results,
+			) {
 				t.Helper()
 
 				assert.True(t, authorizationEndpointCalled)
@@ -1144,7 +1261,11 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 					return tpl
 				}(),
 				expressions: func() []*cellib.CompiledExpression {
-					exp, err := cellib.CompileExpression(env, "Payload.access_granted == true", "err")
+					exp, err := cellib.CompileExpression(
+						env,
+						"Payload.access_granted == true",
+						"err",
+					)
 					require.NoError(t, err)
 
 					return []*cellib.CompiledExpression{exp}
@@ -1191,7 +1312,13 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 				ctx.EXPECT().Request().Return(nil)
 			},
-			assert: func(t *testing.T, err error, sub *subject.Subject, outputs map[string]any, _ heimdall.Results) {
+			assert: func(
+				t *testing.T,
+				err error,
+				sub *subject.Subject,
+				outputs map[string]any,
+				_ heimdall.Results,
+			) {
 				t.Helper()
 
 				assert.True(t, authorizationEndpointCalled)
@@ -1225,13 +1352,22 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 					return tpl
 				}(),
 			},
-			subject: &subject.Subject{ID: "Foo", Attributes: map[string]any{"bar": "baz"}},
+			subject: &subject.Subject{
+				ID:         "Foo",
+				Attributes: map[string]any{"bar": "baz"},
+			},
 			configureContext: func(t *testing.T, ctx *heimdallmocks.RequestContextMock) {
 				t.Helper()
 
 				ctx.EXPECT().Request().Return(nil)
 			},
-			assert: func(t *testing.T, err error, _ *subject.Subject, _ map[string]any, _ heimdall.Results) {
+			assert: func(
+				t *testing.T,
+				err error,
+				_ *subject.Subject,
+				_ map[string]any,
+				_ heimdall.Results,
+			) {
 				t.Helper()
 
 				assert.False(t, authorizationEndpointCalled)
@@ -1256,13 +1392,22 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 					return values.Values{"foo": tpl}
 				}(),
 			},
-			subject: &subject.Subject{ID: "Foo", Attributes: map[string]any{"bar": "baz"}},
+			subject: &subject.Subject{
+				ID:         "Foo",
+				Attributes: map[string]any{"bar": "baz"},
+			},
 			configureContext: func(t *testing.T, ctx *heimdallmocks.RequestContextMock) {
 				t.Helper()
 
 				ctx.EXPECT().Request().Return(nil)
 			},
-			assert: func(t *testing.T, err error, _ *subject.Subject, _ map[string]any, _ heimdall.Results) {
+			assert: func(
+				t *testing.T,
+				err error,
+				_ *subject.Subject,
+				_ map[string]any,
+				_ heimdall.Results,
+			) {
 				t.Helper()
 
 				assert.False(t, authorizationEndpointCalled)
@@ -1278,7 +1423,8 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 		},
 		"failed with positive cache hit due to authorization expression": {
 			authorizer: &remoteAuthorizer{
-				id: "authz",
+				name: "authz",
+				id:   "authz",
 				e: endpoint.Endpoint{
 					URL: srv.URL,
 				},
@@ -1307,7 +1453,7 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 				t *testing.T,
 				cch *mocks.CacheMock,
 				auth *remoteAuthorizer,
-				sub *subject.Subject,
+				_ *subject.Subject,
 			) {
 				t.Helper()
 
@@ -1318,9 +1464,19 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				cacheKey := auth.calculateCacheKey(sub, nil, "")
+				req, err := http.NewRequestWithContext(
+					t.Context(),
+					http.MethodPost,
+					srv.URL,
+					nil,
+				)
+				require.NoError(t, err)
 
-				cch.EXPECT().Get(mock.Anything, cacheKey).Return(rawInfo, nil)
+				cacheKey := auth.calculateCacheKey(req, "")
+
+				cch.EXPECT().
+					Get(mock.Anything, cacheKey).
+					Return(rawInfo, nil)
 			},
 			assert: func(
 				t *testing.T,
@@ -1345,6 +1501,104 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 				assert.NotContains(t, results, "authz")
 			},
 		},
+		"with rendered endpoint header and cache miss due to different output": {
+			authorizer: &remoteAuthorizer{
+				name: "authorizer",
+				id:   "authorizer",
+				e: endpoint.Endpoint{
+					URL:    srv.URL,
+					Method: http.MethodGet,
+					Headers: map[string]string{
+						"X-Tenant-ID": "{{ .Outputs.foo }}",
+					},
+				},
+				ttl: 5 * time.Second,
+			},
+			subject: &subject.Subject{
+				ID:         "Foo",
+				Attributes: map[string]any{"bar": "baz"},
+			},
+			instructServer: func(t *testing.T) {
+				t.Helper()
+
+				checkRequest = func(req *http.Request) {
+					t.Helper()
+
+					assert.Equal(t, "bar", req.Header.Get("X-Tenant-ID"))
+				}
+
+				responseContentType = "application/json"
+				responseContent = []byte(`{"tenant":"bar"}`)
+				responseCode = http.StatusOK
+			},
+			configureContext: func(t *testing.T, ctx *heimdallmocks.RequestContextMock) {
+				t.Helper()
+
+				ctx.EXPECT().Request().Return(nil)
+			},
+			configureCache: func(
+				t *testing.T,
+				cch *mocks.CacheMock,
+				auth *remoteAuthorizer,
+				_ *subject.Subject,
+			) {
+				t.Helper()
+
+				previousReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+				require.NoError(t, err)
+
+				previousReq.Header.Set("X-Tenant-ID", "tenant-a")
+
+				currentReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+				require.NoError(t, err)
+
+				currentReq.Header.Set("X-Tenant-ID", "bar")
+
+				previousCacheKey := auth.calculateCacheKey(previousReq, "")
+				currentCacheKey := auth.calculateCacheKey(currentReq, "")
+
+				require.NotEqual(t, previousCacheKey, currentCacheKey)
+
+				cch.EXPECT().
+					Get(mock.Anything, currentCacheKey).
+					Return(nil, errors.New("no cache entry"))
+
+				cch.EXPECT().
+					Set(mock.Anything, currentCacheKey, mock.Anything, auth.ttl).
+					Return(nil)
+			},
+			assert: func(
+				t *testing.T,
+				err error,
+				sub *subject.Subject,
+				outputs map[string]any,
+				results heimdall.Results,
+			) {
+				t.Helper()
+
+				assert.True(t, authorizationEndpointCalled)
+
+				require.NoError(t, err)
+				assert.Len(t, sub.Attributes, 1)
+
+				require.Len(t, outputs, 2)
+				assert.Equal(
+					t,
+					map[string]any{"tenant": "bar"},
+					outputs["authorizer"],
+				)
+
+				require.Len(t, results, 2)
+
+				result := results["authorizer"]
+				require.NotNil(t, result)
+				assert.Equal(
+					t,
+					map[string]any{"tenant": "bar"},
+					result.Payload,
+				)
+			},
+		},
 	} {
 		t.Run(uc, func(t *testing.T) {
 			// GIVEN
@@ -1355,26 +1609,39 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 			checkRequest = func(*http.Request) { t.Helper() }
 
-			instructServer := x.IfThenElse(tc.instructServer != nil,
+			instructServer := x.IfThenElse(
+				tc.instructServer != nil,
 				tc.instructServer,
-				func(t *testing.T) { t.Helper() })
+				func(t *testing.T) { t.Helper() },
+			)
 
-			configureContext := x.IfThenElse(tc.configureContext != nil,
+			configureContext := x.IfThenElse(
+				tc.configureContext != nil,
 				tc.configureContext,
-				func(t *testing.T, _ *heimdallmocks.RequestContextMock) { t.Helper() })
+				func(t *testing.T, _ *heimdallmocks.RequestContextMock) { t.Helper() },
+			)
 
-			configureCache := x.IfThenElse(tc.configureCache != nil,
+			configureCache := x.IfThenElse(
+				tc.configureCache != nil,
 				tc.configureCache,
-				func(t *testing.T, _ *mocks.CacheMock, _ *remoteAuthorizer, _ *subject.Subject) {
+				func(
+					t *testing.T,
+					_ *mocks.CacheMock,
+					_ *remoteAuthorizer,
+					_ *subject.Subject,
+				) {
 					t.Helper()
-				})
+				},
+			)
 
 			cch := mocks.NewCacheMock(t)
 
 			ctx := heimdallmocks.NewRequestContextMock(t)
 			ctx.EXPECT().Context().Return(cache.WithContext(t.Context(), cch))
 			ctx.EXPECT().Outputs().Return(map[string]any{"foo": "bar"})
-			ctx.EXPECT().Results().Return(heimdall.Results{"foo": heimdall.NewResult("bar")})
+			ctx.EXPECT().Results().Return(
+				heimdall.Results{"foo": heimdall.NewResult("bar")},
+			)
 
 			configureContext(t, ctx)
 			configureCache(t, cch, tc.authorizer, tc.subject)
@@ -1385,6 +1652,377 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 			// THEN
 			tc.assert(t, err, tc.subject, ctx.Outputs(), ctx.Results())
+		})
+	}
+}
+
+func TestRemoteAuthorizerCalculateCacheKey(t *testing.T) {
+	t.Parallel()
+
+	newAuthorizer := func(
+		name string,
+		id string,
+		ttl time.Duration,
+	) *remoteAuthorizer {
+		t.Helper()
+
+		return &remoteAuthorizer{
+			name: name,
+			id:   id,
+			ttl:  ttl,
+		}
+	}
+
+	newRequest := func(
+		method string,
+		rawURL string,
+		headers map[string]string,
+	) *http.Request {
+		t.Helper()
+
+		req, err := http.NewRequestWithContext(t.Context(), method, rawURL, nil)
+		require.NoError(t, err)
+
+		for name, value := range headers {
+			req.Header.Set(name, value)
+		}
+
+		return req
+	}
+
+	for uc, tc := range map[string]struct {
+		authorizer1 *remoteAuthorizer
+		authorizer2 *remoteAuthorizer
+		request1    *http.Request
+		request2    *http.Request
+		payload1    string
+		payload2    string
+		expectEqual bool
+	}{
+		"same effective request": {
+			authorizer1: newAuthorizer(
+				"authorizer",
+				"authorizer",
+				5*time.Second,
+			),
+			authorizer2: newAuthorizer(
+				"authorizer",
+				"authorizer",
+				5*time.Second,
+			),
+			request1: newRequest(
+				http.MethodPost,
+				"https://example.com/authorize",
+				map[string]string{
+					"Content-Type": "application/json",
+					"X-Tenant-ID":  "tenant-a",
+				},
+			),
+			request2: newRequest(
+				http.MethodPost,
+				"https://example.com/authorize",
+				map[string]string{
+					"Content-Type": "application/json",
+					"X-Tenant-ID":  "tenant-a",
+				},
+			),
+			payload1:    `{"foo":"bar"}`,
+			payload2:    `{"foo":"bar"}`,
+			expectEqual: true,
+		},
+		"different step id": {
+			authorizer1: newAuthorizer(
+				"authorizer",
+				"step-a",
+				5*time.Second,
+			),
+			authorizer2: newAuthorizer(
+				"authorizer",
+				"step-b",
+				5*time.Second,
+			),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				nil,
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				nil,
+			),
+			expectEqual: true,
+		},
+		"different authorizer name": {
+			authorizer1: newAuthorizer(
+				"authorizer-a",
+				"step",
+				5*time.Second,
+			),
+			authorizer2: newAuthorizer(
+				"authorizer-b",
+				"step",
+				5*time.Second,
+			),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				nil,
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				nil,
+			),
+		},
+		"different ttl": {
+			authorizer1: newAuthorizer(
+				"authorizer",
+				"authorizer",
+				5*time.Second,
+			),
+			authorizer2: newAuthorizer(
+				"authorizer",
+				"authorizer",
+				10*time.Second,
+			),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				nil,
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				nil,
+			),
+		},
+		"different request method": {
+			authorizer1: newAuthorizer(
+				"authorizer",
+				"authorizer",
+				5*time.Second,
+			),
+			authorizer2: newAuthorizer(
+				"authorizer",
+				"authorizer",
+				5*time.Second,
+			),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				nil,
+			),
+			request2: newRequest(
+				http.MethodPost,
+				"https://example.com/authorize",
+				nil,
+			),
+		},
+		"different rendered url": {
+			authorizer1: newAuthorizer(
+				"authorizer",
+				"authorizer",
+				5*time.Second,
+			),
+			authorizer2: newAuthorizer(
+				"authorizer",
+				"authorizer",
+				5*time.Second,
+			),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/tenant-a",
+				nil,
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/tenant-b",
+				nil,
+			),
+		},
+		"different header value": {
+			authorizer1: newAuthorizer(
+				"authorizer",
+				"authorizer",
+				5*time.Second,
+			),
+			authorizer2: newAuthorizer(
+				"authorizer",
+				"authorizer",
+				5*time.Second,
+			),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				map[string]string{
+					"X-Tenant-ID": "tenant-a",
+				},
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				map[string]string{
+					"X-Tenant-ID": "tenant-b",
+				},
+			),
+		},
+		"different header name": {
+			authorizer1: newAuthorizer(
+				"authorizer",
+				"authorizer",
+				5*time.Second,
+			),
+			authorizer2: newAuthorizer(
+				"authorizer",
+				"authorizer",
+				5*time.Second,
+			),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				map[string]string{
+					"X-Tenant-ID": "foo",
+				},
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				map[string]string{
+					"X-Organization-ID": "foo",
+				},
+			),
+		},
+		"different payload": {
+			authorizer1: newAuthorizer(
+				"authorizer",
+				"authorizer",
+				5*time.Second,
+			),
+			authorizer2: newAuthorizer(
+				"authorizer",
+				"authorizer",
+				5*time.Second,
+			),
+			request1: newRequest(
+				http.MethodPost,
+				"https://example.com/authorize",
+				nil,
+			),
+			request2: newRequest(
+				http.MethodPost,
+				"https://example.com/authorize",
+				nil,
+			),
+			payload1: `{"tenant":"tenant-a"}`,
+			payload2: `{"tenant":"tenant-b"}`,
+		},
+		"different authentication strategy": {
+			authorizer1: &remoteAuthorizer{
+				name: "authorizer",
+				id:   "authorizer",
+				ttl:  5 * time.Second,
+				e: endpoint.Endpoint{
+					AuthStrategy: &authstrategy.BasicAuth{
+						User:     "foo",
+						Password: "bar",
+					},
+				},
+			},
+			authorizer2: &remoteAuthorizer{
+				name: "authorizer",
+				id:   "authorizer",
+				ttl:  5 * time.Second,
+				e: endpoint.Endpoint{
+					AuthStrategy: &authstrategy.BasicAuth{
+						User:     "foo",
+						Password: "baz",
+					},
+				},
+			},
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				nil,
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				nil,
+			),
+		},
+		"different response headers to forward": {
+			authorizer1: &remoteAuthorizer{
+				name:               "authorizer",
+				id:                 "authorizer",
+				ttl:                5 * time.Second,
+				headersForUpstream: []string{"X-Foo"},
+			},
+			authorizer2: &remoteAuthorizer{
+				name:               "authorizer",
+				id:                 "authorizer",
+				ttl:                5 * time.Second,
+				headersForUpstream: []string{"X-Bar"},
+			},
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				nil,
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				nil,
+			),
+			expectEqual: true,
+		},
+		"same effective request despite different endpoint configuration": {
+			authorizer1: &remoteAuthorizer{
+				name: "authorizer",
+				id:   "authorizer",
+				ttl:  5 * time.Second,
+				e: endpoint.Endpoint{
+					URL: "https://example.com/{{ .Values.path }}",
+				},
+			},
+			authorizer2: &remoteAuthorizer{
+				name: "authorizer",
+				id:   "authorizer",
+				ttl:  5 * time.Second,
+				e: endpoint.Endpoint{
+					URL: "https://example.com/authorize",
+				},
+			},
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				nil,
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/authorize",
+				nil,
+			),
+			expectEqual: true,
+		},
+	} {
+		t.Run(uc, func(t *testing.T) {
+			// WHEN
+			key1 := tc.authorizer1.calculateCacheKey(
+				tc.request1,
+				tc.payload1,
+			)
+			key2 := tc.authorizer2.calculateCacheKey(
+				tc.request2,
+				tc.payload2,
+			)
+
+			// THEN
+			if tc.expectEqual {
+				assert.Equal(t, key1, key2)
+			} else {
+				assert.NotEqual(t, key1, key2)
+			}
 		})
 	}
 }

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
@@ -400,7 +400,7 @@ func (c *genericContextualizer) calculateCacheKey(
 	hash := sha256.New()
 	hash.Write(stringx.ToBytes("generic-contextualizer:v3"))
 	hash.Write(separator[:])
-	hash.Write(stringx.ToBytes(c.id))
+	hash.Write(stringx.ToBytes(c.name))
 	hash.Write(separator[:])
 	hash.Write(ttlBytes[:])
 	hash.Write(stringx.ToBytes(req.Method))

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
@@ -158,8 +158,13 @@ func (c *genericContextualizer) Execute(ctx heimdall.RequestContext, sub *subjec
 		return err
 	}
 
+	req, err := c.createRequest(ctx, sub, vals, payload)
+	if err != nil {
+		return err
+	}
+
 	if c.ttl > 0 {
-		cacheKey = c.calculateCacheKey(ctx, sub, vals, payload)
+		cacheKey = c.calculateCacheKey(req, payload)
 
 		if entry, err := cch.Get(ctx.Context(), cacheKey); err == nil {
 			var result heimdall.Result
@@ -173,7 +178,7 @@ func (c *genericContextualizer) Execute(ctx heimdall.RequestContext, sub *subjec
 	}
 
 	if response == nil {
-		response, err = c.callEndpoint(ctx, sub, vals, payload)
+		response, err = c.callEndpoint(ctx, req)
 		if err != nil {
 			return err
 		}
@@ -249,17 +254,10 @@ func (c *genericContextualizer) ContinueOnError() bool { return c.continueOnErro
 
 func (c *genericContextualizer) callEndpoint(
 	ctx heimdall.RequestContext,
-	sub *subject.Subject,
-	values map[string]string,
-	payload string,
+	req *http.Request,
 ) (*heimdall.Result, error) {
 	logger := zerolog.Ctx(ctx.Context())
 	logger.Debug().Msg("Calling contextualizer endpoint")
-
-	req, err := c.createRequest(ctx, sub, values, payload)
-	if err != nil {
-		return nil, err
-	}
 
 	resp, err := c.e.CreateClient(req.URL.Hostname()).Do(req)
 	if err != nil {
@@ -386,9 +384,7 @@ func (c *genericContextualizer) readResponse(ctx heimdall.RequestContext, resp *
 }
 
 func (c *genericContextualizer) calculateCacheKey(
-	ctx heimdall.RequestContext,
-	sub *subject.Subject,
-	values map[string]string,
+	req *http.Request,
 	payload string,
 ) string {
 	const int64BytesCount = 8
@@ -399,43 +395,27 @@ func (c *genericContextualizer) calculateCacheKey(
 	// no integer overflow during conversion possible
 	binary.LittleEndian.PutUint64(ttlBytes[:], uint64(c.ttl))
 
+	var separator [1]byte
+
 	hash := sha256.New()
-	hash.Write(stringx.ToBytes("generic-contextualizer:v2"))
-	hash.Write(c.e.Hash())
+	hash.Write(stringx.ToBytes("generic-contextualizer:v3"))
+	hash.Write(separator[:])
 	hash.Write(stringx.ToBytes(c.id))
-	hash.Write(stringx.ToBytes(payload))
+	hash.Write(separator[:])
 	hash.Write(ttlBytes[:])
-	hash.Write(sub.Hash())
+	hash.Write(stringx.ToBytes(req.Method))
+	hash.Write(separator[:])
+	hash.Write(stringx.ToBytes(req.URL.String()))
+	hash.Write(separator[:])
 
-	for k, v := range values {
-		hash.Write(stringx.ToBytes(k))
-		hash.Write(stringx.ToBytes(v))
-	}
+	_ = req.Header.Write(hash)
 
-	if len(c.fwdHeaders) != 0 || len(c.fwdCookies) != 0 {
-		req := ctx.Request()
+	hash.Write(separator[:])
+	hash.Write(stringx.ToBytes(payload))
 
-		var (
-			headerKind = [1]byte{0x01}
-			cookieKind = [1]byte{0x02}
-			separator  = [1]byte{0x00}
-		)
-
-		for _, headerName := range c.fwdHeaders {
-			hash.Write(headerKind[:])
-			hash.Write(stringx.ToBytes(headerName))
-			hash.Write(separator[:])
-			hash.Write(stringx.ToBytes(req.Header(headerName)))
-			hash.Write(separator[:])
-		}
-
-		for _, cookieName := range c.fwdCookies {
-			hash.Write(cookieKind[:])
-			hash.Write(stringx.ToBytes(cookieName))
-			hash.Write(separator[:])
-			hash.Write(stringx.ToBytes(req.Cookie(cookieName)))
-			hash.Write(separator[:])
-		}
+	if c.e.AuthStrategy != nil {
+		hash.Write(separator[:])
+		hash.Write(c.e.AuthStrategy.Hash())
 	}
 
 	var result [sha256.Size]byte

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer.go
@@ -17,9 +17,6 @@
 package contextualizers
 
 import (
-	"crypto/sha256"
-	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"io"
 	"net/http"
@@ -32,6 +29,7 @@ import (
 
 	"github.com/dadrus/heimdall/internal/app"
 	"github.com/dadrus/heimdall/internal/cache"
+	"github.com/dadrus/heimdall/internal/cache/cachekey"
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/rules/endpoint"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/contenttype"
@@ -387,40 +385,21 @@ func (c *genericContextualizer) calculateCacheKey(
 	req *http.Request,
 	payload string,
 ) string {
-	const int64BytesCount = 8
+	key := cachekey.New("generic-contextualizer:response")
 
-	var ttlBytes [int64BytesCount]byte
+	key.WriteString(c.name)
+	key.WriteInt64(int64(c.ttl))
+	key.WriteString(req.Method)
+	key.WriteString(req.URL.String())
+	key.WriteHeader(req.Header)
+	key.WriteString(payload)
 
-	//nolint:gosec
-	// no integer overflow during conversion possible
-	binary.LittleEndian.PutUint64(ttlBytes[:], uint64(c.ttl))
-
-	var separator [1]byte
-
-	hash := sha256.New()
-	hash.Write(stringx.ToBytes("generic-contextualizer:v3"))
-	hash.Write(separator[:])
-	hash.Write(stringx.ToBytes(c.name))
-	hash.Write(separator[:])
-	hash.Write(ttlBytes[:])
-	hash.Write(stringx.ToBytes(req.Method))
-	hash.Write(separator[:])
-	hash.Write(stringx.ToBytes(req.URL.String()))
-	hash.Write(separator[:])
-
-	_ = req.Header.Write(hash)
-
-	hash.Write(separator[:])
-	hash.Write(stringx.ToBytes(payload))
-
+	key.WriteBool(c.e.AuthStrategy != nil)
 	if c.e.AuthStrategy != nil {
-		hash.Write(separator[:])
-		hash.Write(c.e.AuthStrategy.Hash())
+		key.WriteBytes(c.e.AuthStrategy.Hash())
 	}
 
-	var result [sha256.Size]byte
-
-	return hex.EncodeToString(hash.Sum(result[:0]))
+	return key.SumString()
 }
 
 func (c *genericContextualizer) renderTemplates(

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer_test.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer_test.go
@@ -1195,12 +1195,12 @@ func TestGenericContextualizerExecute(t *testing.T) {
 func TestGenericContextualizerCalculateCacheKey(t *testing.T) {
 	t.Parallel()
 
-	newContextualizer := func(id string, ttl time.Duration) *genericContextualizer {
+	newContextualizer := func(name string, ttl time.Duration) *genericContextualizer {
 		t.Helper()
 
 		return &genericContextualizer{
-			id:  id,
-			ttl: ttl,
+			name: name,
+			ttl:  ttl,
 		}
 	}
 
@@ -1267,7 +1267,7 @@ func TestGenericContextualizerCalculateCacheKey(t *testing.T) {
 			payload2:    `{"foo":"bar"}`,
 			expectEqual: true,
 		},
-		"different contextualizer id": {
+		"different contextualizer names": {
 			contextualizer1: newContextualizer("contextualizer-a", 5*time.Second),
 			contextualizer2: newContextualizer("contextualizer-b", 5*time.Second),
 			request1: newRequest(

--- a/internal/rules/mechanisms/contextualizers/generic_contextualizer_test.go
+++ b/internal/rules/mechanisms/contextualizers/generic_contextualizer_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/dadrus/heimdall/internal/heimdall"
 	heimdallmocks "github.com/dadrus/heimdall/internal/heimdall/mocks"
 	"github.com/dadrus/heimdall/internal/rules/endpoint"
+	"github.com/dadrus/heimdall/internal/rules/endpoint/authstrategy"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/subject"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/template"
 	"github.com/dadrus/heimdall/internal/rules/mechanisms/values"
@@ -968,8 +969,11 @@ func TestGenericContextualizerExecute(t *testing.T) {
 		},
 		"with forwarded header and cache miss due to different value": {
 			contextualizer: &genericContextualizer{
-				id:         "test-contextualizer",
-				e:          endpoint.Endpoint{URL: srv.URL},
+				id: "test-contextualizer",
+				e: endpoint.Endpoint{
+					URL:    srv.URL,
+					Method: http.MethodGet,
+				},
 				fwdHeaders: []string{"X-Tenant-ID"},
 				ttl:        5 * time.Second,
 			},
@@ -1000,21 +1004,23 @@ func TestGenericContextualizerExecute(t *testing.T) {
 					RequestFunctions: reqFuns,
 				})
 			},
-			configureCache: func(t *testing.T, cch *mocks.CacheMock, contextualizer *genericContextualizer, sub *subject.Subject) {
+			configureCache: func(
+				t *testing.T,
+				cch *mocks.CacheMock,
+				contextualizer *genericContextualizer,
+				_ *subject.Subject,
+			) {
 				t.Helper()
 
 				cacheKeyFor := func(headerValue string) string {
 					t.Helper()
 
-					reqFuns := heimdallmocks.NewRequestFunctionsMock(t)
-					reqFuns.EXPECT().Header("X-Tenant-ID").Return(headerValue)
+					req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+					require.NoError(t, err)
 
-					ctx := heimdallmocks.NewRequestContextMock(t)
-					ctx.EXPECT().Request().Return(&heimdall.Request{
-						RequestFunctions: reqFuns,
-					})
+					req.Header.Set("X-Tenant-ID", headerValue)
 
-					return contextualizer.calculateCacheKey(ctx, sub, nil, "")
+					return contextualizer.calculateCacheKey(req, "")
 				}
 
 				tenantACacheKey := cacheKeyFor("tenant-a")
@@ -1022,13 +1028,21 @@ func TestGenericContextualizerExecute(t *testing.T) {
 
 				require.NotEqual(t, tenantACacheKey, tenantBCacheKey)
 
-				cch.EXPECT().Get(mock.Anything, tenantBCacheKey).
+				cch.EXPECT().
+					Get(mock.Anything, tenantBCacheKey).
 					Return(nil, errors.New("no cache entry"))
 
-				cch.EXPECT().Set(mock.Anything, tenantBCacheKey, mock.Anything, contextualizer.ttl).
+				cch.EXPECT().
+					Set(mock.Anything, tenantBCacheKey, mock.Anything, contextualizer.ttl).
 					Return(nil)
 			},
-			assert: func(t *testing.T, err error, sub *subject.Subject, outputs map[string]any, results heimdall.Results) {
+			assert: func(
+				t *testing.T,
+				err error,
+				sub *subject.Subject,
+				outputs map[string]any,
+				results heimdall.Results,
+			) {
 				t.Helper()
 
 				assert.True(t, remoteEndpointCalled)
@@ -1043,6 +1057,96 @@ func TestGenericContextualizerExecute(t *testing.T) {
 				result := results["test-contextualizer"]
 				require.NotNil(t, result)
 				assert.Equal(t, map[string]any{"tenant": "tenant-b"}, result.Payload)
+			},
+		},
+		"with rendered endpoint header and cache miss due to different output": {
+			contextualizer: &genericContextualizer{
+				id: "test-contextualizer",
+				e: endpoint.Endpoint{
+					URL:    srv.URL,
+					Method: http.MethodGet,
+					Headers: map[string]string{
+						"X-Tenant-ID": "{{ .Outputs.foo }}",
+					},
+				},
+				ttl: 5 * time.Second,
+			},
+			subject: &subject.Subject{
+				ID:         "Foo",
+				Attributes: map[string]any{"bar": "baz"},
+			},
+			instructServer: func(t *testing.T) {
+				t.Helper()
+
+				checkRequest = func(req *http.Request) {
+					t.Helper()
+
+					assert.Equal(t, "bar", req.Header.Get("X-Tenant-ID"))
+				}
+
+				responseContentType = "application/json"
+				responseContent = []byte(`{"tenant":"bar"}`)
+				responseCode = http.StatusOK
+			},
+			configureContext: func(t *testing.T, ctx *heimdallmocks.RequestContextMock) {
+				t.Helper()
+
+				ctx.EXPECT().Request().Return(nil)
+			},
+			configureCache: func(
+				t *testing.T,
+				cch *mocks.CacheMock,
+				contextualizer *genericContextualizer,
+				_ *subject.Subject,
+			) {
+				t.Helper()
+
+				previousReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+				require.NoError(t, err)
+
+				previousReq.Header.Set("X-Tenant-ID", "tenant-a")
+
+				currentReq, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+				require.NoError(t, err)
+
+				currentReq.Header.Set("X-Tenant-ID", "bar")
+
+				previousCacheKey := contextualizer.calculateCacheKey(previousReq, "")
+				currentCacheKey := contextualizer.calculateCacheKey(currentReq, "")
+
+				require.NotEqual(t, previousCacheKey, currentCacheKey)
+
+				cch.EXPECT().
+					Get(mock.Anything, currentCacheKey).
+					Return(nil, errors.New("no cache entry"))
+
+				cch.EXPECT().
+					Set(mock.Anything, currentCacheKey, mock.Anything, contextualizer.ttl).
+					Return(nil)
+			},
+			assert: func(
+				t *testing.T,
+				err error,
+				sub *subject.Subject,
+				outputs map[string]any,
+				results heimdall.Results,
+			) {
+				t.Helper()
+
+				assert.True(t, remoteEndpointCalled)
+
+				require.NoError(t, err)
+				assert.Len(t, sub.Attributes, 1)
+
+				require.Len(t, outputs, 2)
+				assert.Equal(t, map[string]any{"tenant": "bar"}, outputs["test-contextualizer"])
+
+				require.Len(t, results, 2)
+
+				result := results["test-contextualizer"]
+				require.NotNil(t, result)
+
+				assert.Equal(t, map[string]any{"tenant": "bar"}, result.Payload)
 			},
 		},
 	} {
@@ -1091,170 +1195,308 @@ func TestGenericContextualizerExecute(t *testing.T) {
 func TestGenericContextualizerCalculateCacheKey(t *testing.T) {
 	t.Parallel()
 
-	ep := endpoint.Endpoint{
-		URL: "https://example.com/context",
+	newContextualizer := func(id string, ttl time.Duration) *genericContextualizer {
+		t.Helper()
+
+		return &genericContextualizer{
+			id:  id,
+			ttl: ttl,
+		}
 	}
 
-	sub := &subject.Subject{
-		ID:         "subject",
-		Attributes: map[string]any{},
+	newRequest := func(
+		method string,
+		rawURL string,
+		headers map[string]string,
+		cookies map[string]string,
+	) *http.Request {
+		t.Helper()
+
+		req, err := http.NewRequestWithContext(t.Context(), method, rawURL, nil)
+		require.NoError(t, err)
+
+		for name, value := range headers {
+			req.Header.Set(name, value)
+		}
+
+		for name, value := range cookies {
+			req.AddCookie(&http.Cookie{
+				Name:  name,
+				Value: value,
+			})
+		}
+
+		return req
 	}
 
 	for uc, tc := range map[string]struct {
 		contextualizer1 *genericContextualizer
 		contextualizer2 *genericContextualizer
-		headers1        map[string]string
-		headers2        map[string]string
-		cookies1        map[string]string
-		cookies2        map[string]string
+		request1        *http.Request
+		request2        *http.Request
+		payload1        string
+		payload2        string
 		expectEqual     bool
 	}{
-		"same configuration and request": {
-			contextualizer1: &genericContextualizer{
-				id:         "contextualizer",
-				e:          ep,
-				fwdHeaders: []string{"X-Tenant-ID"},
-				fwdCookies: []string{"tenant"},
-				ttl:        5 * time.Second,
-			},
-			contextualizer2: &genericContextualizer{
-				id:         "contextualizer",
-				e:          ep,
-				fwdHeaders: []string{"X-Tenant-ID"},
-				fwdCookies: []string{"tenant"},
-				ttl:        5 * time.Second,
-			},
-			headers1:    map[string]string{"X-Tenant-ID": "tenant-a"},
-			headers2:    map[string]string{"X-Tenant-ID": "tenant-a"},
-			cookies1:    map[string]string{"tenant": "tenant-a"},
-			cookies2:    map[string]string{"tenant": "tenant-a"},
+		"same effective request": {
+			contextualizer1: newContextualizer("contextualizer", 5*time.Second),
+			contextualizer2: newContextualizer("contextualizer", 5*time.Second),
+			request1: newRequest(
+				http.MethodPost,
+				"https://example.com/context",
+				map[string]string{
+					"Content-Type": "application/json",
+					"X-Tenant-ID":  "tenant-a",
+				},
+				map[string]string{
+					"tenant": "tenant-a",
+				},
+			),
+			request2: newRequest(
+				http.MethodPost,
+				"https://example.com/context",
+				map[string]string{
+					"Content-Type": "application/json",
+					"X-Tenant-ID":  "tenant-a",
+				},
+				map[string]string{
+					"tenant": "tenant-a",
+				},
+			),
+			payload1:    `{"foo":"bar"}`,
+			payload2:    `{"foo":"bar"}`,
 			expectEqual: true,
 		},
-		"different forwarded header value": {
-			contextualizer1: &genericContextualizer{
-				id:         "contextualizer",
-				e:          ep,
-				fwdHeaders: []string{"X-Tenant-ID"},
-				ttl:        5 * time.Second,
-			},
-			contextualizer2: &genericContextualizer{
-				id:         "contextualizer",
-				e:          ep,
-				fwdHeaders: []string{"X-Tenant-ID"},
-				ttl:        5 * time.Second,
-			},
-			headers1: map[string]string{"X-Tenant-ID": "tenant-a"},
-			headers2: map[string]string{"X-Tenant-ID": "tenant-b"},
+		"different contextualizer id": {
+			contextualizer1: newContextualizer("contextualizer-a", 5*time.Second),
+			contextualizer2: newContextualizer("contextualizer-b", 5*time.Second),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				nil,
+				nil,
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				nil,
+				nil,
+			),
 		},
-		"different forwarded header name": {
-			contextualizer1: &genericContextualizer{
-				id:         "contextualizer",
-				e:          ep,
-				fwdHeaders: []string{"X-Tenant-ID"},
-				ttl:        5 * time.Second,
-			},
-			contextualizer2: &genericContextualizer{
-				id:         "contextualizer",
-				e:          ep,
-				fwdHeaders: []string{"X-Organization-ID"},
-				ttl:        5 * time.Second,
-			},
-			headers1: map[string]string{"X-Tenant-ID": "foo"},
-			headers2: map[string]string{"X-Organization-ID": "foo"},
+		"different ttl": {
+			contextualizer1: newContextualizer("contextualizer", 5*time.Second),
+			contextualizer2: newContextualizer("contextualizer", 10*time.Second),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				nil,
+				nil,
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				nil,
+				nil,
+			),
 		},
-		"different forwarded cookie value": {
-			contextualizer1: &genericContextualizer{
-				id:         "contextualizer",
-				e:          ep,
-				fwdCookies: []string{"tenant"},
-				ttl:        5 * time.Second,
-			},
-			contextualizer2: &genericContextualizer{
-				id:         "contextualizer",
-				e:          ep,
-				fwdCookies: []string{"tenant"},
-				ttl:        5 * time.Second,
-			},
-			cookies1: map[string]string{"tenant": "tenant-a"},
-			cookies2: map[string]string{"tenant": "tenant-b"},
+		"different request method": {
+			contextualizer1: newContextualizer("contextualizer", 5*time.Second),
+			contextualizer2: newContextualizer("contextualizer", 5*time.Second),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				nil,
+				nil,
+			),
+			request2: newRequest(
+				http.MethodPost,
+				"https://example.com/context",
+				nil,
+				nil,
+			),
 		},
-		"different forwarded cookie name": {
-			contextualizer1: &genericContextualizer{
-				id:         "contextualizer",
-				e:          ep,
-				fwdCookies: []string{"tenant"},
-				ttl:        5 * time.Second,
-			},
-			contextualizer2: &genericContextualizer{
-				id:         "contextualizer",
-				e:          ep,
-				fwdCookies: []string{"organization"},
-				ttl:        5 * time.Second,
-			},
-			cookies1: map[string]string{"tenant": "foo"},
-			cookies2: map[string]string{"organization": "foo"},
+		"different rendered url": {
+			contextualizer1: newContextualizer("contextualizer", 5*time.Second),
+			contextualizer2: newContextualizer("contextualizer", 5*time.Second),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/tenant-a",
+				nil,
+				nil,
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/tenant-b",
+				nil,
+				nil,
+			),
 		},
-		"different forwarded value type": {
+		"different header value": {
+			contextualizer1: newContextualizer("contextualizer", 5*time.Second),
+			contextualizer2: newContextualizer("contextualizer", 5*time.Second),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				map[string]string{"X-Tenant-ID": "tenant-a"},
+				nil,
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				map[string]string{"X-Tenant-ID": "tenant-b"},
+				nil,
+			),
+		},
+		"different header name": {
+			contextualizer1: newContextualizer("contextualizer", 5*time.Second),
+			contextualizer2: newContextualizer("contextualizer", 5*time.Second),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				map[string]string{"X-Tenant-ID": "foo"},
+				nil,
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				map[string]string{"X-Organization-ID": "foo"},
+				nil,
+			),
+		},
+		"different cookie value": {
+			contextualizer1: newContextualizer("contextualizer", 5*time.Second),
+			contextualizer2: newContextualizer("contextualizer", 5*time.Second),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				nil,
+				map[string]string{"tenant": "tenant-a"},
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				nil,
+				map[string]string{"tenant": "tenant-b"},
+			),
+		},
+		"different cookie name": {
+			contextualizer1: newContextualizer("contextualizer", 5*time.Second),
+			contextualizer2: newContextualizer("contextualizer", 5*time.Second),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				nil,
+				map[string]string{"tenant": "foo"},
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				nil,
+				map[string]string{"organization": "foo"},
+			),
+		},
+		"different header and cookie": {
+			contextualizer1: newContextualizer("contextualizer", 5*time.Second),
+			contextualizer2: newContextualizer("contextualizer", 5*time.Second),
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				map[string]string{"tenant": "foo"},
+				nil,
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				nil,
+				map[string]string{"tenant": "foo"},
+			),
+		},
+		"different payload": {
+			contextualizer1: newContextualizer("contextualizer", 5*time.Second),
+			contextualizer2: newContextualizer("contextualizer", 5*time.Second),
+			request1: newRequest(
+				http.MethodPost,
+				"https://example.com/context",
+				nil,
+				nil,
+			),
+			request2: newRequest(
+				http.MethodPost,
+				"https://example.com/context",
+				nil,
+				nil,
+			),
+			payload1: `{"tenant":"tenant-a"}`,
+			payload2: `{"tenant":"tenant-b"}`,
+		},
+		"same effective request despite different endpoint configuration": {
 			contextualizer1: &genericContextualizer{
-				id:         "contextualizer",
-				e:          ep,
-				fwdHeaders: []string{"tenant"},
-				ttl:        5 * time.Second,
+				id:  "contextualizer",
+				ttl: 5 * time.Second,
+				e: endpoint.Endpoint{
+					URL: "https://example.com/{{ .Values.path }}",
+				},
 			},
 			contextualizer2: &genericContextualizer{
-				id:         "contextualizer",
-				e:          ep,
-				fwdCookies: []string{"tenant"},
-				ttl:        5 * time.Second,
+				id:  "contextualizer",
+				ttl: 5 * time.Second,
+				e: endpoint.Endpoint{
+					URL: "https://example.com/context",
+				},
 			},
-			headers1: map[string]string{"tenant": "foo"},
-			cookies2: map[string]string{"tenant": "foo"},
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				nil,
+				nil,
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				nil,
+				nil,
+			),
+			expectEqual: true,
+		},
+		"different authentication strategy": {
+			contextualizer1: &genericContextualizer{
+				id:  "contextualizer",
+				ttl: 5 * time.Second,
+				e: endpoint.Endpoint{
+					AuthStrategy: &authstrategy.BasicAuth{
+						User:     "foo",
+						Password: "bar",
+					},
+				},
+			},
+			contextualizer2: &genericContextualizer{
+				id:  "contextualizer",
+				ttl: 5 * time.Second,
+				e: endpoint.Endpoint{
+					AuthStrategy: &authstrategy.BasicAuth{
+						User:     "foo",
+						Password: "baz",
+					},
+				},
+			},
+			request1: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				nil,
+				nil,
+			),
+			request2: newRequest(
+				http.MethodGet,
+				"https://example.com/context",
+				nil,
+				nil,
+			),
 		},
 	} {
 		t.Run(uc, func(t *testing.T) {
-			// GIVEN
-			createContext := func(
-				headers map[string]string,
-				cookies map[string]string,
-				contextualizer *genericContextualizer,
-			) heimdall.RequestContext {
-				t.Helper()
-
-				ctx := heimdallmocks.NewRequestContextMock(t)
-
-				if len(contextualizer.fwdHeaders) == 0 && len(contextualizer.fwdCookies) == 0 {
-					return ctx
-				}
-
-				reqFuns := heimdallmocks.NewRequestFunctionsMock(t)
-
-				for _, headerName := range contextualizer.fwdHeaders {
-					reqFuns.EXPECT().
-						Header(headerName).
-						Return(headers[headerName])
-				}
-
-				for _, cookieName := range contextualizer.fwdCookies {
-					reqFuns.EXPECT().
-						Cookie(cookieName).
-						Return(cookies[cookieName])
-				}
-
-				ctx.EXPECT().
-					Request().
-					Return(&heimdall.Request{
-						RequestFunctions: reqFuns,
-					})
-
-				return ctx
-			}
-
-			ctx1 := createContext(tc.headers1, tc.cookies1, tc.contextualizer1)
-			ctx2 := createContext(tc.headers2, tc.cookies2, tc.contextualizer2)
-
 			// WHEN
-			key1 := tc.contextualizer1.calculateCacheKey(ctx1, sub, nil, "")
-			key2 := tc.contextualizer2.calculateCacheKey(ctx2, sub, nil, "")
+			key1 := tc.contextualizer1.calculateCacheKey(tc.request1, tc.payload1)
+			key2 := tc.contextualizer2.calculateCacheKey(tc.request2, tc.payload2)
 
 			// THEN
 			if tc.expectEqual {

--- a/internal/rules/oauth2/clientcredentials/clientcredentials.go
+++ b/internal/rules/oauth2/clientcredentials/clientcredentials.go
@@ -18,9 +18,6 @@ package clientcredentials
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/binary"
-	"encoding/hex"
 	"io"
 	"net/http"
 	"net/url"
@@ -31,6 +28,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/dadrus/heimdall/internal/cache"
+	"github.com/dadrus/heimdall/internal/cache/cachekey"
 	"github.com/dadrus/heimdall/internal/heimdall"
 	"github.com/dadrus/heimdall/internal/rules/endpoint"
 	"github.com/dadrus/heimdall/internal/x"
@@ -115,43 +113,26 @@ func (c *Config) Apply(req *http.Request) error {
 }
 
 func (c *Config) Hash() []byte {
-	digest := sha256.New()
-	digest.Write(stringx.ToBytes(c.ClientID))
-	digest.Write(stringx.ToBytes(c.ClientSecret))
-	digest.Write(stringx.ToBytes(c.TokenURL))
+	key := cachekey.New("oauth2-client-credentials")
+	key.WriteString(c.TokenURL)
+	key.WriteString(c.ClientID)
+	key.WriteString(c.ClientSecret)
+	key.WriteString(string(c.effectiveAuthMethod()))
+	key.WriteStrings(c.Scopes)
 
-	for _, scope := range c.Scopes {
-		digest.Write(stringx.ToBytes(scope))
-		digest.Write([]byte{0})
-	}
-
-	return digest.Sum(nil)
+	return key.Sum()
 }
 
 func (c *Config) calculateCacheKey() string {
-	digest := sha256.New()
-	digest.Write(stringx.ToBytes(c.ClientID))
-	digest.Write(stringx.ToBytes(c.ClientSecret))
-	digest.Write(stringx.ToBytes(c.TokenURL))
+	key := cachekey.New("oauth2-client-credentials:token")
+	key.WriteBytes(c.Hash())
+	key.WriteBool(c.TTL != nil)
 
-	for _, scope := range c.Scopes {
-		digest.Write(stringx.ToBytes(scope))
-		digest.Write([]byte{0})
+	if c.TTL != nil {
+		key.WriteInt64(int64(*c.TTL))
 	}
 
-	if c.TTL == nil {
-		digest.Write([]byte{0})
-	} else {
-		digest.Write([]byte{1})
-
-		var ttl [8]byte
-		binary.BigEndian.PutUint64(ttl[:], uint64(*c.TTL)) //nolint:gosec
-		digest.Write(ttl[:])
-	}
-
-	var result [sha256.Size]byte
-
-	return hex.EncodeToString(digest.Sum(result[:0]))
+	return key.SumString()
 }
 
 func (c *Config) getCacheTTL(resp *TokenInfo) time.Duration {
@@ -258,4 +239,12 @@ func (c *Config) fetchToken(ctx context.Context) (*TokenInfo, error) {
 	}
 
 	return tokenInfo, nil
+}
+
+func (c *Config) effectiveAuthMethod() AuthMethod {
+	if c.AuthMethod == "" {
+		return AuthMethodBasicAuth
+	}
+
+	return c.AuthMethod
 }

--- a/internal/rules/oauth2/clientcredentials/clientcredentials_test.go
+++ b/internal/rules/oauth2/clientcredentials/clientcredentials_test.go
@@ -669,16 +669,44 @@ func TestClientCredentialsHash(t *testing.T) {
 	}{
 		"same configuration": {
 			c1: &Config{
+				TokenURL:     "https://example.com/token",
 				ClientID:     "Foo",
 				ClientSecret: "Bar",
 				Scopes:       []string{"foo", "bar"},
 			},
 			c2: &Config{
+				TokenURL:     "https://example.com/token",
 				ClientID:     "Foo",
 				ClientSecret: "Bar",
 				Scopes:       []string{"foo", "bar"},
 			},
 			expectEqual: true,
+		},
+		"default and explicit basic auth method": {
+			c1: &Config{
+				TokenURL:     "https://example.com/token",
+				ClientID:     "Foo",
+				ClientSecret: "Bar",
+			},
+			c2: &Config{
+				TokenURL:     "https://example.com/token",
+				ClientID:     "Foo",
+				ClientSecret: "Bar",
+				AuthMethod:   AuthMethodBasicAuth,
+			},
+			expectEqual: true,
+		},
+		"different token url": {
+			c1: &Config{
+				TokenURL:     "https://example.com/token-a",
+				ClientID:     "Foo",
+				ClientSecret: "Bar",
+			},
+			c2: &Config{
+				TokenURL:     "https://example.com/token-b",
+				ClientID:     "Foo",
+				ClientSecret: "Bar",
+			},
 		},
 		"different client ids": {
 			c1: &Config{
@@ -688,6 +716,38 @@ func TestClientCredentialsHash(t *testing.T) {
 			c2: &Config{
 				ClientID:     "Baz",
 				ClientSecret: "Bar",
+			},
+		},
+		"different client secrets": {
+			c1: &Config{
+				ClientID:     "Foo",
+				ClientSecret: "Bar",
+			},
+			c2: &Config{
+				ClientID:     "Foo",
+				ClientSecret: "Baz",
+			},
+		},
+		"different authentication methods": {
+			c1: &Config{
+				ClientID:     "Foo",
+				ClientSecret: "Bar",
+				AuthMethod:   AuthMethodBasicAuth,
+			},
+			c2: &Config{
+				ClientID:     "Foo",
+				ClientSecret: "Bar",
+				AuthMethod:   AuthMethodRequestBody,
+			},
+		},
+		"field boundaries are preserved": {
+			c1: &Config{
+				ClientID:     "a",
+				ClientSecret: "bc",
+			},
+			c2: &Config{
+				ClientID:     "ab",
+				ClientSecret: "c",
 			},
 		},
 		"ambiguous scope sets": {
@@ -704,11 +764,9 @@ func TestClientCredentialsHash(t *testing.T) {
 		},
 	} {
 		t.Run(uc, func(t *testing.T) {
-			// WHEN
 			hash1 := tc.c1.Hash()
 			hash2 := tc.c2.Hash()
 
-			// THEN
 			assert.NotEmpty(t, hash1)
 			assert.NotEmpty(t, hash2)
 
@@ -745,6 +803,34 @@ func TestClientCredentialsCalculateCacheKey(t *testing.T) {
 			},
 			expectEqual: true,
 		},
+		"default and explicit basic auth method": {
+			c1: &Config{
+				TokenURL:     "https://example.com/token",
+				ClientID:     "client",
+				ClientSecret: "secret",
+			},
+			c2: &Config{
+				TokenURL:     "https://example.com/token",
+				ClientID:     "client",
+				ClientSecret: "secret",
+				AuthMethod:   AuthMethodBasicAuth,
+			},
+			expectEqual: true,
+		},
+		"different authentication method": {
+			c1: &Config{
+				TokenURL:     "https://example.com/token",
+				ClientID:     "client",
+				ClientSecret: "secret",
+				AuthMethod:   AuthMethodBasicAuth,
+			},
+			c2: &Config{
+				TokenURL:     "https://example.com/token",
+				ClientID:     "client",
+				ClientSecret: "secret",
+				AuthMethod:   AuthMethodRequestBody,
+			},
+		},
 		"different cache ttl": {
 			c1: &Config{
 				TokenURL:     "https://example.com/token",
@@ -757,6 +843,31 @@ func TestClientCredentialsCalculateCacheKey(t *testing.T) {
 				ClientID:     "client",
 				ClientSecret: "secret",
 				TTL:          new(15 * time.Second),
+			},
+		},
+		"default and explicit cache ttl": {
+			c1: &Config{
+				TokenURL:     "https://example.com/token",
+				ClientID:     "client",
+				ClientSecret: "secret",
+			},
+			c2: &Config{
+				TokenURL:     "https://example.com/token",
+				ClientID:     "client",
+				ClientSecret: "secret",
+				TTL:          new(5 * time.Second),
+			},
+		},
+		"field boundaries are preserved": {
+			c1: &Config{
+				TokenURL:     "https://example.com/token",
+				ClientID:     "a",
+				ClientSecret: "bc",
+			},
+			c2: &Config{
+				TokenURL:     "https://example.com/token",
+				ClientID:     "ab",
+				ClientSecret: "c",
 			},
 		},
 		"ambiguous scope sets": {
@@ -777,11 +888,9 @@ func TestClientCredentialsCalculateCacheKey(t *testing.T) {
 		},
 	} {
 		t.Run(uc, func(t *testing.T) {
-			// WHEN
 			key1 := tc.c1.calculateCacheKey()
 			key2 := tc.c2.calculateCacheKey()
 
-			// THEN
 			assert.NotEmpty(t, key1)
 			assert.NotEmpty(t, key2)
 


### PR DESCRIPTION
## Related issue(s)

closes #3463

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

This PR hardens cache identity generation used by cached mechanisms and endpoint authentication strategies described in the referenced ticket.
