### PR TITLE
refactor!: `forward_response_headers_to_upstream` removed from `remote` authorizer

### DIFF
--- a/cmd/validate/test_data/config-no-default-principal-in-default-rule.yaml
+++ b/cmd/validate/test_data/config-no-default-principal-in-default-rule.yaml
@@ -231,8 +231,6 @@ mechanisms:
           headers:
             foo-bar: "{{ .Subject.ID }}"
         payload: https://bla.bar
-        forward_response_headers_to_upstream:
-          - bla-bar
         expressions:
           - expression: "Payload.foo == 'bar'"
     - id: attributes_based_authorizer_2

--- a/cmd/validate/test_data/config-valid-with-default-rule.yaml
+++ b/cmd/validate/test_data/config-valid-with-default-rule.yaml
@@ -286,8 +286,6 @@ mechanisms:
           headers:
             foo-bar: "{{ .Subject.ID }}"
         payload: https://bla.bar
-        forward_response_headers_to_upstream:
-          - bla-bar
         expressions:
           - expression: "Payload.foo == 'bar'"
     - id: attributes_based_authorizer_2

--- a/cmd/validate/test_data/config-valid-without-default-rule.yaml
+++ b/cmd/validate/test_data/config-valid-without-default-rule.yaml
@@ -238,8 +238,6 @@ mechanisms:
           headers:
             foo-bar: "{{ .Subject.ID }}"
         payload: https://bla.bar
-        forward_response_headers_to_upstream:
-          - bla-bar
         expressions:
           - expression: "Payload.foo == 'bar'"
     - id: attributes_based_authorizer_2

--- a/docs/content/docs/configuration/reference.adoc
+++ b/docs/content/docs/configuration/reference.adoc
@@ -331,8 +331,6 @@ mechanisms:
       expressions:
         - expression: |
             Payload.response == true
-      forward_response_headers_to_upstream:
-        - bla-bar
   - id: user_is_admin_authz
     type: cel
     config:

--- a/docs/content/docs/mechanisms/authorizers.adoc
+++ b/docs/content/docs/mechanisms/authorizers.adoc
@@ -166,12 +166,6 @@ List of https://github.com/google/cel-spec[CEL] expressions which define the log
 +
 Each expression has access to the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_payload" >}}[`Payload`] object.
 
-* *`forward_response_headers_to_upstream`*: _string array_ (optional, overridable)
-+
-Enables forwarding of selected response headers returned by the authorization endpoint to the upstream service.
-+
-NOTE: This setting is deprecated and will be removed in the 0.18.0 release. Use the response available through the link:{{< relref "/docs/mechanisms/evaluation_objects.adoc#_results" >}}[`Results`] evaluation object together with a `header` finalizer instead.
-
 * *`cache_ttl`*: _link:{{< relref "/docs/configuration/types.adoc#_duration" >}}[Duration]_ (optional, overridable)
 +
 Allows caching of the authorization endpoint responses. Defaults to `0s`, which means no caching. The cache identity is derived from the authorizer, the configured cache TTL and the effective request to the endpoint, including the HTTP method, rendered URL and headers, rendered payload and endpoint authentication strategy. Authorization expressions are evaluated for every execution, regardless of whether the authorization endpoint response was obtained remotely or reused from the cache.

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -146,8 +146,6 @@ mechanisms:
           headers:
             foo-bar: "{{ .Subject.ID }}"
         payload: https://bla.bar
-        forward_response_headers_to_upstream:
-          - bla-bar
     - id: attributes_based_authorizer
       type: cel
       config:

--- a/internal/config/test_data/test_config.yaml
+++ b/internal/config/test_data/test_config.yaml
@@ -418,8 +418,6 @@ mechanisms:
         values:
           key: value
         payload: https://bla.bar
-        forward_response_headers_to_upstream:
-          - bla-bar
         expressions:
           - expression: "Payload.foo == 'bar'"
     - id: attributes_based_authorizer_2

