### PR TITLE
fix: Ensuring remote authorizer does not follow redirects

### DIFF
--- a/internal/rules/mechanisms/authorizers/remote_authorizer.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer.go
@@ -329,7 +329,12 @@ func (a *remoteAuthorizer) fetchAuthorizationInformation(
 	logger := zerolog.Ctx(ctx.Context())
 	logger.Debug().Msg("Calling remote authorization endpoint")
 
-	resp, err := a.e.CreateClient(req.URL.Hostname()).Do(req)
+	client := a.e.CreateClient(req.URL.Hostname())
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		var clientErr *url.Error
 		if errors.As(err, &clientErr) && clientErr.Timeout() {

--- a/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
@@ -558,6 +558,7 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 	var (
 		authorizationEndpointCalled bool
+		redirectEndpointCalled      bool
 		checkRequest                func(req *http.Request)
 
 		responseHeaders     map[string]string
@@ -568,6 +569,13 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 	env, err := cel.NewEnv(cellib.Library())
 	require.NoError(t, err)
+
+	redirectSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectEndpointCalled = true
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer redirectSrv.Close()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authorizationEndpointCalled = true
@@ -1075,6 +1083,49 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 				require.ErrorIs(t, err, heimdall.ErrAuthorization)
 				require.ErrorContains(t, err, "authorization failed")
+
+				var identifier interface{ ID() string }
+				require.ErrorAs(t, err, &identifier)
+				assert.Equal(t, "authz", identifier.ID())
+			},
+		},
+		"with redirect response": {
+			authorizer: &remoteAuthorizer{
+				id: "authz",
+				e: endpoint.Endpoint{
+					URL: srv.URL,
+				},
+			},
+			subject: &subject.Subject{ID: "foo"},
+			instructServer: func(t *testing.T) {
+				t.Helper()
+
+				responseHeaders = map[string]string{
+					"Location": redirectSrv.URL,
+				}
+				responseCode = http.StatusFound
+			},
+			configureContext: func(t *testing.T, ctx *heimdallmocks.RequestContextMock) {
+				t.Helper()
+
+				ctx.EXPECT().Request().Return(nil)
+			},
+			assert: func(
+				t *testing.T,
+				err error,
+				_ *subject.Subject,
+				_ map[string]any,
+				_ heimdall.Results,
+			) {
+				t.Helper()
+
+				assert.True(t, authorizationEndpointCalled)
+				assert.False(t, redirectEndpointCalled)
+
+				require.Error(t, err)
+				require.ErrorIs(t, err, heimdall.ErrAuthorization)
+				require.ErrorContains(t, err, "authorization failed")
+				require.ErrorContains(t, err, strconv.Itoa(http.StatusFound))
 
 				var identifier interface{ ID() string }
 				require.ErrorAs(t, err, &identifier)
@@ -1603,6 +1654,7 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 		t.Run(uc, func(t *testing.T) {
 			// GIVEN
 			authorizationEndpointCalled = false
+			redirectEndpointCalled = false
 			responseHeaders = nil
 			responseContentType = ""
 			responseContent = nil


### PR DESCRIPTION
## Related issue(s)

addresses #3442 

## Checklist

<!--
Remove the boxes, which are not applicable and put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
-->

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.

## Description

This PR is less about fixing a bug and more about preserving the expected semantics of PDP communication by preventing redirects.