### PR TITLE
fix: Error messages in html responses escaped

### DIFF
--- a/internal/handler/middleware/grpc/errorhandler/error_response.go
+++ b/internal/handler/middleware/grpc/errorhandler/error_response.go
@@ -19,6 +19,7 @@ package errorhandler
 import (
 	"encoding/xml"
 	"fmt"
+	"html"
 
 	"github.com/elnormous/contenttype"
 	envoy_core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -81,7 +82,7 @@ func errorResponse(
 func format(mimeType string, body any) (string, error) {
 	switch mimeType {
 	case "text/html":
-		return fmt.Sprintf("<p>%s</p>", body), nil
+		return fmt.Sprintf("<p>%s</p>", html.EscapeString(fmt.Sprint(body))), nil
 	case "application/json":
 		res, err := json.Marshal(body)
 

--- a/internal/handler/middleware/grpc/errorhandler/error_response_test.go
+++ b/internal/handler/middleware/grpc/errorhandler/error_response_test.go
@@ -80,6 +80,16 @@ func TestErrorResponse(t *testing.T) {
 			expectedType: "application/json",
 			expBody:      "{\"code\":\"authorizationError\",\"message\":\"test\"}",
 		},
+		"escape error in text/html": {
+			// ensuring that error is escaped if it somehow should contain data from outside
+			// should not be possible (TM)
+			grpcCode:     codes.PermissionDenied,
+			httpCode:     http.StatusForbidden,
+			err:          errorchain.NewWithMessage(heimdall.ErrAuthorization, "<script>alert(1)</script>"),
+			offeredType:  "text/html",
+			expectedType: "text/html",
+			expBody:      "<p>authorization error: &lt;script&gt;alert(1)&lt;/script&gt;</p>",
+		},
 	} {
 		t.Run(uc, func(t *testing.T) {
 			// WHEN

--- a/internal/handler/middleware/http/errorhandler/error_handler_test.go
+++ b/internal/handler/middleware/http/errorhandler/error_handler_test.go
@@ -162,6 +162,15 @@ func TestHandlerHandle(t *testing.T) {
 			expCode: http.StatusInternalServerError,
 			expBody: "<p>internal error</p>",
 		},
+		"escape error in text/html": {
+			// ensuring that error is escaped if it somehow should contain data from outside
+			// should not be possible (TM)
+			handler: New(WithVerboseErrors(true)),
+			err:     errorchain.NewWithMessage(heimdall.ErrAuthorization, "<script>alert(1)</script>"),
+			expCode: http.StatusForbidden,
+			accept:  "text/html",
+			expBody: "<p>authorization error: &lt;script&gt;alert(1)&lt;/script&gt;</p>",
+		},
 	} {
 		t.Run(uc, func(t *testing.T) {
 			// GIVEN

--- a/internal/handler/middleware/http/errorhandler/formatter.go
+++ b/internal/handler/middleware/http/errorhandler/formatter.go
@@ -19,6 +19,7 @@ package errorhandler
 import (
 	"encoding/xml"
 	"fmt"
+	"html"
 	"net/http"
 
 	"github.com/elnormous/contenttype"
@@ -42,7 +43,7 @@ func format(req *http.Request, body error) (contenttype.MediaType, []byte, error
 	// Format based on the accept content type
 	switch mediaType.Subtype {
 	case "html":
-		return mediaType, []byte(fmt.Sprintf("<p>%s</p>", body)), nil
+		return mediaType, []byte(fmt.Sprintf("<p>%s</p>", html.EscapeString(body.Error()))), nil
 	case "json":
 		res, err := json.Marshal(body)
 


### PR DESCRIPTION
## Related issue(s)

none

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

This PR is less about fixing a bug and more about hardening. It ensures that HTML responses created by Heimdall in verbose mode are properly escaped. 

Although the corresponding messages currently only contain error information generated by heimdall itself, this change ensures that potentially problematic input cannot be reflected unescaped in the response, should it ever become part of those messages.