--- a/internal/rules/mechanisms/authorizers/remote_authorizer.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer.go
@@ -59,41 +59,15 @@ func init() {
 }
 
 type remoteAuthorizer struct {
-	name               string
-	id                 string
-	app                app.Context
-	e                  endpoint.Endpoint
-	payload            template.Template
-	expressions        compiledExpressions
-	headersForUpstream []string
-	ttl                time.Duration
-	celEnv             *cel.Env
-	v                  values.Values
-}
-
-type authorizationInformation struct {
-	Headers http.Header `json:"headers"`
-	Payload any         `json:"payload"`
-}
-
-func (ai *authorizationInformation) addHeadersTo(headerNames []string, ctx pipeline.Context) {
-	for _, headerName := range headerNames {
-		headerValue := ai.Headers.Get(headerName)
-		if len(headerValue) != 0 {
-			ctx.AddHeaderForUpstream(headerName, headerValue)
-		}
-	}
-}
-
-func (ai *authorizationInformation) addResultsTo(key string, ctx pipeline.Context) {
-	if ai.Payload != nil {
-		ctx.Outputs()[key] = ai.Payload
-	}
-
-	ctx.Results()[key] = pipeline.NewResultWithHeaders(
-		ai.Payload,
-		ai.Headers,
-	)
+	name        string
+	id          string
+	app         app.Context
+	e           endpoint.Endpoint
+	payload     template.Template
+	expressions compiledExpressions
+	ttl         time.Duration
+	celEnv      *cel.Env
+	v           values.Values
 }
 
 func newRemoteAuthorizer(app app.Context, name string, rawConfig map[string]any) (types.Mechanism, error) {
@@ -104,12 +78,11 @@ func newRemoteAuthorizer(app app.Context, name string, rawConfig map[string]any)
 		Msg("Creating authorizer")
 
 	type Config struct {
-		Endpoint                 endpoint.Endpoint `mapstructure:"endpoint"                             validate:"required"` //nolint:lll
-		Expressions              []Expression      `mapstructure:"expressions"                          validate:"dive"`
-		Payload                  template.Template `mapstructure:"payload"                              validate:"required_without=Endpoint.Headers"` //nolint:lll
-		ResponseHeadersToForward []string          `mapstructure:"forward_response_headers_to_upstream"`
-		CacheTTL                 time.Duration     `mapstructure:"cache_ttl"`
-		Values                   values.Values     `mapstructure:"values"`
+		Endpoint    endpoint.Endpoint `mapstructure:"endpoint"    validate:"required"` //nolint:lll
+		Expressions []Expression      `mapstructure:"expressions" validate:"dive"`
+		Payload     template.Template `mapstructure:"payload"     validate:"required_without=Endpoint.Headers"` //nolint:lll
+		CacheTTL    time.Duration     `mapstructure:"cache_ttl"`
+		Values      values.Values     `mapstructure:"values"`
 	}
 
 	var conf Config
@@ -143,25 +116,16 @@ func newRemoteAuthorizer(app app.Context, name string, rawConfig map[string]any)
 			Msg("No TLS configured for the endpoint used in authorizer")
 	}
 
-	if len(conf.ResponseHeadersToForward) > 0 {
-		logger.Warn().
-			Str("_type", AuthorizerRemote).
-			Str("_name", name).
-			Msg("Usage of forward_response_headers_to_upstream is deprecated. " +
-				"Please use Results object in a header finalizer instead")
-	}
-
 	return &remoteAuthorizer{
-		name:               name,
-		id:                 name,
-		app:                app,
-		e:                  conf.Endpoint,
-		payload:            conf.Payload,
-		expressions:        expressions,
-		headersForUpstream: conf.ResponseHeadersToForward,
-		ttl:                conf.CacheTTL,
-		celEnv:             env,
-		v:                  conf.Values,
+		name:        name,
+		id:          name,
+		app:         app,
+		e:           conf.Endpoint,
+		payload:     conf.Payload,
+		expressions: expressions,
+		ttl:         conf.CacheTTL,
+		celEnv:      env,
+		v:           conf.Values,
 	}, nil
 }
 
@@ -178,7 +142,7 @@ func (a *remoteAuthorizer) Execute(ctx pipeline.Context, sub pipeline.Subject) e
 
 	var (
 		cacheKey string
-		authInfo *authorizationInformation
+		authInfo *pipeline.Result
 		fetched  bool
 	)
 
@@ -196,7 +160,7 @@ func (a *remoteAuthorizer) Execute(ctx pipeline.Context, sub pipeline.Subject) e
 		cacheKey = a.calculateCacheKey(req, payload)
 
 		if entry, err := cch.Get(ctx.Context(), cacheKey); err == nil {
-			var ai authorizationInformation
+			var ai pipeline.Result
 
 			if err = json.Unmarshal(entry, &ai); err == nil {
 				logger.Debug().Msg("Reusing authorization information from cache")
@@ -219,7 +183,7 @@ func (a *remoteAuthorizer) Execute(ctx pipeline.Context, sub pipeline.Subject) e
 		return err
 	}
 
-	if fetched && a.ttl > 0 && len(cacheKey) != 0 {
+	if fetched && len(cacheKey) != 0 {
 		data, _ := json.Marshal(authInfo)
 
 		if err = cch.Set(ctx.Context(), cacheKey, data, a.ttl); err != nil {
@@ -227,8 +191,11 @@ func (a *remoteAuthorizer) Execute(ctx pipeline.Context, sub pipeline.Subject) e
 		}
 	}
 
-	authInfo.addHeadersTo(a.headersForUpstream, ctx)
-	authInfo.addResultsTo(a.id, ctx)
+	if authInfo.Payload != nil {
+		ctx.Outputs()[a.id] = authInfo.Payload
+	}
+
+	ctx.Results()[a.id] = authInfo
 
 	return nil
 }
@@ -251,8 +218,7 @@ func (a *remoteAuthorizer) CreateStep(
 	type Config struct {
 		Endpoint                 *endpoint.Endpoint `mapstructure:"endpoint"                             validate:"not_allowed"` //nolint:lll
 		Payload                  template.Template  `mapstructure:"payload"`
-		Expressions              []Expression       `mapstructure:"expressions"                          validate:"dive"`
-		ResponseHeadersToForward []string           `mapstructure:"forward_response_headers_to_upstream"`
+		Expressions              []Expression       `mapstructure:"expressions"                          validate:"dive"` //nolint:lll
 		CacheTTL                 time.Duration      `mapstructure:"cache_ttl"`
 		Values                   values.Values      `mapstructure:"values"`
 	}
@@ -264,15 +230,6 @@ func (a *remoteAuthorizer) CreateStep(
 	); err != nil {
 		return nil, errorchain.NewWithMessagef(pipeline.ErrConfiguration,
 			"failed decoding config for remote authorizer '%s'", a.name).CausedBy(err)
-	}
-
-	if len(conf.ResponseHeadersToForward) > 0 {
-		logger := a.app.Logger()
-		logger.Warn().
-			Str("_type", AuthorizerRemote).
-			Str("_name", a.name).
-			Msg("Usage of forward_response_headers_to_upstream is deprecated. " +
-				"Please use Results object in a header finalizer instead")
 	}
 
 	expressions, err := compileExpressions(conf.Expressions, a.celEnv)
@@ -288,10 +245,8 @@ func (a *remoteAuthorizer) CreateStep(
 		payload:     x.IfThenElse(conf.Payload != nil, conf.Payload, a.payload),
 		celEnv:      a.celEnv,
 		expressions: x.IfThenElse(len(expressions) != 0, expressions, a.expressions),
-		headersForUpstream: x.IfThenElse(len(conf.ResponseHeadersToForward) != 0,
-			conf.ResponseHeadersToForward, a.headersForUpstream),
-		ttl: x.IfThenElse(conf.CacheTTL > 0, conf.CacheTTL, a.ttl),
-		v:   a.v.Merge(conf.Values),
+		ttl:         x.IfThenElse(conf.CacheTTL > 0, conf.CacheTTL, a.ttl),
+		v:           a.v.Merge(conf.Values),
 	}, nil
 }
 
@@ -329,7 +284,7 @@ func (a *remoteAuthorizer) createRequest(
 func (a *remoteAuthorizer) fetchAuthorizationInformation(
 	ctx pipeline.Context,
 	req *http.Request,
-) (*authorizationInformation, error) {
+) (*pipeline.Result, error) {
 	logger := zerolog.Ctx(ctx.Context())
 	logger.Debug().Msg("Calling remote authorization endpoint")
 
@@ -361,10 +316,7 @@ func (a *remoteAuthorizer) fetchAuthorizationInformation(
 		return nil, err
 	}
 
-	return &authorizationInformation{
-		Headers: resp.Header,
-		Payload: data,
-	}, nil
+	return pipeline.NewResultWithHeaders(data, resp.Header), nil
 }
 
 func (a *remoteAuthorizer) readResponse(ctx pipeline.Context, resp *http.Response) (any, error) {

--- a/internal/rules/mechanisms/authorizers/remote_authorizer.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer.go
@@ -216,11 +216,11 @@ func (a *remoteAuthorizer) CreateStep(
 	}
 
 	type Config struct {
-		Endpoint                 *endpoint.Endpoint `mapstructure:"endpoint"                             validate:"not_allowed"` //nolint:lll
-		Payload                  template.Template  `mapstructure:"payload"`
-		Expressions              []Expression       `mapstructure:"expressions"                          validate:"dive"` //nolint:lll
-		CacheTTL                 time.Duration      `mapstructure:"cache_ttl"`
-		Values                   values.Values      `mapstructure:"values"`
+		Endpoint    *endpoint.Endpoint `mapstructure:"endpoint"    validate:"not_allowed"`
+		Payload     template.Template  `mapstructure:"payload"`
+		Expressions []Expression       `mapstructure:"expressions" validate:"dive"`
+		CacheTTL    time.Duration      `mapstructure:"cache_ttl"`
+		Values      values.Values      `mapstructure:"values"`
 	}
 
 	var conf Config

--- a/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
+++ b/internal/rules/mechanisms/authorizers/remote_authorizer_test.go
@@ -121,7 +121,6 @@ payload: "{{ .Subject.ID }}"
 				})
 				require.NoError(t, err)
 				assert.Equal(t, "bar", val)
-				assert.Empty(t, auth.headersForUpstream)
 				assert.Zero(t, auth.ttl)
 
 				assert.Equal(t, "minimal valid configuration with enforced and used TLS", auth.ID())
@@ -161,7 +160,6 @@ endpoint:
 				require.NotNil(t, auth)
 				require.Equal(t, "Foo", auth.e.Headers["X-My-Header"].String())
 				assert.Nil(t, auth.payload)
-				assert.Empty(t, auth.headersForUpstream)
 				assert.Zero(t, auth.ttl)
 
 				assert.Equal(t, "configuration with endpoint and endpoint header", auth.ID())
@@ -194,9 +192,6 @@ endpoint:
 payload: "{{ .Subject.ID }}: {{ splitList \"/\" .Request.URL.Path | atIndex -1 }}"
 expressions:
   - expression: "Payload.foo == 'bar'"
-forward_response_headers_to_upstream:
-  - Foo
-  - Bar
 cache_ttl: 5s
 values:
   foo: "{{ .Subject.ID }}"
@@ -227,9 +222,6 @@ values:
 				}, auth)
 				require.NoError(t, err)
 				assert.Equal(t, "bar: bar", val)
-				assert.Len(t, auth.headersForUpstream, 2)
-				assert.Contains(t, auth.headersForUpstream, "Foo")
-				assert.Contains(t, auth.headersForUpstream, "Bar")
 				assert.NotNil(t, auth.ttl)
 				assert.Equal(t, 5*time.Second, auth.ttl)
 
@@ -323,7 +315,6 @@ payload: bar
 				assert.Equal(t, prototype.e, configured.e)
 				assert.Equal(t, prototype.payload, configured.payload)
 				assert.Equal(t, prototype.expressions, configured.expressions)
-				assert.Empty(t, configured.headersForUpstream)
 				assert.NotNil(t, configured.ttl)
 				assert.Equal(t, prototype.Type(), configured.Type())
 			},
@@ -379,7 +370,6 @@ payload: bar
 				assert.Equal(t, prototype.e, configured.e)
 				assert.NotEqual(t, prototype.payload, configured.payload)
 				assert.Equal(t, prototype.expressions, configured.expressions)
-				assert.Empty(t, configured.headersForUpstream)
 				assert.NotNil(t, configured.ttl)
 				assert.Equal(t, "with overridden empty payload", configured.ID())
 				assert.Equal(t, prototype.Name(), configured.Name())
@@ -407,7 +397,6 @@ payload: bar
 				assert.Equal(t, prototype.e, configured.e)
 				assert.Equal(t, prototype.payload, configured.payload)
 				assert.Equal(t, prototype.expressions, configured.expressions)
-				assert.Empty(t, configured.headersForUpstream)
 				assert.Equal(t, 1*time.Second, configured.ttl)
 				assert.Equal(t, "foo", configured.ID())
 				assert.NotEqual(t, prototype.ID(), configured.ID())
@@ -448,8 +437,7 @@ values:
 `),
 			stepDef: types.StepDefinition{
 				Config: config.MechanismConfig{
-					"payload":                              "Baz",
-					"forward_response_headers_to_upstream": []string{"Bar", "Foo"},
+					"payload": "Baz",
 					"expressions": []map[string]any{
 						{"expression": "Payload.foo == 'bar'"},
 					},
@@ -478,14 +466,10 @@ values:
 				require.NoError(t, err)
 
 				assert.Equal(t, "Baz", val)
-				assert.Len(t, configured.headersForUpstream, 2)
-				assert.Contains(t, configured.headersForUpstream, "Bar")
-				assert.Contains(t, configured.headersForUpstream, "Foo")
 				assert.Equal(t, 15*time.Second, configured.ttl)
 
 				assert.NotEqual(t, prototype.ttl, configured.ttl)
 				assert.Equal(t, prototype.v, configured.v)
-				assert.NotEqual(t, prototype.headersForUpstream, configured.headersForUpstream)
 				assert.NotEqual(t, prototype.payload, configured.payload)
 				assert.Equal(t, "with everything possible, but values reconfigured", configured.ID())
 				assert.Equal(t, prototype.Name(), configured.Name())
@@ -504,9 +488,8 @@ values:
 `),
 			stepDef: types.StepDefinition{
 				Config: config.MechanismConfig{
-					"values":                               map[string]any{"bar": "foo"},
-					"payload":                              "Baz",
-					"forward_response_headers_to_upstream": []string{"Bar", "Foo"},
+					"values":  map[string]any{"bar": "foo"},
+					"payload": "Baz",
 					"expressions": []map[string]any{
 						{"expression": "Payload.foo == 'bar'"},
 					},
@@ -543,13 +526,9 @@ values:
 				require.NoError(t, err)
 
 				assert.Equal(t, "Baz", val)
-				assert.Len(t, configured.headersForUpstream, 2)
-				assert.Contains(t, configured.headersForUpstream, "Bar")
-				assert.Contains(t, configured.headersForUpstream, "Foo")
 				assert.Equal(t, 15*time.Second, configured.ttl)
 
 				assert.NotEqual(t, prototype.ttl, configured.ttl)
-				assert.NotEqual(t, prototype.headersForUpstream, configured.headersForUpstream)
 				assert.NotEqual(t, prototype.payload, configured.payload)
 				assert.Equal(t, "with everything possible", configured.ID())
 				assert.Equal(t, prototype.Name(), configured.Name())
@@ -649,8 +628,7 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 		configureCache   func(t *testing.T, cch *mocks.CacheMock, authorizer *remoteAuthorizer, sub pipeline.Subject)
 		assert           func(t *testing.T, err error, sub pipeline.Subject, outputs map[string]any, results pipeline.Results)
 	}{
-		"successful with payload and with header, without payload from server and without header " +
-			"forwarding and with disabled cache": {
+		"successful with payload and with header, without payload from server and with disabled cache": {
 			authorizer: &remoteAuthorizer{
 				id: "authorizer",
 				e: endpointtestsupport.EndpointValue(t, srv.URL,
@@ -718,8 +696,7 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 				assert.Empty(t, result.Payload)
 			},
 		},
-		"successful with json payload and with header, with json payload from server and with header " +
-			"forwarding and with disabled cache": {
+		"successful with json payload and with header from server and with disabled cache": {
 			authorizer: &remoteAuthorizer{
 				id: "authorizer",
 				e: endpointtestsupport.EndpointValue(t, srv.URL,
@@ -732,7 +709,6 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 					return tpl
 				}(),
-				headersForUpstream: []string{"X-Foo-Bar", "X-Bar-Foo"},
 			},
 			subject: pipeline.Subject{
 				"default": &pipeline.Principal{
@@ -779,7 +755,6 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 			configureContext: func(t *testing.T, ctx *pipelinemocks.ContextMock) {
 				t.Helper()
 
-				ctx.EXPECT().AddHeaderForUpstream("X-Foo-Bar", "HeyFoo")
 				ctx.EXPECT().Request().Return(nil)
 			},
 			assert: func(t *testing.T, err error, sub pipeline.Subject, outputs map[string]any, results pipeline.Results) {
@@ -827,8 +802,8 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 				assert.Contains(t, payload, "permissions")
 			},
 		},
-		"successful with www-form-urlencoded payload and without header, without payload from server " +
-			"and with header forwarding and with failing cache hit": {
+		"successful with www-form-urlencoded payload and without header, without payload, but with headers from server " +
+			"and with failing cache hit": {
 			authorizer: &remoteAuthorizer{
 				id: "authorizer",
 				e: endpointtestsupport.EndpointValue(t, srv.URL,
@@ -844,8 +819,7 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 					return tpl
 				}(),
-				headersForUpstream: []string{"X-Foo-Bar", "X-Bar-Foo"},
-				ttl:                20 * time.Second,
+				ttl: 20 * time.Second,
 			},
 			subject: pipeline.Subject{
 				"default": &pipeline.Principal{
@@ -880,7 +854,6 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 			configureContext: func(t *testing.T, ctx *pipelinemocks.ContextMock) {
 				t.Helper()
 
-				ctx.EXPECT().AddHeaderForUpstream("X-Foo-Bar", "HeyFoo")
 				ctx.EXPECT().Request().Return(nil)
 			},
 			configureCache: func(t *testing.T, cch *mocks.CacheMock, auth *remoteAuthorizer, _ pipeline.Subject) {
@@ -889,11 +862,11 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(nil, assert.AnError)
 				cch.EXPECT().Set(mock.Anything, mock.Anything,
 					mock.MatchedBy(func(data []byte) bool {
-						var ai authorizationInformation
+						var ai pipeline.Result
 
 						err := json.Unmarshal(data, &ai)
 
-						return err == nil && ai.Payload == nil && len(ai.Headers.Get("X-Foo-Bar")) != 0
+						return err == nil && ai.Payload == nil && len(ai.Header("X-Foo-Bar")) != 0
 					}), auth.ttl).Return(nil)
 			},
 			assert: func(t *testing.T, err error, sub pipeline.Subject, outputs map[string]any, results pipeline.Results) {
@@ -907,6 +880,7 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 				assert.Empty(t, outputs["authorizer"])
 				assert.NotEmpty(t, results["authorizer"])
+				assert.Equal(t, "HeyFoo", results["authorizer"].Header("X-Foo-Bar"))
 			},
 		},
 		"successful without headers and payload and with cache": {
@@ -986,8 +960,7 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 
 					return tpl
 				}(),
-				headersForUpstream: []string{"X-Foo-Bar", "X-Bar-Foo"},
-				ttl:                20 * time.Second,
+				ttl: 20 * time.Second,
 			},
 			subject: pipeline.Subject{
 				"default": &pipeline.Principal{
@@ -998,20 +971,20 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 			configureContext: func(t *testing.T, ctx *pipelinemocks.ContextMock) {
 				t.Helper()
 
-				ctx.EXPECT().AddHeaderForUpstream("X-Foo-Bar", "HeyFoo")
-				ctx.EXPECT().AddHeaderForUpstream("X-Bar-Foo", "HeyBar")
 				ctx.EXPECT().Request().Return(nil)
 			},
 			configureCache: func(t *testing.T, cch *mocks.CacheMock, _ *remoteAuthorizer, _ pipeline.Subject) {
 				t.Helper()
 
-				rawInfo, err := json.Marshal(authorizationInformation{
-					Headers: http.Header{
+				result := pipeline.NewResultWithHeaders(
+					map[string]any{"foo": "bar"},
+					http.Header{
 						"X-Foo-Bar": {"HeyFoo"},
 						"X-Bar-Foo": {"HeyBar"},
 					},
-					Payload: map[string]any{"foo": "bar"},
-				})
+				)
+
+				rawInfo, err := json.Marshal(result)
 				require.NoError(t, err)
 
 				cch.EXPECT().Get(mock.Anything, mock.Anything).Return(rawInfo, nil)
@@ -1480,11 +1453,11 @@ func TestRemoteAuthorizerExecute(t *testing.T) {
 			configureCache: func(t *testing.T, cch *mocks.CacheMock, auth *remoteAuthorizer, _ pipeline.Subject) {
 				t.Helper()
 
-				rawInfo, err := json.Marshal(authorizationInformation{
-					Payload: map[string]any{
-						"role": "user",
-					},
-				})
+				result := pipeline.NewResult(
+					map[string]any{"role": "user"},
+				)
+
+				rawInfo, err := json.Marshal(result)
 				require.NoError(t, err)
 
 				req, err := http.NewRequestWithContext(
@@ -1943,31 +1916,6 @@ func TestRemoteAuthorizerCalculateCacheKey(t *testing.T) {
 				"https://example.com/authorize",
 				nil,
 			),
-		},
-		"different response headers to forward": {
-			authorizer1: &remoteAuthorizer{
-				name:               "authorizer",
-				id:                 "authorizer",
-				ttl:                5 * time.Second,
-				headersForUpstream: []string{"X-Foo"},
-			},
-			authorizer2: &remoteAuthorizer{
-				name:               "authorizer",
-				id:                 "authorizer",
-				ttl:                5 * time.Second,
-				headersForUpstream: []string{"X-Bar"},
-			},
-			request1: newRequest(
-				http.MethodGet,
-				"https://example.com/authorize",
-				nil,
-			),
-			request2: newRequest(
-				http.MethodGet,
-				"https://example.com/authorize",
-				nil,
-			),
-			expectEqual: true,
 		},
 		"same effective request despite different endpoint configuration": {
 			authorizer1: &remoteAuthorizer{

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -1847,14 +1847,6 @@
             "expressions": {
               "$ref": "#/definitions/expressionList"
             },
-            "forward_response_headers_to_upstream": {
-              "description": "A list of headers to forward to the upstream service.",
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "uniqueItems": true
-            },
             "cache_ttl": {
               "type": "string",
               "description": "How long to cache the response received from the authorization endpoint. 0 or less means no caching",


### PR DESCRIPTION
## Related issue(s)

relates to #3375

## Checklist

- [x] I agree to follow this project's [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md).
- [x] I have read, and I am following this repository's [Contributing Guidelines](../blob/main/CONTRIBUTING.md).
- [x] I have read the [Security Policy](../blob/main/SECURITY.md).
- [x] I have referenced an issue describing the bug/feature request.
- [x] I have added tests that prove the correctness of my implementation.
- [x] I have updated the documentation.

## Description

This PR completes the deprecation introduced with #3375 and removes `forward_response_headers_to_upstream` from the `remote` authorizer.

Existing configurations must be migrated before upgrading to v0.18.0. For example,

```yaml
execute:
  - authorizer: my_authorizer
    config:
      forward_response_headers_to_upstream:
        - X-Some-Name
```

can be replaced by using a `header` finalizer and configuring the rule-specific mapping in the rule:

```yaml
execute:
  - authorizer: my_authorizer
    id: authorization

  - finalizer: upstream_headers
    config:
      headers:
        X-Some-Name: '{{ .Results.authorization.Header "X-Some-Name" }}'
```

where `upstream_headers` references a `header` finalizer from the mechanism catalogue.
